### PR TITLE
fix: activity-aware stale timeout and recovery hardening

### DIFF
--- a/docs/bug-analyses/2026-03-17-stale-timeout-and-recovery-bug-analysis.md
+++ b/docs/bug-analyses/2026-03-17-stale-timeout-and-recovery-bug-analysis.md
@@ -1,0 +1,66 @@
+# Bug Analysis: Stale Timeout Race + Recovery Failures
+
+> **Status**: Confirmed | **Date**: 2026-03-17
+> **Severity**: Critical
+> **Affected Area**: `internal/belayer/belayer.go` (tick loop, recovery), `internal/belayer/taskrunner.go` (CheckStaleClimbs, SpawnClimb)
+
+## Symptoms
+- Climbs that completed successfully (wrote TOP.json) were marked failed by the stale timeout check
+- After daemon restart, recovery tried to respawn climbs into a tmux session that no longer existed
+- Recovery didn't detect that climbs had already completed (TOP.json present)
+- The 30m stale timeout is a blunt instrument — doesn't distinguish between an idle agent and one actively working
+
+## Reproduction Steps
+1. Submit a problem with climbs that take ~30 minutes (e.g., codex provider)
+2. Climbs spawn at T+0, write TOP.json near T+30m
+3. Stale timeout fires at exactly T+30m, marks climbs failed
+4. Stop and restart daemon — recovery fails to recreate tmux session, can't respawn
+
+## Root Cause
+
+Three compounding bugs:
+
+### Bug 1: Stale timeout race with completion check (same-tick race)
+
+In `belayer.go:tick()`, `CheckCompletions` (line 145) runs before `CheckStaleClimbs` (line 167). If a climb writes TOP.json between these two calls in the same tick, `CheckCompletions` misses it and `CheckStaleClimbs` fires the timeout. The TOP.json guard in `CheckStaleClimbs` (taskrunner.go:510-513) mitigates this but is subject to filesystem timing — if the file write hasn't flushed or the stat call races with the write, the guard can miss it.
+
+More fundamentally: the stale timeout is purely elapsed-time-based (`now.Sub(startedAt) > staleTimeout`). It doesn't check whether the agent is actively producing output. An agent that has been writing to its log file continuously for 30 minutes gets the same treatment as one that died silently after 5 minutes.
+
+### Bug 2: Recovery doesn't recreate tmux sessions
+
+In `belayer.go:recover()` (line 407-491), the recovery path sets `runner.tmuxSession` (line 428) but never creates the tmux session. It assumes the session still exists from before the crash. But `belayer stop` kills the tmux session during cleanup. When recovery queues ready climbs (line 478-481) and `processLeadQueue` tries to spawn them (line 397), `SpawnClimb` calls `tmux.NewWindow(tr.tmuxSession, ...)` on a non-existent session, which fails.
+
+### Bug 3: Recovery respawns already-completed climbs
+
+Recovery calls `CheckCompletions` (line 437) which handles Running climbs. But climbs that were marked Failed by the stale timeout (and subsequently completed) have status Pending or Failed in the database. `CheckCompletions` only checks Running climbs (taskrunner.go:382). So TOP.json files from completed-but-failed climbs are never detected. Recovery then queues these climbs for respawning (line 478-481), wasting resources redoing completed work.
+
+## Evidence
+- `belayer.go:145,167` — CheckCompletions before CheckStaleClimbs, same tick
+- `taskrunner.go:462-463` — stale check: `now.Sub(startedAt) > staleTimeout`, no activity check
+- `belayer.go:428` — recovery sets tmuxSession name but never creates it
+- `taskrunner.go:253` — SpawnClimb assumes tmux session exists
+- `belayer.go:437` — recovery CheckCompletions only handles Running climbs
+- `taskrunner.go:382` — CheckCompletions skips non-Running climbs
+- User observation: climbs spawned at 19:29:45, timed out at 19:59:50 (exactly 30m)
+- User observation: completed climbs had TOP.json but daemon didn't detect them after restart
+
+## Impact Assessment
+- **Data loss**: completed work is discarded and redone unnecessarily
+- **Stuck state**: daemon can't recover after stop+start, requires manual reset
+- **Resource waste**: 30m of codex execution wasted per false timeout
+- **Scaling blocker**: as lead execution times vary (codex ~30m, claude ~15m), a single static timeout can't accommodate all providers
+
+## Recommended Fix Direction
+
+### Bug 1: Activity-aware stale timeout
+Replace the pure elapsed-time timeout with an activity-aware check:
+1. Track last log file modification time per climb (already captured in silence detection)
+2. Only trigger stale timeout if **both** conditions are true: elapsed > staleTimeout AND log file hasn't been modified in > silenceThreshold (2 min)
+3. If the agent is actively producing output (log file recently modified), extend the deadline — it's not stale, it's just slow
+4. Keep the hard timeout as an absolute ceiling (e.g., configurable, default 2h) to prevent infinite hangs
+
+### Bug 2: Recovery must ensure tmux session exists
+In `recover()`, after setting `runner.tmuxSession`, check if the session exists with `tmux.HasSession()`. If not, create it with `tmux.NewSession()` (same pattern as `Init()` at taskrunner.go:192-198). Also pre-create spotter/anchor windows as Init does.
+
+### Bug 3: Recovery must check TOP.json for all non-complete climbs
+Before queuing ready climbs during recovery, scan **all** climbs (not just Running) for existing TOP.json files. For any climb with a TOP.json that's still in Pending/Failed state, mark it complete in the store and DAG. This handles the case where a climb completed but the daemon was stopped before it could process the completion.

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -3,3 +3,4 @@
 | File | Summary | Date |
 |------|---------|------|
 | [2026-03-17-trust-dialog-blocking-bug-analysis.md](2026-03-17-trust-dialog-blocking-bug-analysis.md) | Agent trust-folder dialogs block tmux sessions, wasting climb attempts | 2026-03-17 |
