### PR TITLE
refactor(harness): delegate orchestrate and review to superpowers/pr-review-toolkit

### DIFF
--- a/agentassets_test.go
+++ b/agentassets_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPluginVersion(t *testing.T) {
-	if got := MustPluginVersion("harness"); got != "3.0.0" {
+	if got := MustPluginVersion("harness"); got != "3.1.0" {
 		t.Fatalf("unexpected harness version: %s", got)
 	}
 	if got := MustPluginVersion("pr"); got != "1.2.0" {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -35,7 +35,7 @@ Uses pure Go SQLite (`modernc.org/sqlite`) — no CGO required. WAL mode and for
 
 Validation flows through four layers. See [review-loops-test-infra-design](design-docs/2026-03-16-review-loops-test-infra-design.md) for full design.
 
-1. **Lead** (multi-persona review loop): Runs implementation, then loops multi-persona review (max 3 cycles) until all personas pass. Personas configured per repo via `review-personas.toml`. Writes `TOP.json` on completion.
+1. **Lead** (multi-agent review loop): Runs implementation, then loops pr-review-toolkit agents (max 3 cycles) until all agents pass. Writes `TOP.json` on completion.
 2. **Spotter** (per-repo spec compliance): Activated when all climbs for a repo complete. Validates spec compliance, test contract fulfillment, and runtime correctness. Writes `SPOT.json`.
 3. **Anchor** (cross-repo alignment): Multi-repo problems only. Reviews all repos for cross-repo consistency with integration-focused personas after all spotters pass. Writes `VERDICT.json`.
 4. **Reflect** (learning capture): Classifies errors, extracts learnings to SQLite, surfaces system improvement recommendations. Runs after final validation, parallel with PR creation.

--- a/internal/defaults/claudemd/lead.md
+++ b/internal/defaults/claudemd/lead.md
@@ -17,31 +17,13 @@ You MUST follow the harness pipeline for all work. This ensures structured plann
 | Step | Command | Purpose |
 |------|---------|---------|
 | 1 | `/harness:init` | Initialize docs structure (skip if already present) |
-| 2 | Check `review-personas.toml` | If missing, detect repo type and generate (see below) |
-| 3 | `/harness:plan` | Create implementation plan from your GOAL.json spec |
-| 4 | `/harness:orchestrate` | Execute the plan with worker agents |
-| 5 | `/harness:review` | Multi-persona review loop until green (max 3 cycles) |
-| 6 | `/harness:complete` | Archive plan, commit all changes |
-| 7 | Write TOP.json | Signal completion (see below) |
+| 2 | `/harness:plan` | Create implementation plan from your GOAL.json spec |
+| 3 | `/harness:orchestrate` | Execute the plan with worker agents |
+| 4 | `/harness:review` | Multi-agent review loop using pr-review-toolkit until green (max 3 cycles) |
+| 5 | `/harness:complete` | Archive plan, commit all changes |
+| 6 | Write TOP.json | Signal completion (see below) |
 
 After `/harness:complete` finishes, write TOP.json (see below).
-
-## Review Personas
-
-Before running `/harness:review`, check for `review-personas.toml` in the repo root. If missing:
-1. Analyze the repo type:
-   - `go.mod` present → backend
-   - `package.json` with React/Vue/Next/Svelte → frontend
-   - `package.json` with `bin` field → CLI
-   - `go.mod` with no `main` package → library
-   - Default → backend
-2. Generate a `review-personas.toml` with appropriate personas for the repo type. At minimum include:
-   - `test-engineer` — test coverage, test quality, test contract compliance
-   - `domain-expert` — business logic correctness, spec compliance
-   - `code-quality` — code style, performance, maintainability
-3. Commit the file: `git add review-personas.toml && git commit -m "chore: add review personas config"`
-
-The review command reads this file to configure its multi-persona review loop.
 
 ### Decision Making & Drift
 

--- a/internal/plugins/registry.go
+++ b/internal/plugins/registry.go
@@ -14,7 +14,7 @@ const (
 	installedFile    = "installed_plugins.json"
 
 	// Plugin versions — keep in sync with plugins/*/.claude-plugin/plugin.json
-	HarnessVersion = "2.1.0"
+	HarnessVersion = "3.1.0"
 	PRVersion      = "1.2.0"
 )
 

--- a/plugins/harness/.claude-plugin/plugin.json
+++ b/plugins/harness/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "harness",
-  "version": "3.0.0",
-  "description": "3-tier documentation system with learning persistence, doc lifecycle management, and health scoring. Brainstorm, plan, orchestrate, review, reflect, complete with multi-persona review loops.",
+  "version": "3.1.0",
+  "description": "3-tier documentation system with learning persistence, doc lifecycle management, and health scoring. Brainstorm, plan, orchestrate, review, reflect, complete with pr-review-toolkit agents and superpowers SDD delegation.",
   "author": {
     "name": "donovanyohan"
   },

--- a/plugins/harness/commands/loop.md
+++ b/plugins/harness/commands/loop.md
@@ -81,7 +81,7 @@ Autonomous end-to-end execution: plan, orchestrate, review, fix, reflect, and co
    <LOOP_OVERRIDES>
    These overrides REPLACE conflicting instructions from /harness:orchestrate:
 
-   - **No checkpoints:** Do not output checkpoint status blocks (Phase 6 steps 10-11 of orchestrate). Do not wait for user input between tasks. This overrides the Orchestrator Rule "Report progress at checkpoints and wait for user feedback." Proceed immediately to the next task after updating the living plan.
+   - **No checkpoints:** Do not output checkpoint status blocks or wait for user input between tasks. This overrides orchestrate's "Checkpoint after EVERY task" HARNESS_OVERRIDES entry. Proceed immediately to the next task after updating the living plan.
    - **Auto-resolve blockers:** If a worker reports a surprise or blocker, append it to the decision log and make a judgment call:
      - **Fundamental** (would require changing the design doc's approach or affects 3+ unstarted tasks): STOP the loop via Emergency Stop
      - **Tactical** (unexpected API shape, missing test fixture, localized workaround): resolve and continue
@@ -97,7 +97,7 @@ Autonomous end-to-end execution: plan, orchestrate, review, fix, reflect, and co
    <LOOP_OVERRIDES>
    These overrides REPLACE conflicting instructions from /harness:review:
 
-   - **No resolution prompt:** Do not present the Phase 5 "Which approach?" options (review.md steps 8-9). Do not wait for user selection. Findings are auto-triaged as described below.
+   - **No resolution prompt:** Do not present the Phase 6 resolution options (review.md steps 12-13). Do not wait for user selection. Findings are auto-triaged as described below.
    </LOOP_OVERRIDES>
 
 11. **Auto-triage findings** using this rule:

--- a/plugins/harness/commands/orchestrate.md
+++ b/plugins/harness/commands/orchestrate.md
@@ -4,7 +4,7 @@ description: Use when executing a living plan with agent teams, or when user say
 
 # Orchestrate
 
-Execute a living plan using agent teams with per-task micro-reflects and living plan updates.
+Execute a living plan using subagent-driven development with per-task living plan updates, micro-reviews, and user checkpoints.
 
 ## Usage
 
@@ -12,12 +12,6 @@ Execute a living plan using agent teams with per-task micro-reflects and living 
 /harness:orchestrate
 /harness:orchestrate docs/exec-plans/active/{file}.md
 ```
-
-## Architecture
-
-- Orchestrator (main agent, Opus) owns coordination, never writes code
-- Workers (Sonnet 4.6) implement tasks
-- Workers report back, orchestrator updates plan and runs micro-reflects
 
 ## Invocation
 
@@ -37,211 +31,72 @@ Execute a living plan using agent teams with per-task micro-reflects and living 
 
 3. If any tasks are already marked complete in Progress, skip them. Resume from the first incomplete task.
 
-### Phase 2: Team & Task Setup
+### Phase 2: Execute with Subagent-Driven Development
 
-4. Create the agent team:
+4. **Invoke `superpowers:subagent-driven-development`** with the plan context. Follow its full process (dispatch implementer subagents per task, spec compliance review, code quality review, handle implementer status).
 
-   ```typescript
-   TeamCreate({
-     team_name: "{plan-kebab-name}",
-     description: "Executing: {plan title}"
-   })
+   <HARNESS_OVERRIDES>
+   The following overrides REPLACE conflicting instructions from superpowers:subagent-driven-development.
+   These take ABSOLUTE PRECEDENCE over any path, handoff, or workflow instruction in that skill:
+
+   - **Plan location:** The plan is in `docs/exec-plans/active/`, NOT `docs/superpowers/plans/`. Provide the full task text from the plan to implementer subagents — do not make them read the plan file.
+   - **No worktree setup:** Do NOT invoke `superpowers:using-git-worktrees`. Harness manages its own workflow context.
+   - **No final code reviewer or finishing-a-development-branch:** Do NOT dispatch the "final code reviewer subagent for entire implementation" step, and do NOT invoke `superpowers:finishing-a-development-branch`. Harness uses `/harness:review` for holistic review instead. After all tasks complete (each having passed their individual two-stage reviews), proceed directly to Phase 3 below.
+   - **Parallel dispatch for independent tasks:** SDD normally processes tasks sequentially. Override this when the plan contains independent tasks (no shared files, no data dependencies). For independent tasks, use `superpowers:dispatching-parallel-agents` to run them concurrently. If agent teams are available (TeamCreate, SendMessage), use them for coordination — create a named team, dispatch named workers, and collect results via SendMessage. After all parallel workers complete, run the two-stage review (spec + quality) on each task's changes before proceeding. Parallel dispatch is an optimization, not a requirement — fall back to sequential if uncertain about independence.
+   - **Living plan updates after EVERY task:** After each task completes (after both reviews pass), update the plan file immediately:
+     - **Progress:** Check off the completed task: `- [x] Task {N}: {name} _(completed {YYYY-MM-DD})_`
+     - **Surprises:** If the implementer reported anything unexpected, add a row: `| {date} | {what} | {plan impact} | {action taken} |`
+     - **Drift:** If the implementer deviated from the plan, add a row: `| Task {N} | {plan said} | {actually happened} | {why} |`
+     - **Decision Log:** If a non-trivial decision was made, add a row: `| {date} | Implementation | {decision} | {rationale} |`
+     - **Last Updated:** Update the timestamp in the plan's status line.
+   - **Micro-review after EVERY task:** After updating the plan, check the task's diff (`git diff HEAD~1`) for:
+     - Stale docs contradicted by the diff (new modules not in ARCHITECTURE.md, changed patterns not in DESIGN.md)
+     - Obvious code issues (unused imports, debug logging, unresolved TODOs)
+     - Test coverage gaps
+     Fix any stale docs immediately. Note code issues for `/harness:review`.
+   - **Checkpoint after EVERY task:** After the micro-review, report status to the user and wait for feedback:
+     ```
+     ## Task {N} Complete
+
+     **Progress:** {M} of {total} tasks done
+     **Surprises:** {any new entries, or "none"}
+     **Drift:** {any deviations, or "none"}
+     **Docs:** {what was updated, or "current"}
+     **Code notes:** {any issues spotted, or "clean"}
+
+     Ready for next task. Continue? (y/n)
+     ```
+     Apply any user corrections before proceeding to the next task.
+   - **Refactor scope awareness:** If the plan header contains `Refactor Scope:`, also update the scope doc's step statuses after each task. When orchestrate finishes all planned steps and hits an async gate, output the gate info:
+     ```
+     Step {N} ({name}): completed
+     Step {M} ({name}): in_progress — {status}
+
+     Gate before Step {X}: {gate condition}
+
+     This refactor is paused at a gate. Return in a new session and run:
+       /harness:refactor-status
+     ```
+   </HARNESS_OVERRIDES>
+
+### Phase 3: Completion
+
+5. When all tasks are complete, report final status:
+
    ```
+   ## All Tasks Complete
 
-5. Create tasks for each remaining plan task:
+   **Progress:** {total} of {total} tasks done
+   **Total surprises:** {N}
+   **Total drift entries:** {N}
+   **Decisions logged:** {N}
 
-   ```typescript
-   TaskCreate({
-     subject: "Task {N}: {task name}",
-     description: `
-       {full task specification from plan}
+   ## Next Step
 
-       Acceptance criteria:
-       {acceptance criteria from plan}
+   Run `/harness:review` to:
+   - Simplify code
+   - Run multi-perspective code review
+   - Fix or defer findings
 
-       MANDATORY COMPLETION REQUIREMENTS:
-       1. Verify implementation: run tests/build/lint as appropriate
-       2. Commit changes with descriptive message
-       3. Report back: what was done, any surprises, any deviations from plan
-     `,
-     activeForm: "Implementing Task {N}"
-   })
+   Then `/harness:reflect` → `/harness:complete`.
    ```
-
-6. Set up dependencies between tasks based on plan structure:
-
-   ```typescript
-   TaskUpdate({ taskId: "2", addBlockedBy: ["1"] })
-   ```
-
-### Phase 3: Dispatch Workers
-
-7. For each unblocked task (or batch of independent tasks), spawn a Sonnet 4.6 worker:
-
-   ```typescript
-   // Mark task in progress
-   TaskUpdate({ taskId: "N", status: "in_progress" })
-
-   // Spawn worker
-   Task({
-     description: "Task {N}: {task name}",
-     prompt: `You are a team member working on: {task name}.
-
-   PROJECT: {absolute path to project}
-   TEAM: {team-name}
-
-   ## Task Specification
-
-   {paste the full ### Task N section from the plan}
-
-   ## Context
-   - Plan: {plan path}
-   - Previous tasks completed: {list}
-   - Known surprises: {from plan's Surprises table, or "none"}
-
-   ## Implementation Approach
-
-   Implement directly using your tools (Read, Edit, Write, Bash).
-   Follow existing patterns in the codebase.
-
-   ## MANDATORY Before Claiming Complete
-
-   1. Run relevant tests/build to verify implementation works
-   2. Commit changes: git add {files} && git commit -m "{descriptive message}"
-   3. Report back:
-      - What was done (summary)
-      - Any surprises (unexpected findings, blockers encountered, different from plan)
-      - Any deviations from plan (what the plan said vs what you actually did, and why)
-   4. Mark task complete via: TaskUpdate({ taskId: "{N}", status: "completed" })
-   `,
-     subagent_type: "general-purpose",
-     model: "sonnet",
-     mode: "bypassPermissions",
-     team_name: "{team-name}",
-     name: "worker-{N}",
-     run_in_background: true
-   })
-   ```
-
-   **Independent tasks dispatched in parallel** — send multiple Task tool calls in one message. Sequential (blocked) tasks wait for their blockers to complete.
-
-### Phase 4: Monitor & Update Living Plan
-
-8. After each task completes, update the plan file immediately:
-
-   **a) Update Progress** — check off the completed task with timestamp:
-   ```markdown
-   - [x] Task {N}: {name} _(completed {YYYY-MM-DD})_
-   ```
-
-   **b) Add Surprises row** if worker reported anything unexpected:
-   ```markdown
-   | {date} | {what was unexpected} | {how it affects the plan} | {what was done} |
-   ```
-
-   **c) Add Plan Drift row** if worker deviated from the plan:
-   ```markdown
-   | Task {N} | {what the plan said} | {what actually happened} | {why} |
-   ```
-
-   **d) Add Decision Log row** if a non-trivial decision was made:
-   ```markdown
-   | {date} | Implementation | {decision} | {rationale} |
-   ```
-
-   **e) Update Last Updated** timestamp in the plan's status line.
-
-   **f) If the plan's source is a refactor scope doc** (check for `Refactor Scope:` in the plan header), also update the scope doc's step statuses. When orchestrate finishes all planned steps and hits an async gate, update the scope doc and output the gate info:
-   ```
-   Step {N} ({name}): completed
-   Step {M} ({name}): in_progress — {status}
-
-   Gate before Step {X}: {gate condition}
-
-   This refactor is paused at a gate. Return in a new session and run:
-     /harness:refactor-status
-   ```
-
-### Phase 5: Micro-Review
-
-9. After updating the plan, run a quick review scoped to the task's changes:
-
-   a) Check the task's diff for obvious issues:
-   ```bash
-   git diff HEAD~1 --stat
-   git diff HEAD~1
-   ```
-
-   b) Scan for:
-   - Stale docs contradicted by the diff (new modules not in ARCHITECTURE.md, changed patterns not in DESIGN.md)
-   - Obvious code issues (unused imports, debug logging left in, TODO comments that should be resolved)
-   - Test coverage gaps (new code paths without corresponding tests)
-
-   c) Fix any stale docs immediately while context is fresh.
-
-   d) If code issues are found, note them in the checkpoint report — they'll be caught thoroughly by `/harness:review` later.
-
-### Phase 6: Checkpoint
-
-10. After each task (or batch of parallel tasks), report status:
-
-    ```
-    ## Task {N} Complete
-
-    **Progress:** {M} of {total} tasks done
-    **Surprises:** {any new entries, or "none"}
-    **Drift:** {any deviations, or "none"}
-    **Docs:** {what was updated, or "current"}
-    **Code notes:** {any issues spotted, or "clean"}
-
-    Ready for next task. Continue? (y/n)
-    ```
-
-11. Wait for user feedback. Apply any corrections before proceeding to next task.
-
-### Phase 7: Completion
-
-12. When all tasks are complete, dispatch team shutdown:
-
-    ```typescript
-    SendMessage({ type: "shutdown_request", recipient: "worker-N", content: "All tasks complete." })
-    // Repeat for each active teammate
-    TeamDelete()
-    ```
-
-13. Report final status:
-
-    ```
-    ## All Tasks Complete
-
-    **Progress:** {total} of {total} tasks done
-    **Total surprises:** {N}
-    **Total drift entries:** {N}
-    **Decisions logged:** {N}
-
-    ## Next Step
-
-    Run `/harness:review` to:
-    - Simplify code
-    - Run multi-perspective code review (6 agents)
-    - Fix or defer findings
-
-    Then `/harness:reflect` → `/harness:complete`.
-    ```
-
-## Orchestrator Rules
-
-**DO:**
-- Write detailed worker prompts with full task spec, project path, and team name
-- Spawn workers with `model: "sonnet"` (Sonnet 4.6) for cost-effective implementation
-- Update living plan after EVERY task (progress, surprises, drift, decisions)
-- Run micro-review after EVERY task to catch stale docs and obvious issues
-- Report progress at checkpoints and wait for user feedback
-- Run integration checks yourself (never delegate to workers)
-
-**DON'T:**
-- Write code yourself — pure control plane only
-- Skip living plan updates after any task
-- Skip micro-reviews after any task
-- Dispatch dependent tasks in parallel (check blockedBy before spawning)
-- Mark the project done without running a final build/test check yourself

--- a/plugins/harness/commands/review.md
+++ b/plugins/harness/commands/review.md
@@ -6,6 +6,8 @@ description: Use when implementation is done and code needs quality review, when
 
 Multi-agent review loop on local changes using pr-review-toolkit agents. Runs all review agents in parallel, fixes issues, and re-runs failing agents until all pass or max cycles reached. Run after `/harness:orchestrate`, before `/harness:complete`.
 
+**Compatibility note:** This command no longer uses `review-personas.toml` or the previous multi-persona loop configuration. Any remaining references to it in other docs are legacy and will be cleaned up.
+
 ## Usage
 
 ```
@@ -15,13 +17,15 @@ Multi-agent review loop on local changes using pr-review-toolkit agents. Runs al
 
 ## Prerequisites
 
-This command requires the **pr-review-toolkit** plugin. If not installed, STOP and print:
+This command requires the **pr-review-toolkit** plugin. Verify it is installed by checking if its agents are available (e.g., `pr-review-toolkit:code-reviewer` appears in the agent list). If not installed, STOP and print:
 ```
 ERROR: Missing required plugin: pr-review-toolkit
 
 Install it:
   /plugins add pr-review-toolkit
 ```
+
+Optional: The **adr** plugin enables architecture compliance checking in Phase 5. If not installed, Phase 5 is skipped.
 
 ## Invocation
 
@@ -97,14 +101,14 @@ Install it:
 
 ### Phase 5: ADR Compliance
 
-9. Check if `docs/ARCHITECTURE.md` exists in the project.
+9. Check if `docs/ARCHITECTURE.md` exists AND the `adr` plugin is available (i.e., `/adr:review` is a recognized command).
 
-10. **If it exists:**
+10. **If both exist:**
     - Run `/adr:review` against the diff from Phase 1
     - Report any CRITICAL or WARNING violations
     - If the diff introduces new architectural patterns that aren't covered by existing ADRs, note them for `/harness:reflect` — do NOT create new ADRs during review. The bar for flagging is high: only note patterns that represent genuinely new architectural decisions, not routine implementation choices.
 
-11. **If it does not exist:** Skip silently.
+11. **If either is missing:** Skip silently — not every project uses ADRs or has the adr plugin installed.
 
 ### Phase 6: Resolution
 

--- a/plugins/harness/commands/review.md
+++ b/plugins/harness/commands/review.md
@@ -4,13 +4,23 @@ description: Use when implementation is done and code needs quality review, when
 
 # Review
 
-Multi-persona review loop on local changes. Runs review personas in parallel, fixes issues, and re-runs failing personas until all pass or max cycles reached. Run after `/harness:orchestrate`, before `/harness:complete`.
+Multi-agent review loop on local changes using pr-review-toolkit agents. Runs all review agents in parallel, fixes issues, and re-runs failing agents until all pass or max cycles reached. Run after `/harness:orchestrate`, before `/harness:complete`.
 
 ## Usage
 
 ```
 /harness:review                    # Review changes since active plan creation
 /harness:review HEAD~5             # Review last 5 commits
+```
+
+## Prerequisites
+
+This command requires the **pr-review-toolkit** plugin. If not installed, STOP and print:
+```
+ERROR: Missing required plugin: pr-review-toolkit
+
+Install it:
+  /plugins add pr-review-toolkit
 ```
 
 ## Invocation
@@ -34,70 +44,71 @@ Multi-persona review loop on local changes. Runs review personas in parallel, fi
 
 3. **Apply `superpowers:verification-before-completion`** — run the project's verification commands (tests, build, lint, typecheck) BEFORE starting review. If verification fails, STOP and fix first. Do not review broken code.
 
-### Phase 3: Persona Discovery
+### Phase 3: Review Loop
 
-4. Look for `review-personas.toml` in the repo root. This file defines the review personas for this repo.
+4. Set `cycle = 1`, `max_cycles = 3`, `failing_agents = all 5 review agents`.
 
-5. If `review-personas.toml` is missing:
-   - Detect repo type:
-     - `go.mod` present → backend
-     - `package.json` with React/Vue/Next/Svelte → frontend
-     - `package.json` with `bin` field → CLI
-     - `go.mod` with no `main` package → library
-     - Default → backend
-   - Read the matching template from `internal/defaults/personas/{type}.toml` (if in belayer repo) or use the built-in defaults below
-   - Generate `review-personas.toml` in the repo root and commit it:
-     ```bash
-     git add review-personas.toml
-     git commit -m "chore: add review personas config"
-     ```
+5. **Review cycle loop** — repeat until all pass or `cycle > max_cycles`:
 
-6. Parse the personas file. Each persona has: `description`, `focus` (list of areas), `docs` (list of doc paths to read).
+   a. Spawn each agent in `failing_agents` **in parallel** via the Agent tool, passing each the git diff from Phase 1. Use these pr-review-toolkit agent types:
 
-### Phase 4: Multi-Persona Review Loop
+   | Agent | `subagent_type` | Focus |
+   |-------|----------------|-------|
+   | Code Reviewer | `pr-review-toolkit:code-reviewer` | Code quality, bugs, logic errors, CLAUDE.md adherence |
+   | Silent Failure Hunter | `pr-review-toolkit:silent-failure-hunter` | Silent failures, error handling, inappropriate fallbacks |
+   | Test Analyzer | `pr-review-toolkit:pr-test-analyzer` | Test coverage completeness, missing edge cases |
+   | Type Design Analyzer | `pr-review-toolkit:type-design-analyzer` | Type design, encapsulation, invariant expression |
+   | Comment Analyzer | `pr-review-toolkit:comment-analyzer` | Comment accuracy, staleness, maintainability |
 
-7. Set `cycle = 1`, `max_cycles = 3` (or read from belayer.toml `[review_loop].max_review_cycles` if available), `failing_personas = all_personas`.
+   Each agent prompt should include:
+   - The full diff (from Phase 1 scope)
+   - The changed file list
+   - Instruction: "Review these local changes (not a PR). Return your findings in your standard format. End with a verdict: PASS (no critical/important issues) or FAIL (critical/important issues found)."
 
-8. **Review cycle loop** — repeat until all pass or `cycle > max_cycles`:
+   b. Wait for all agents to complete. Collect results.
 
-   a. For each persona in `failing_personas`, spawn a Claude Code subagent (via Agent tool) **in parallel**. Each subagent receives:
-      - The persona's description and focus areas
-      - The git diff (from Phase 1 scope)
-      - The contents of any docs listed in the persona's `docs` field
-      - The test contract from the active plan's design doc (if available)
-      - Instruction: "Review this diff from the perspective of {persona.description}. Focus on: {persona.focus}. Return JSON: `{ \"pass\": true/false, \"issues\": [{ \"file\": \"...\", \"line\": N, \"description\": \"...\", \"severity\": \"error|warning\" }] }`"
-
-   b. Wait for all subagents to complete. Collect results.
-
-   c. Separate passing and failing personas.
+   c. Determine pass/fail for each agent:
+      - **PASS**: No critical or important issues reported
+      - **FAIL**: Critical or important issues found (code-reviewer confidence ≥80, test-analyzer criticality ≥7, type-design-analyzer ratings ≤4, silent-failure-hunter CRITICAL/HIGH, comment-analyzer Critical Issues)
 
    d. If all pass → exit loop.
 
    e. If any fail:
-      - Present findings grouped by persona
+      - Present findings grouped by agent
       - Fix all reported issues inline (edit files directly)
       - Re-run verification (tests/build must still pass after fixes)
-      - Commit fixes: `git commit -am "fix: address {persona} review findings (cycle {cycle})"`
-      - Set `failing_personas = only personas that failed`
+      - Commit fixes: `git commit -am "fix: address review findings (cycle {cycle})"`
+      - Set `failing_agents = only agents that failed`
       - Increment `cycle`
 
-9. After loop exits:
+6. After loop exits:
    - If all passed: review is green
    - If max cycles reached with failures remaining: note unresolved issues
 
-### Phase 5: Code Simplification
+### Phase 4: Code Simplification
 
-10. After the persona loop, spawn a `code-simplifier:code-simplifier` agent (or invoke `/simplify`) scoped to the changed files. Let it make improvements.
+7. Spawn the `pr-review-toolkit:code-simplifier` agent scoped to the changed files. This agent modifies code directly — let it make improvements.
 
-11. If the simplifier made changes, commit and re-run verification:
-    ```bash
-    git add {changed files}
-    git commit -m "refactor: simplify code from review"
-    ```
+8. If the simplifier made changes, commit and re-run verification:
+   ```bash
+   git add {changed files}
+   git commit -m "refactor: simplify code from review"
+   ```
+
+### Phase 5: ADR Compliance
+
+9. Check if `docs/ARCHITECTURE.md` exists in the project.
+
+10. **If it exists:**
+    - Run `/adr:review` against the diff from Phase 1
+    - Report any CRITICAL or WARNING violations
+    - If the diff introduces new architectural patterns that aren't covered by existing ADRs, note them for `/harness:reflect` — do NOT create new ADRs during review. The bar for flagging is high: only note patterns that represent genuinely new architectural decisions, not routine implementation choices.
+
+11. **If it does not exist:** Skip silently.
 
 ### Phase 6: Resolution
 
-12. If unresolved persona issues remain after max cycles:
+12. If unresolved issues remain after max cycles:
     - Present options:
       ```
       ## Review: {N} unresolved issues after {max_cycles} cycles
@@ -105,7 +116,7 @@ Multi-persona review loop on local changes. Runs review personas in parallel, fi
       Options:
       1. Fix now — address remaining findings inline
       2. `/harness:orchestrate` — create tasks for significant fixes
-      3. Defer — proceed with findings noted (TOP.json will be marked review_incomplete)
+      3. Defer — proceed with findings noted
 
       Which approach?
       ```
@@ -121,16 +132,18 @@ Multi-persona review loop on local changes. Runs review personas in parallel, fi
     **Scope:** {diff description}
     **Verification:** {passing — with evidence}
     **Review cycles:** {N} of {max_cycles}
-    **Personas:** {passed}/{total} passed
+    **Agents:** {passed}/5 passed
     **Simplification:** {changes made | no changes needed}
+    **ADR compliance:** {N violations | compliant | skipped}
 
-    ### Per-Persona Results
-    | Persona | Status | Issues Found | Issues Resolved |
-    |---------|--------|-------------|-----------------|
-    | architect | pass | 2 | 2 |
-    | test-engineer | pass | 1 | 1 |
-    | domain-expert | pass | 0 | 0 |
-    | code-quality | fail | 3 | 1 |
+    ### Per-Agent Results
+    | Agent | Status | Issues Found | Issues Resolved |
+    |-------|--------|-------------|-----------------|
+    | code-reviewer | pass | 2 | 2 |
+    | silent-failure-hunter | pass | 1 | 1 |
+    | pr-test-analyzer | pass | 0 | 0 |
+    | type-design-analyzer | pass | 0 | 0 |
+    | comment-analyzer | fail | 3 | 1 |
 
     ### Unresolved Issues
     - {any remaining issues, or "None"}
@@ -139,24 +152,3 @@ Multi-persona review loop on local changes. Runs review personas in parallel, fi
 
     Run `/harness:complete` to archive the plan and commit all changes.
     ```
-
-## Built-in Default Personas
-
-If no template is available and the repo type cannot be determined, use these defaults:
-
-```toml
-[personas.test-engineer]
-description = "Reviews test coverage, test quality, and test contract compliance"
-focus = ["test coverage", "edge cases", "test contract satisfaction", "test isolation"]
-docs = []
-
-[personas.domain-expert]
-description = "Reviews business logic correctness and spec compliance"
-focus = ["acceptance criteria", "edge cases from spec", "domain invariants"]
-docs = []
-
-[personas.code-quality]
-description = "Reviews code style, performance, and maintainability"
-focus = ["naming", "complexity", "performance", "error handling"]
-docs = []
-```


### PR DESCRIPTION
## Summary

Harness orchestrate and review skills were re-implementing logic that superpowers and pr-review-toolkit already handle well. This refactors them into thin wrappers that delegate to upstream skills with HARNESS_OVERRIDES, matching the pattern already established by brainstorm and plan.

## Changes

- **orchestrate.md**: Rewrote from 248-line self-contained orchestrator to thin wrapper delegating to `superpowers:subagent-driven-development`. Adds parallel dispatch encouragement via `dispatching-parallel-agents` and agent teams. Explicitly blocks SDD's final code reviewer and `finishing-a-development-branch` (harness has its own review/complete pipeline).
- **review.md**: Replaced custom persona system (review-personas.toml, 3 default personas) with 5 pr-review-toolkit agents (code-reviewer, silent-failure-hunter, pr-test-analyzer, type-design-analyzer, comment-analyzer) plus code-simplifier. Added ADR compliance check with high bar for flagging new architecture decisions (deferred to reflect).
- **loop.md**: Fixed stale phase references to match restructured orchestrate and review.
- **plugin.json**: Bumped harness version 3.0.0 → 3.1.0.
- **registry.go + agentassets_test.go**: Synced version constants and test expectations.

## Testing

- `TestPluginVersion` passes with updated version expectations
- `TestCodexSkillFiles` passes (orchestrate.md rewrite references validated)
- `TestRootCommandIncludesExplorer` failure is pre-existing on master (unrelated)

---
*Created with `/pr:author`*