+| [2026-03-17-stale-timeout-and-recovery-bug-analysis.md](2026-03-17-stale-timeout-and-recovery-bug-analysis.md) | Stale timeout race discards completed work; recovery fails to recreate tmux sessions or detect TOP.json | 2026-03-17 |

--- a/docs/exec-plans/archive/stale-timeout-and-recovery-plan.md
+++ b/docs/exec-plans/archive/stale-timeout-and-recovery-plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Stale Timeout + Recovery Fixes
+
+> **Status**: Complete | **Created**: 2026-03-17 | **Completed**: 2026-03-17
+> **Source**: `docs/bug-analyses/2026-03-17-stale-timeout-and-recovery-bug-analysis.md`
+> **Branch**: `fix/stale-timeout-and-recovery`
+
+## Goal
+
+Fix three bugs: (1) stale timeout ignores agent activity, (2) recovery doesn't recreate tmux sessions, (3) recovery misses completed climbs.
+
+## Progress
+
+- [x] Task 1: Activity-aware stale timeout
+- [x] Task 2: Recovery ensures tmux session exists
+- [x] Task 3: Recovery checks TOP.json for all non-complete climbs
+- [x] Task 4: Tests for all three fixes
+
+## Drift Log
+
+_No drift yet._
+
+---
+
+### Task 1: Activity-aware stale timeout
+
+**File:** `internal/belayer/taskrunner.go` — `CheckStaleClimbs()`
+
+Current behavior: `timedOut := tracked && now.Sub(startedAt) > staleTimeout` — pure elapsed time.
+
+Change to: only time out if the agent is also **silent** (log file not modified recently). If the log file has been updated within the silence threshold, the agent is actively working — skip the timeout.
+
+```go
+// Replace the timedOut condition:
+timedOut := tracked && now.Sub(startedAt) > staleTimeout
+
+// With activity-aware check:
+timedOut := false
+if tracked && now.Sub(startedAt) > staleTimeout {
+    logPath := tr.logMgr.LogPath(tr.task.ID, climb.ID)
+    if info, err := os.Stat(logPath); err == nil {
+        // Only time out if log file is also silent
+        timedOut = now.Sub(info.ModTime()) > 2*time.Minute
+    } else {
+        // No log file at all — definitely stale
+        timedOut = true
+    }
+}
+```
+
+This means a climb that has been running for 30m but still producing output will NOT be timed out. Only climbs that have exceeded the timeout AND gone silent for 2+ minutes are considered stale.
+
+**Acceptance:** An actively-writing agent at 30m+ is not timed out; a silent agent at 30m+ is.
+
+---
+
+### Task 2: Recovery ensures tmux session exists
+
+**File:** `internal/belayer/belayer.go` — `recover()`
+
+After `runner.tmuxSession = fmt.Sprintf(...)` (line 428), add a tmux session existence check:
+
+```go
+// Ensure tmux session exists (may have been killed during previous stop)
+if !s.tmux.HasSession(runner.tmuxSession) {
+    if err := s.tmux.NewSession(runner.tmuxSession); err != nil {
+        log.Printf("belayer: error recreating tmux session for %s: %v", task.ID, err)
+        continue
+    }
+}
+```
+
+Also pre-create spotter and anchor windows (same as Init does at taskrunner.go:200-213) so that ActivateSpotter/SpawnAnchor don't fail.
+
+**Acceptance:** After daemon stop + start, recovery creates the tmux session and windows before trying to spawn.
+
+---
+
+### Task 3: Recovery checks TOP.json for all non-complete climbs
+
+**File:** `internal/belayer/belayer.go` — `recover()`
+
+Currently, `runner.CheckCompletions()` (line 437) only checks Running climbs. Add a scan of **all non-complete climbs** for TOP.json before queuing ready climbs:
+
+```go
+// Check for TOP.json on ANY non-complete climb (not just Running)
+for _, climb := range climbs {
+    if climb.Status == model.ClimbStatusComplete {
+        continue
+    }
+    worktreePath := runner.worktrees[climb.RepoName]
+    topPath := filepath.Join(worktreePath, ".lead", climb.ID, "TOP.json")
+    if _, err := os.Stat(topPath); err == nil {
+        // Climb completed while we were down — mark it
+        runner.dag.MarkComplete(climb.ID)
+        s.store.UpdateClimbStatus(climb.ID, model.ClimbStatusComplete)
+        log.Printf("belayer: recovery found TOP.json for climb %s — marking complete", climb.ID)
+    }
+}
+```
+
+This goes before the existing `CheckCompletions` call and the ready-climb queuing.
+
+**Acceptance:** Climbs with TOP.json in Pending/Failed state are detected during recovery and not respawned.
+
+---
+
+### Task 4: Tests
+
+**Files:** `internal/belayer/taskrunner_test.go`, `internal/belayer/belayer_test.go` (or setter_test.go)
+
+1. **`TestCheckStaleClimbs_ActiveAgentNotTimedOut`**: Mock a climb running > staleTimeout with a recently-modified log file. Verify it is NOT timed out.
+
+2. **`TestCheckStaleClimbs_SilentAgentTimedOut`**: Mock a climb running > staleTimeout with a stale log file (>2min old). Verify it IS timed out.
+
+3. **`TestRecover_RecreatesTmuxSession`**: Recovery with no existing tmux session. Verify `NewSession` is called.
+
+4. **`TestRecover_DetectsCompletedClimbs`**: Recovery where a Failed climb has a TOP.json. Verify it's marked complete and not queued for respawn.
+
+**Acceptance:** All tests pass. `go test ./internal/belayer/...` green.

--- a/internal/belayer/belayer.go
+++ b/internal/belayer/belayer.go
@@ -428,12 +428,53 @@ func (s *Belayer) recover() error {
 		runner.tmuxSession = fmt.Sprintf("belayer-problem-%s", task.ID)
 		runner.problemDir = filepath.Join(s.config.CragDir, "tasks", task.ID)
 
+		// Ensure tmux session exists (may have been killed during previous stop)
+		if !s.tmux.HasSession(runner.tmuxSession) {
+			if err := s.tmux.NewSession(runner.tmuxSession); err != nil {
+				log.Printf("belayer: error recreating tmux session for %s: %v", task.ID, err)
+				continue
+			}
+			log.Printf("belayer: recreated tmux session %s during recovery", runner.tmuxSession)
+
+			// Pre-create spotter and anchor windows (same as Init)
+			repos := runner.dag.UniqueRepos()
+			for _, repo := range repos {
+				spotWindow := fmt.Sprintf("spot-%s", repo)
+				if err := s.tmux.NewWindow(runner.tmuxSession, spotWindow); err != nil {
+					log.Printf("warning: failed to pre-create spotter window %s during recovery: %v", spotWindow, err)
+				}
+			}
+			if len(repos) > 1 {
+				if err := s.tmux.NewWindow(runner.tmuxSession, "anchor"); err != nil {
+					log.Printf("warning: failed to pre-create anchor window during recovery: %v", err)
+				}
+			}
+		}
+
 		// Populate worktrees map
 		for _, repoName := range runner.dag.UniqueRepos() {
 			runner.worktrees[repoName] = filepath.Join(s.config.CragDir, "tasks", task.ID, repoName)
 		}
 
-		// Check for TOP.json files that completed while we were down
+		// Check for TOP.json on any non-complete climb (handles climbs that
+		// completed after being marked failed/pending by a stale timeout).
+		for _, climb := range climbs {
+			if climb.Status == model.ClimbStatusComplete {
+				continue
+			}
+			worktreePath := runner.worktrees[climb.RepoName]
+			topPath := filepath.Join(worktreePath, ".lead", climb.ID, "TOP.json")
+			if _, statErr := os.Stat(topPath); statErr == nil {
+				runner.dag.MarkComplete(climb.ID)
+				if storeErr := s.store.UpdateClimbStatus(climb.ID, model.ClimbStatusComplete); storeErr != nil {
+					log.Printf("belayer: error marking recovered climb %s as complete: %v", climb.ID, storeErr)
+				} else {
+					log.Printf("belayer: recovery found TOP.json for climb %s — marking complete", climb.ID)
+				}
+			}
+		}
+
+		// Also run standard CheckCompletions for Running climbs
 		if _, _, err := runner.CheckCompletions(); err != nil {
 			log.Printf("belayer: error checking completions during recovery for %s: %v", task.ID, err)
 		}

--- a/internal/belayer/belayer.go
+++ b/internal/belayer/belayer.go
@@ -463,12 +463,16 @@ func (s *Belayer) recover() error {
 				continue
 			}
 			worktreePath := runner.worktrees[climb.RepoName]
+			if _, wtErr := os.Stat(worktreePath); wtErr != nil {
+				continue // worktree missing (init may have been incomplete)
+			}
 			topPath := filepath.Join(worktreePath, ".lead", climb.ID, "TOP.json")
 			if _, statErr := os.Stat(topPath); statErr == nil {
-				runner.dag.MarkComplete(climb.ID)
+				// Store write first — only mutate in-memory DAG on success
 				if storeErr := s.store.UpdateClimbStatus(climb.ID, model.ClimbStatusComplete); storeErr != nil {
 					log.Printf("belayer: error marking recovered climb %s as complete: %v", climb.ID, storeErr)
 				} else {
+					runner.dag.MarkComplete(climb.ID)
 					log.Printf("belayer: recovery found TOP.json for climb %s — marking complete", climb.ID)
 				}
 			}

--- a/internal/belayer/setter_test.go
+++ b/internal/belayer/setter_test.go
@@ -687,6 +687,101 @@ func TestSetter_CrashRecovery(t *testing.T) {
 	assert.True(t, foundApi2)
 }
 
+func TestSetter_CrashRecovery_RecreatesTmuxSession(t *testing.T) {
+	s, tm, lm, sp, tmpDir := setupTestEnv(t)
+
+	goals := []model.Climb{
+		{ID: "api-1", ProblemID: "task-tmux", RepoName: "api", Description: "test", DependsOn: []string{}, Status: model.ClimbStatusPending},
+	}
+	insertTestTask(t, s, "task-tmux", goals)
+	require.NoError(t, s.UpdateProblemStatus("task-tmux", model.ProblemStatusRunning))
+
+	// Create worktree dir
+	worktreeDir := filepath.Join(tmpDir, "tasks", "task-tmux", "api")
+	require.NoError(t, os.MkdirAll(worktreeDir, 0o755))
+
+	// Do NOT create a tmux session — simulates the session being killed during stop
+
+	setter := &Belayer{
+		config: Config{
+			CragName: "test-crag",
+			CragDir:  tmpDir,
+			MaxLeads: 8,
+		},
+		store:    s,
+		tmux:     tm,
+		logMgr:   lm,
+		spawners: &lead.SpawnerSet{Lead: sp, Spotter: sp, Anchor: sp},
+		problems: make(map[string]*ProblemRunner),
+	}
+
+	err := setter.recover()
+	require.NoError(t, err)
+
+	// Tmux session should have been recreated
+	sessionName := "belayer-problem-task-tmux"
+	assert.True(t, tm.HasSession(sessionName), "tmux session should be recreated during recovery")
+
+	// Spotter window should be pre-created
+	windows, _ := tm.ListWindows(sessionName)
+	found := false
+	for _, w := range windows {
+		if w == "spot-api" {
+			found = true
+		}
+	}
+	assert.True(t, found, "spotter window should be pre-created during recovery")
+}
+
+func TestSetter_CrashRecovery_DetectsFailedClimbWithTOP(t *testing.T) {
+	s, tm, lm, sp, tmpDir := setupTestEnv(t)
+
+	goals := []model.Climb{
+		{ID: "api-1", ProblemID: "task-failed", RepoName: "api", Description: "test", DependsOn: []string{}, Status: model.ClimbStatusPending},
+	}
+	insertTestTask(t, s, "task-failed", goals)
+
+	// Simulate: climb was marked failed by stale timeout, but actually completed
+	require.NoError(t, s.UpdateProblemStatus("task-failed", model.ProblemStatusRunning))
+	require.NoError(t, s.UpdateClimbStatus("api-1", model.ClimbStatusFailed))
+
+	// Create worktree with TOP.json (climb actually completed)
+	worktreeDir := filepath.Join(tmpDir, "tasks", "task-failed", "api")
+	goalDir := filepath.Join(worktreeDir, ".lead", "api-1")
+	require.NoError(t, os.MkdirAll(goalDir, 0o755))
+	doneJSON := TopJSON{Status: "complete", Summary: "completed after timeout"}
+	data, _ := json.Marshal(doneJSON)
+	require.NoError(t, os.WriteFile(filepath.Join(goalDir, "TOP.json"), data, 0o644))
+
+	setter := &Belayer{
+		config: Config{
+			CragName: "test-crag",
+			CragDir:  tmpDir,
+			MaxLeads: 8,
+		},
+		store:    s,
+		tmux:     tm,
+		logMgr:   lm,
+		spawners: &lead.SpawnerSet{Lead: sp, Spotter: sp, Anchor: sp},
+		problems: make(map[string]*ProblemRunner),
+	}
+
+	err := setter.recover()
+	require.NoError(t, err)
+
+	require.Contains(t, setter.problems, "task-failed")
+	runner := setter.problems["task-failed"]
+
+	// The failed climb should now be marked complete (recovery detected TOP.json)
+	assert.Equal(t, model.ClimbStatusComplete, runner.dag.Get("api-1").Status,
+		"failed climb with TOP.json should be marked complete during recovery")
+
+	// It should NOT be in the lead queue (since it's complete)
+	for _, q := range setter.leadQueue {
+		assert.NotEqual(t, "api-1", q.Climb.ID, "completed climb should not be queued for respawn")
+	}
+}
+
 func TestSetter_RunTickCycle(t *testing.T) {
 	s, tm, lm, sp, tmpDir := setupTestEnv(t)
 

--- a/internal/belayer/taskrunner.go
+++ b/internal/belayer/taskrunner.go
@@ -13,12 +13,13 @@ import (
 	"syscall"
 	"time"
 
+	belayerassets "github.com/donovan-yohan/belayer"
 	"github.com/donovan-yohan/belayer/internal/agentic"
 	"github.com/donovan-yohan/belayer/internal/anchor"
 	"github.com/donovan-yohan/belayer/internal/belayerconfig"
 	"github.com/donovan-yohan/belayer/internal/climbctx"
-	"github.com/donovan-yohan/belayer/internal/defaults"
 	"github.com/donovan-yohan/belayer/internal/crag"
+	"github.com/donovan-yohan/belayer/internal/defaults"
 	"github.com/donovan-yohan/belayer/internal/envprovider"
 	"github.com/donovan-yohan/belayer/internal/lead"
 	"github.com/donovan-yohan/belayer/internal/logmgr"
@@ -74,7 +75,7 @@ type ProblemRunner struct {
 	scm         scm.SCMProvider
 	prConfig    belayerconfig.PRConfig
 	reviewLoop  belayerconfig.ReviewLoopConfig
-	envClient   *envprovider.Client // nil = legacy direct worktree creation
+	envClient   *envprovider.Client  // nil = legacy direct worktree creation
 	startedAt   map[string]time.Time // climbID -> when it started running
 
 	// Config directories for prompt/profile resolution.
@@ -90,35 +91,35 @@ type ProblemRunner struct {
 	validationEnabled bool // when true, TOP.json triggers spotting instead of direct completion
 
 	// Repo-level spotter tracking
-	repoSpotterActivated     map[string]bool     // repo -> whether spotter has been activated
-	repoSpotterAttempts      map[string]int      // repo -> spotter attempt count
-	reviewIncompleteClimbIDs map[string]bool     // climbID -> true if TOP.json status was review_incomplete
+	repoSpotterActivated     map[string]bool // repo -> whether spotter has been activated
+	repoSpotterAttempts      map[string]int  // repo -> spotter attempt count
+	reviewIncompleteClimbIDs map[string]bool // climbID -> true if TOP.json status was review_incomplete
 	// Populated during CheckCompletions; ActivateSpotter uses TOP.json directly instead.
 
 	// Cached learning retrieval — run once per problem, shared across all leads.
-	cachedLearnings     []climbctx.LeadLearning
-	learningsRetrieved  bool
+	cachedLearnings    []climbctx.LeadLearning
+	learningsRetrieved bool
 }
 
 // NewProblemRunner creates a ProblemRunner for the given problem.
 // envClient may be nil, in which case Init falls back to direct crag worktree creation.
 func NewProblemRunner(task *model.Problem, cragDir, globalCfgDir, cragCfgDir string, s *store.Store, tm tmux.TmuxManager, lm *logmgr.LogManager, sp *lead.SpawnerSet, scmProvider scm.SCMProvider, prCfg belayerconfig.PRConfig, reviewLoopCfg belayerconfig.ReviewLoopConfig, envClient *envprovider.Client) *ProblemRunner {
 	return &ProblemRunner{
-		task:                 task,
-		worktrees:            make(map[string]string),
-		cragDir:              cragDir,
-		globalConfigDir:      globalCfgDir,
-		cragConfigDir:        cragCfgDir,
-		store:                s,
-		tmux:                 tm,
-		logMgr:               lm,
-		spawners:             sp,
-		git:                  &RealGitRunner{},
-		scm:                  scmProvider,
-		prConfig:             prCfg,
-		reviewLoop:           reviewLoopCfg,
-		envClient:            envClient,
-		startedAt:            make(map[string]time.Time),
+		task:                     task,
+		worktrees:                make(map[string]string),
+		cragDir:                  cragDir,
+		globalConfigDir:          globalCfgDir,
+		cragConfigDir:            cragCfgDir,
+		store:                    s,
+		tmux:                     tm,
+		logMgr:                   lm,
+		spawners:                 sp,
+		git:                      &RealGitRunner{},
+		scm:                      scmProvider,
+		prConfig:                 prCfg,
+		reviewLoop:               reviewLoopCfg,
+		envClient:                envClient,
+		startedAt:                make(map[string]time.Time),
 		validationEnabled:        true,
 		repoSpotterActivated:     make(map[string]bool),
 		repoSpotterAttempts:      make(map[string]int),
@@ -289,18 +290,29 @@ func (tr *ProblemRunner) SpawnClimb(queued QueuedClimb) error {
 	mailAddr := fmt.Sprintf("problem/%s/lead/%s/%s", tr.task.ID, climb.RepoName, climb.ID)
 
 	goalJSONPath := fmt.Sprintf(".lead/%s/GOAL.json", climb.ID)
+	provider := spawnerProvider(tr.spawners.Lead)
 	initialPrompt := fmt.Sprintf(`Read %s and begin working on your assignment. Follow the harness pipeline:
 
 1. Read %s to understand your goal and task spec
-2. If this repo does not have harness docs yet, run /harness:init
-3. Run /harness:plan to create an implementation plan from your goal spec
-4. Run /harness:orchestrate to execute the plan with worker agents
-5. Run /harness:review to run multi-agent code review and fix any findings
-6. Run /harness:reflect to update docs, capture learnings and retrospective
-7. Run /harness:complete to archive the plan and commit
+2. If this repo does not have harness docs yet, run %s
+3. Run %s to create an implementation plan from your goal spec
+4. Run %s to execute the plan with worker agents
+5. Run %s to run multi-agent code review and fix any findings
+6. Run %s to update docs, capture learnings and retrospective
+7. Run %s to archive the plan and commit
 8. Write TOP.json in .lead/%s/ when complete
 
-You are fully autonomous. Make decisions, document drift, and keep moving.`, goalJSONPath, goalJSONPath, climb.ID)
+You are fully autonomous. Make decisions, document drift, and keep moving.`,
+		goalJSONPath,
+		goalJSONPath,
+		belayerassets.Invocation(provider, "harness", "init"),
+		belayerassets.Invocation(provider, "harness", "plan"),
+		belayerassets.Invocation(provider, "harness", "orchestrate"),
+		belayerassets.Invocation(provider, "harness", "review"),
+		belayerassets.Invocation(provider, "harness", "reflect"),
+		belayerassets.Invocation(provider, "harness", "complete"),
+		climb.ID,
+	)
 
 	if err := tr.spawners.Lead.Spawn(context.Background(), lead.SpawnOpts{
 		TmuxSession:        tr.tmuxSession,
@@ -328,6 +340,15 @@ You are fully autonomous. Make decisions, document drift, and keep moving.`, goa
 	return nil
 }
 
+func spawnerProvider(sp lead.AgentSpawner) string {
+	switch sp.(type) {
+	case *lead.CodexSpawner:
+		return "codex"
+	default:
+		return "claude"
+	}
+}
+
 // retrieveLearnings returns cached relevant learnings for this problem.
 // Runs the learning retrieval agentic node on first call, caches the result
 // for all subsequent leads in the same problem.
@@ -351,7 +372,7 @@ func (tr *ProblemRunner) retrieveLearnings() []climbctx.LeadLearning {
 
 	result, err := agentic.RunRetrieval(ctx, "sonnet", agentic.RetrievalInput{
 		ProblemSpec: tr.task.Spec,
-		Learnings:  learnings,
+		Learnings:   learnings,
 	})
 	if err != nil {
 		log.Printf("warning: learning retrieval failed for problem %s, leads will not receive past learnings: %v", tr.task.ID, err)
@@ -460,7 +481,19 @@ func (tr *ProblemRunner) CheckStaleClimbs(staleTimeout time.Duration) ([]QueuedC
 		reason := "window died"
 
 		startedAt, tracked := tr.startedAt[climb.ID]
-		timedOut := tracked && now.Sub(startedAt) > staleTimeout
+		elapsedPastTimeout := tracked && now.Sub(startedAt) > staleTimeout
+
+		// Activity-aware timeout: only time out if the agent is also silent.
+		// An agent still producing log output is working, not stale.
+		timedOut := false
+		if elapsedPastTimeout {
+			logPath := tr.logMgr.LogPath(tr.task.ID, climb.ID)
+			if info, statErr := os.Stat(logPath); statErr == nil {
+				timedOut = now.Sub(info.ModTime()) > 2*time.Minute
+			} else {
+				timedOut = true // no log file at all — definitely stale
+			}
+		}
 
 		// Check for silence — no log output for silenceThreshold
 		if !windowDead && !timedOut {

--- a/internal/belayer/taskrunner.go
+++ b/internal/belayer/taskrunner.go
@@ -490,9 +490,11 @@ func (tr *ProblemRunner) CheckStaleClimbs(staleTimeout time.Duration) ([]QueuedC
 			logPath := tr.logMgr.LogPath(tr.task.ID, climb.ID)
 			if info, statErr := os.Stat(logPath); statErr == nil {
 				timedOut = now.Sub(info.ModTime()) > 2*time.Minute
-			} else {
+			} else if os.IsNotExist(statErr) {
 				timedOut = true // no log file at all — definitely stale
 			}
+			// For other stat errors (permissions, transient), fall back to
+			// elapsed-time-only: timedOut remains false, avoiding false kills.
 		}
 
 		// Check for silence — no log output for silenceThreshold

--- a/internal/belayer/taskrunner_test.go
+++ b/internal/belayer/taskrunner_test.go
@@ -349,3 +349,37 @@ func TestCheckStaleClimbs_EarlyTrustDetection(t *testing.T) {
 	assert.Len(t, tm.rawKeysSent, 1, "Enter should have been sent")
 	assert.Equal(t, "test-sess:api-c2:Enter", tm.rawKeysSent[0])
 }
+
+func TestCheckStaleClimbs_ActiveAgentNotTimedOut(t *testing.T) {
+	tr, _, logPath := setupTrustTestEnv(t, "task3", "c3", "api")
+
+	// Log file was updated just 30 seconds ago (agent is actively working)
+	require.NoError(t, os.WriteFile(logPath, []byte("still working..."), 0o644))
+	require.NoError(t, os.Chtimes(logPath, time.Now().Add(-30*time.Second), time.Now().Add(-30*time.Second)))
+
+	// Climb started 35 minutes ago — past the 30m timeout
+	tr.startedAt["c3"] = time.Now().Add(-35 * time.Minute)
+
+	retries, err := tr.CheckStaleClimbs(30 * time.Minute)
+	require.NoError(t, err)
+
+	// Agent is still active (log modified 30s ago) — should NOT be timed out
+	assert.Empty(t, retries, "active agent should not be timed out even past staleTimeout")
+}
+
+func TestCheckStaleClimbs_SilentAgentTimedOut(t *testing.T) {
+	tr, _, logPath := setupTrustTestEnv(t, "task4", "c4", "api")
+
+	// Log file not updated for 5 minutes (agent is silent)
+	require.NoError(t, os.WriteFile(logPath, []byte("last output"), 0o644))
+	require.NoError(t, os.Chtimes(logPath, time.Now().Add(-5*time.Minute), time.Now().Add(-5*time.Minute)))
+
+	// Climb started 35 minutes ago — past the 30m timeout
+	tr.startedAt["c4"] = time.Now().Add(-35 * time.Minute)
+
+	retries, err := tr.CheckStaleClimbs(30 * time.Minute)
+	require.NoError(t, err)
+
+	// Agent is silent (log not modified for 5min) AND past timeout — should be timed out
+	assert.Len(t, retries, 1, "silent agent past staleTimeout should be timed out and retried")
+}


### PR DESCRIPTION
## Summary

- **Activity-aware stale timeout**: Climbs past the stale timeout are only marked failed if their log file is also silent (>2min no output). An actively-writing agent at 35min won't be killed if it's still producing output. Transient `os.Stat` errors are handled gracefully (skip activity check rather than false-kill).
- **Recovery recreates tmux sessions**: `recover()` now checks `HasSession` and creates the tmux session + spotter/anchor windows if they were cleaned up during a previous `belayer stop`.
- **Recovery detects completed climbs**: Scans ALL non-complete climbs (including Failed/Pending) for existing TOP.json before queuing respawns, preventing duplicate work.
- **Provider-aware lead prompts**: Lead prompts now use `belayerassets.Invocation()` to emit the correct slash-command syntax per agent provider (Claude vs Codex). Includes `spawnerProvider()` helper.

## Test plan

- [x] `TestCheckStaleClimbs_ActiveAgentNotTimedOut` — agent past 30m timeout with recent log output is NOT timed out
- [x] `TestCheckStaleClimbs_SilentAgentTimedOut` — agent past 30m timeout with 5min-old log IS timed out
- [x] `TestSetter_CrashRecovery_RecreatesTmuxSession` — recovery creates session + spotter windows when session is missing
- [x] `TestSetter_CrashRecovery_DetectsFailedClimbWithTOP` — failed climb with TOP.json is marked complete, not respawned
- [x] Full test suite passes: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)