### PR TITLE
feat(harness): self-learning adversarial production review

### DIFF
--- a/agentassets_test.go
+++ b/agentassets_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPluginVersion(t *testing.T) {
-	if got := MustPluginVersion("harness"); got != "3.1.0" {
+	if got := MustPluginVersion("harness"); got != "3.2.0" {
 		t.Fatalf("unexpected harness version: %s", got)
 	}
 	if got := MustPluginVersion("pr"); got != "1.2.0" {

--- a/internal/plugins/registry.go
+++ b/internal/plugins/registry.go
@@ -14,7 +14,7 @@ const (
 	installedFile    = "installed_plugins.json"
 
 	// Plugin versions — keep in sync with plugins/*/.claude-plugin/plugin.json
-	HarnessVersion  = "3.1.0"
+	HarnessVersion  = "3.2.0"
 	PRVersion       = "1.2.0"
 	ExplorerVersion = "0.2.0"
 )

--- a/plugins/harness/.claude-plugin/plugin.json
+++ b/plugins/harness/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "harness",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "3-tier documentation system with learning persistence, doc lifecycle management, and health scoring. Brainstorm, plan, orchestrate, review, reflect, complete with pr-review-toolkit agents and superpowers SDD delegation.",
   "author": {
     "name": "donovanyohan"

--- a/plugins/harness/agents/harness-pruner.md
+++ b/plugins/harness/agents/harness-pruner.md
@@ -21,7 +21,7 @@ Harness transforms monolithic CLAUDE.md files into a 3-tier progressive disclosu
 
 The principle: CLAUDE.md is a **map**, not a manual. Every line in CLAUDE.md earns its place in the context window. Detailed content lives in Tier 2 summaries and Tier 3 deep docs.
 
-## Eighteen Audit Checks
+## Audit Checks
 
 | Check | What to Look For | Severity |
 |-------|-----------------|----------|
@@ -43,6 +43,10 @@ The principle: CLAUDE.md is a **map**, not a manual. Every line in CLAUDE.md ear
 | **Missing Frontmatter** | Design docs in `docs/design-docs/` without YAML frontmatter | warn |
 | **Frontmatter Status Consistency** | Docs with `status: current` that have been superseded by newer docs on the same topic, or docs with `status: implemented` that have no `implemented-by` reference | warn |
 | **Index Status Badges** | `docs/design-docs/index.md` Status column doesn't match frontmatter `status` on corresponding docs, or index lacks Status column entirely | warn |
+| **Review Guidance Missing** | `docs/REVIEW_GUIDANCE.md` doesn't exist when harness is initialized (Documentation Map exists in CLAUDE.md) | warn |
+| **Review Guidance Empty Context** | `docs/REVIEW_GUIDANCE.md` Deployment Context section contains only "unknown" placeholders | warn |
+| **Orphaned Escape Log Entries** | Escape Log table entries that don't have a matching question in the Adversarial Question Bank | warn |
+| **Over-indexed Question Categories** | Question bank categories with zero escape log entries after 5+ reviews have been run (may be wasting review time on non-applicable questions) | info |
 
 ## Audit Process
 
@@ -167,6 +171,25 @@ Read `docs/design-docs/index.md`. Check:
 - Does the index have a `Status` column? If not, flag as **warn**
 - If it has a Status column, for each entry: read the corresponding design doc's frontmatter `status` field and compare to the index badge. Flag mismatches as **warn**.
 
+### Step 19: Review Guidance Missing
+
+Check if CLAUDE.md has a Documentation Map (harness is initialized). If so, check if `docs/REVIEW_GUIDANCE.md` exists. If harness is initialized but REVIEW_GUIDANCE.md is missing, flag as **warn** — the adversarial review system won't run during `/harness:review`.
+
+### Step 20: Review Guidance Empty Context
+
+If `docs/REVIEW_GUIDANCE.md` exists, read the Deployment Context section. If all values are "unknown" or placeholder text, flag as **warn** — the adversarial review will run without project-specific context, reducing its effectiveness. Suggest the user fill in deployment topology, database type, scale, and infrastructure details.
+
+### Step 21: Orphaned Escape Log Entries
+
+If `docs/REVIEW_GUIDANCE.md` exists and has an Escape Log table with entries, verify each entry's "Question Added" column text appears (or a close match) in one of the Adversarial Question Bank category sections. Flag entries where the question wasn't actually added as **warn**.
+
+### Step 22: Over-indexed Question Categories
+
+If `docs/REVIEW_GUIDANCE.md` exists:
+- Count the number of escape log entries per question category
+- If a category has questions but zero escape log entries AND the project has run 5+ reviews (check git log for "address review findings" commits), flag the category as **info** — it may be over-indexed for this project's domain
+- This is informational only. Categories without escapes are not necessarily wrong — they may be preventing bugs from ever being introduced.
+
 ## Output Format
 
 ```markdown
@@ -234,13 +257,16 @@ When the user approves fixes, apply them in this order:
 13. **Frontmatter status consistency** — Update `status` field and fill in `supersedes` or `implemented-by` references as needed.
 14. **Index status badges** — If index lacks Status column, add it. Read each design doc's frontmatter and set the index Status column to match: `Current`, `Implemented`, `Superseded`, or `Stale`.
 15. **Stale plans** — Offer to run /harness:complete for each stale plan
+16. **Review guidance missing** — Create `docs/REVIEW_GUIDANCE.md` from the default scaffold. Read the harness plugin's `references/adversarial-review-prompt.md` for the default question bank. Analyze the repo to pre-populate deployment context.
+17. **Review guidance empty context** — Analyze the repo (Dockerfile, CI config, database drivers, deployment manifests) and suggest deployment context values for the user to confirm.
+18. **Orphaned escape log entries** — For each orphaned entry, add the question from the "Question Added" column to the matching category in the Adversarial Question Bank. If no matching category exists, create one.
 
 For each fix applied, report what was changed.
 
 ## Behavioral Rules
 
 **You MUST:**
-- Run ALL eighteen checks before producing the report
+- Run ALL audit checks before producing the report
 - Include file paths in every finding
 - Provide a specific suggested fix for every issue
 - Calculate and report the health classification

--- a/plugins/harness/commands/_learnings-format.md
+++ b/plugins/harness/commands/_learnings-format.md
@@ -99,7 +99,7 @@ When `init.md` generates a new LEARNINGS.md, use exactly this scaffold:
 Persistent learnings captured across sessions. Append-only, merge-friendly.
 
 Status: `active` | `superseded`
-Categories: `architecture` | `testing` | `patterns` | `workflow` | `debugging` | `performance`
+Categories: `architecture` | `testing` | `patterns` | `workflow` | `debugging` | `performance` | `review-escape`
 
 ---
 ```

--- a/plugins/harness/commands/init.md
+++ b/plugins/harness/commands/init.md
@@ -130,15 +130,11 @@ Transform a monolithic CLAUDE.md into a 3-tier progressive disclosure documentat
     Each question targets a production failure pattern. Add new questions when bugs
     escape review — see Escape Log below.
 
-    {Include relevant category sections from references/adversarial-review-prompt.md,
-     filtered by detected project characteristics. Always include:
-     - Failure Modes & Resilience
-     - Resource Exhaustion
-     Add others based on detection:
-     - Concurrency & Scale (if HTTP handlers found)
-     - Distributed Systems (if multi-instance or cron detected)
-     - Data Integrity (if database code found)
-     - Security (if auth code found)}
+    ### Failure Modes & Resilience
+    (populated from references/adversarial-review-prompt.md)
+
+    ### Resource Exhaustion
+    (populated from references/adversarial-review-prompt.md)
 
     ## Escape Log
 
@@ -148,6 +144,12 @@ Transform a monolithic CLAUDE.md into a 3-tier progressive disclosure documentat
     | Date | Bug | Caught By | Category | Question Added |
     |------|-----|-----------|----------|----------------|
     ```
+
+    **Populating the question bank:** Read `references/adversarial-review-prompt.md` for the full default question bank. Copy the actual questions (not just placeholders) into the relevant category sections. Always include Failure Modes & Resilience and Resource Exhaustion. Add other categories based on repo detection:
+    - Concurrency & Scale (if HTTP handlers found)
+    - Distributed Systems (if multi-instance deployment or cron detected)
+    - Data Integrity (if database code found)
+    - Security (if auth code found)
 
 9. Generate `docs/ARCHITECTURE.md` using the matklad format. Analyze the project's directory structure, key modules, and build system to produce:
 

--- a/plugins/harness/commands/init.md
+++ b/plugins/harness/commands/init.md
@@ -94,7 +94,7 @@ Transform a monolithic CLAUDE.md into a 3-tier progressive disclosure documentat
     Persistent learnings captured across sessions. Append-only, merge-friendly.
 
     Status: `active` | `superseded`
-    Categories: `architecture` | `testing` | `patterns` | `workflow` | `debugging` | `performance`
+    Categories: `architecture` | `testing` | `patterns` | `workflow` | `debugging` | `performance` | `review-escape`
 
     ---
     ```

--- a/plugins/harness/commands/init.md
+++ b/plugins/harness/commands/init.md
@@ -99,6 +99,56 @@ Transform a monolithic CLAUDE.md into a 3-tier progressive disclosure documentat
     ---
     ```
 
+8.7. Generate `docs/REVIEW_GUIDANCE.md` — the self-learning adversarial review configuration:
+
+    First, analyze the repository to pre-populate deployment context and relevant question categories:
+    - Check for `Dockerfile`, `docker-compose.yml`, `fly.toml`, `render.yaml`, Kubernetes manifests → infer deployment topology (single instance, multi-instance, serverless)
+    - Check for database drivers/ORMs in dependencies → infer database type
+    - Check for cron/scheduler code → flag distributed systems questions
+    - Check for HTTP server/handler code → flag concurrency questions
+    - Check for auth/security middleware → flag security questions
+    - Check CI config for deployment targets → infer scale
+
+    Then generate the file. Read `references/adversarial-review-prompt.md` for the full default question bank. Include only question categories relevant to the detected project characteristics — but always include Resource Exhaustion and Failure Modes as baseline categories.
+
+    ```markdown
+    # Review Guidance
+
+    Production failure patterns and adversarial questions for this project.
+    Updated automatically when bugs escape review — the harness learns from its mistakes.
+
+    ## Deployment Context
+
+    - Instances: {detected or "unknown — update when deployment topology is known"}
+    - Database: {detected or "unknown"}
+    - Scale: {detected or "unknown — update with approximate request volume and data size"}
+    - Infrastructure: {detected or "unknown — list queues, cron, caches, external APIs"}
+
+    ## Adversarial Question Bank
+
+    Questions asked during isolated adversarial review (`/harness:review` Phase 3).
+    Each question targets a production failure pattern. Add new questions when bugs
+    escape review — see Escape Log below.
+
+    {Include relevant category sections from references/adversarial-review-prompt.md,
+     filtered by detected project characteristics. Always include:
+     - Failure Modes & Resilience
+     - Resource Exhaustion
+     Add others based on detection:
+     - Concurrency & Scale (if HTTP handlers found)
+     - Distributed Systems (if multi-instance or cron detected)
+     - Data Integrity (if database code found)
+     - Security (if auth code found)}
+
+    ## Escape Log
+
+    Bugs that escaped harness review and were caught externally.
+    Each entry feeds back into the question bank above.
+
+    | Date | Bug | Caught By | Category | Question Added |
+    |------|-----|-----------|----------|----------------|
+    ```
+
 9. Generate `docs/ARCHITECTURE.md` using the matklad format. Analyze the project's directory structure, key modules, and build system to produce:
 
    ```markdown
@@ -331,6 +381,7 @@ Transform a monolithic CLAUDE.md into a 3-tier progressive disclosure documentat
     | Design | `docs/DESIGN.md` | Design principles, core beliefs, pattern decisions |
     | Plans | `docs/PLANS.md` | Active work, completed plans, tech debt tracking |
     | Learnings | `docs/LEARNINGS.md` | Past learnings, corrections, patterns discovered across sessions |
+    | Review Guidance | `docs/REVIEW_GUIDANCE.md` | Adversarial review questions, escape log, deployment context |
     | Bug Analyses | `docs/bug-analyses/` | When investigating bugs, understanding past root causes |
     | Refactor Scopes | `docs/refactor-scopes/` | When planning refactoring, reviewing past extraction patterns |
     | References | `docs/references/` | External library docs, API specs, llms.txt files |
@@ -415,6 +466,7 @@ Transform a monolithic CLAUDE.md into a 3-tier progressive disclosure documentat
     - docs/DESIGN.md
     - docs/PLANS.md
     - docs/LEARNINGS.md
+    - docs/REVIEW_GUIDANCE.md
     - docs/design-docs/index.md
     - docs/design-docs/core-beliefs.md
     - {any discovered Tier 2 files}

--- a/plugins/harness/commands/loop.md
+++ b/plugins/harness/commands/loop.md
@@ -97,7 +97,7 @@ Autonomous end-to-end execution: plan, orchestrate, review, fix, reflect, and co
    <LOOP_OVERRIDES>
    These overrides REPLACE conflicting instructions from /harness:review:
 
-   - **No resolution prompt:** Do not present the Phase 6 resolution options (review.md steps 12-13). Do not wait for user selection. Findings are auto-triaged as described below.
+   - **No resolution prompt:** Do not present the Phase 7 resolution options (review.md steps 21-22). Do not wait for user selection. Findings are auto-triaged as described below.
    </LOOP_OVERRIDES>
 
 11. **Auto-triage findings** using this rule:

--- a/plugins/harness/commands/prune.md
+++ b/plugins/harness/commands/prune.md
@@ -32,6 +32,10 @@ Audit documentation for staleness, broken links, orphaned guides, and bloat. Pro
 | Design-docs index lacks Current/Archived separation | warn |
 | Superseded design docs without "superseded by" marker | warn |
 | PLANS.md references features for deleted modules | warn |
+| REVIEW_GUIDANCE.md missing (harness initialized but no review guidance) | warn |
+| REVIEW_GUIDANCE.md Deployment Context is empty/placeholder ("unknown") | warn |
+| REVIEW_GUIDANCE.md Escape Log entries without matching question in bank | warn |
+| REVIEW_GUIDANCE.md question categories with zero escapes after 5+ reviews | info |
 
 ## Invocation
 
@@ -47,7 +51,7 @@ prompt: |
   ## Instructions
 
   1. Read CLAUDE.md and verify it has a "Documentation Map" section
-  2. Run ALL eighteen audit checks (see your agent instructions)
+  2. Run ALL audit checks (see your agent instructions and the Checks table)
   3. Produce the full prune report with severity, location, and suggested fix for every issue
   4. Calculate health classification (HEALTHY / NEEDS ATTENTION / UNHEALTHY)
   5. Present the report to the user
@@ -56,6 +60,8 @@ prompt: |
   - After presenting the report, automatically apply safe fixes:
     - Add missing files to docs/design-docs/index.md
     - Remove broken links from Documentation Map
+    - Create docs/REVIEW_GUIDANCE.md from default scaffold if missing (read references/adversarial-review-prompt.md for default question bank)
+    - Add escape log questions to matching bank categories if orphaned
   - For destructive fixes (deleting files, modifying CLAUDE.md), still ask for confirmation
 
   If no --fix flag:

--- a/plugins/harness/commands/reflect.md
+++ b/plugins/harness/commands/reflect.md
@@ -132,7 +132,7 @@ Full documentation reconciliation, conversation mining, and retrospective. Run a
 
 This phase feeds the self-learning review system. When bugs escape `/harness:review` and are caught by external reviewers (copilot, PR reviewers, QA, production incidents), those escapes become new adversarial questions that improve future reviews.
 
-14.7. **Detect review escapes** — scan the conversation history and available context for bugs that were NOT caught by `/harness:review` but were found by:
+14.6. **Detect review escapes** — scan the conversation history and available context for bugs that were NOT caught by `/harness:review` but were found by:
    - **External PR review** — copilot suggestions, human reviewer comments
    - **Manual testing** — bugs found during QA or dogfooding after review passed
    - **Production incidents** — issues traced to recently reviewed code
@@ -144,7 +144,7 @@ This phase feeds the self-learning review system. When bugs escape `/harness:rev
    - Conversation contains a bug fix for code that was part of the reviewed diff
    - The `/harness:review` report shows all agents PASS but issues were later found
 
-14.8. **Categorize each escape** into the adversarial question bank taxonomy:
+14.7. **Categorize each escape** into the adversarial question bank taxonomy:
    - `concurrency` — race conditions, thundering herds, lock contention
    - `distributed` — double-execution, coordination failures, split-brain
    - `failure-modes` — missing retries, cascade failures, no circuit breaker
@@ -153,12 +153,12 @@ This phase feeds the self-learning review system. When bugs escape `/harness:rev
    - `security` — injection, auth bypass, data exposure
    - `logic` — incorrect behavior, wrong edge case handling (code-level bugs the review agents should have caught)
 
-14.9. **Formulate "what breaks?" questions** for each escape:
+14.8. **Formulate "what breaks?" questions** for each escape:
    - Each question must be specific enough to catch this bug class in future reviews
    - Frame as a scenario, not a fix: "What happens when X?" not "Add jitter to backoff"
    - Example: A thundering herd escape → "Does retry/backoff logic use jitter, or will concurrent clients synchronize into waves?"
 
-14.10. **Update `docs/REVIEW_GUIDANCE.md`** if it exists:
+14.9. **Update `docs/REVIEW_GUIDANCE.md`** if it exists:
 
    a. Append each escape to the **Escape Log** table:
       ```markdown
@@ -172,9 +172,9 @@ This phase feeds the self-learning review system. When bugs escape `/harness:rev
 
    c. If the escape was a `logic` category bug (something the existing review agents should have caught), also write a learning to `docs/LEARNINGS.md` with category `review-escape` noting which agent should have caught it and why it might have been missed (confidence threshold too high? wrong framing?)
 
-14.11. If `docs/REVIEW_GUIDANCE.md` does NOT exist, skip this phase. In the final Report, set Review Escape Mining to: "Skipped — docs/REVIEW_GUIDANCE.md not found. Run /harness:init to enable adversarial review learning."
+14.10. If `docs/REVIEW_GUIDANCE.md` does NOT exist, skip this phase. In the final Report, set Review Escape Mining to: "Skipped — docs/REVIEW_GUIDANCE.md not found. Run /harness:init or /harness:review to enable adversarial review learning."
 
-14.12. Report escape mining results (include in the final Report output):
+14.11. Report escape mining results (include in the final Report output):
    - Number of escapes detected
    - Questions added/refined
    - Categories affected

--- a/plugins/harness/commands/reflect.md
+++ b/plugins/harness/commands/reflect.md
@@ -174,7 +174,7 @@ This phase feeds the self-learning review system. When bugs escape `/harness:rev
 
 14.11. If `docs/REVIEW_GUIDANCE.md` does NOT exist, skip this phase silently. The adversarial review system is opt-in — it's created during `/harness:init` but older projects may not have it.
 
-14.12. Report escape mining results (include in the Phase 8 report):
+14.12. Report escape mining results (include in the final Report output):
    - Number of escapes detected
    - Questions added/refined
    - Categories affected

--- a/plugins/harness/commands/reflect.md
+++ b/plugins/harness/commands/reflect.md
@@ -108,7 +108,7 @@ Full documentation reconciliation, conversation mining, and retrospective. Run a
      Persistent learnings captured across sessions. Append-only, merge-friendly.
 
      Status: `active` | `superseded`
-     Categories: `architecture` | `testing` | `patterns` | `workflow` | `debugging` | `performance`
+     Categories: `architecture` | `testing` | `patterns` | `workflow` | `debugging` | `performance` | `review-escape`
 
      ---
      ```
@@ -118,7 +118,7 @@ Full documentation reconciliation, conversation mining, and retrospective. Run a
 
      ### L-{NNN}: {one-line insight}
      - status: active
-     - category: {matching domain: architecture|testing|patterns|workflow|debugging|performance}
+     - category: {matching domain: architecture|testing|patterns|workflow|debugging|performance|review-escape}
      - source: /harness:reflect {YYYY-MM-DD}
      - branch: {current git branch}
 
@@ -172,7 +172,7 @@ This phase feeds the self-learning review system. When bugs escape `/harness:rev
 
    c. If the escape was a `logic` category bug (something the existing review agents should have caught), also write a learning to `docs/LEARNINGS.md` with category `review-escape` noting which agent should have caught it and why it might have been missed (confidence threshold too high? wrong framing?)
 
-14.11. If `docs/REVIEW_GUIDANCE.md` does NOT exist, skip this phase silently. The adversarial review system is opt-in — it's created during `/harness:init` but older projects may not have it.
+14.11. If `docs/REVIEW_GUIDANCE.md` does NOT exist, skip this phase. In the final Report, set Review Escape Mining to: "Skipped — docs/REVIEW_GUIDANCE.md not found. Run /harness:init to enable adversarial review learning."
 
 14.12. Report escape mining results (include in the final Report output):
    - Number of escapes detected

--- a/plugins/harness/commands/reflect.md
+++ b/plugins/harness/commands/reflect.md
@@ -128,6 +128,57 @@ Full documentation reconciliation, conversation mining, and retrospective. Run a
      ```
    - The learning must be actionable — "when doing X, check Y" not "X was broken"
 
+### Phase 5.5: Review Escape Mining
+
+This phase feeds the self-learning review system. When bugs escape `/harness:review` and are caught by external reviewers (copilot, PR reviewers, QA, production incidents), those escapes become new adversarial questions that improve future reviews.
+
+14.7. **Detect review escapes** — scan the conversation history and available context for bugs that were NOT caught by `/harness:review` but were found by:
+   - **External PR review** — copilot suggestions, human reviewer comments
+   - **Manual testing** — bugs found during QA or dogfooding after review passed
+   - **Production incidents** — issues traced to recently reviewed code
+   - **User corrections during this session** — user pointing out bugs in code that passed review
+
+   Indicators of an escape:
+   - User says "copilot found...", "the reviewer said...", "PR feedback..."
+   - User reports a bug in code that was committed after `/harness:review` passed
+   - Conversation contains a bug fix for code that was part of the reviewed diff
+   - The `/harness:review` report shows all agents PASS but issues were later found
+
+14.8. **Categorize each escape** into the adversarial question bank taxonomy:
+   - `concurrency` — race conditions, thundering herds, lock contention
+   - `distributed` — double-execution, coordination failures, split-brain
+   - `failure-modes` — missing retries, cascade failures, no circuit breaker
+   - `resource-exhaustion` — memory leaks, unbounded growth, connection exhaustion
+   - `data-integrity` — partial writes, missing transactions, duplicate processing
+   - `security` — injection, auth bypass, data exposure
+   - `logic` — incorrect behavior, wrong edge case handling (code-level bugs the review agents should have caught)
+
+14.9. **Formulate "what breaks?" questions** for each escape:
+   - Each question must be specific enough to catch this bug class in future reviews
+   - Frame as a scenario, not a fix: "What happens when X?" not "Add jitter to backoff"
+   - Example: A thundering herd escape → "Does retry/backoff logic use jitter, or will concurrent clients synchronize into waves?"
+
+14.10. **Update `docs/REVIEW_GUIDANCE.md`** if it exists:
+
+   a. Append each escape to the **Escape Log** table:
+      ```markdown
+      | {YYYY-MM-DD} | {one-line bug description} | {copilot|reviewer|QA|production|self} | {category} | {question text} |
+      ```
+
+   b. Add the new question to the appropriate **Adversarial Question Bank** category:
+      - If the category exists, append the question under it
+      - If the category doesn't exist, create a new `### {Category}` section
+      - If a similar question already exists, refine it to be more specific rather than adding a duplicate
+
+   c. If the escape was a `logic` category bug (something the existing review agents should have caught), also write a learning to `docs/LEARNINGS.md` with category `review-escape` noting which agent should have caught it and why it might have been missed (confidence threshold too high? wrong framing?)
+
+14.11. If `docs/REVIEW_GUIDANCE.md` does NOT exist, skip this phase silently. The adversarial review system is opt-in — it's created during `/harness:init` but older projects may not have it.
+
+14.12. Report escape mining results (include in the Phase 8 report):
+   - Number of escapes detected
+   - Questions added/refined
+   - Categories affected
+
 ### Phase 6: Outcomes & Retrospective
 
 15. Ask user for their perspective:
@@ -197,6 +248,11 @@ Full documentation reconciliation, conversation mining, and retrospective. Run a
     ### Learnings Written
     - {N} new learnings added to docs/LEARNINGS.md
     - {list of learning IDs and one-line summaries}
+
+    ### Review Escape Mining
+    - Escapes detected: {N}
+    - Questions added to REVIEW_GUIDANCE.md: {N}
+    - Categories affected: {list, or "None — no review escapes detected"}
 
     ### Retrospective
     - Captured in plan's Outcomes & Retrospective section

--- a/plugins/harness/commands/review.md
+++ b/plugins/harness/commands/review.md
@@ -25,7 +25,7 @@ Install it:
   /plugins add pr-review-toolkit
 ```
 
-Optional: The **adr** plugin enables architecture compliance checking in Phase 5. If not installed, Phase 5 is skipped.
+Optional: The **adr** plugin enables architecture compliance checking in Phase 6. If not installed, Phase 6 is skipped.
 
 ## Invocation
 
@@ -48,11 +48,70 @@ Optional: The **adr** plugin enables architecture compliance checking in Phase 5
 
 3. **Apply `superpowers:verification-before-completion`** — run the project's verification commands (tests, build, lint, typecheck) BEFORE starting review. If verification fails, STOP and fix first. Do not review broken code.
 
-### Phase 3: Review Loop
+### Phase 3: Adversarial Production Review
 
-4. Set `cycle = 1`, `max_cycles = 3`, `failing_agents = all 5 review agents`.
+Context-isolated adversarial review using `claude -p`. This phase catches production failure patterns (thundering herds, resource exhaustion, distributed coordination bugs) that open-ended subagent review misses. The key: the reviewer gets **only the diff and targeted questions** — no conversation history, no knowledge of intent.
 
-5. **Review cycle loop** — repeat until all pass or `cycle > max_cycles`:
+4. Check if `docs/REVIEW_GUIDANCE.md` exists. If it does not exist, generate it now using the default scaffold (see `/harness:init` Phase 2 step 8.7 for the scaffold template, or read `references/adversarial-review-prompt.md` for the default question bank). Commit it:
+   ```bash
+   git add docs/REVIEW_GUIDANCE.md
+   git commit -m "docs: initialize review guidance for adversarial review"
+   ```
+
+5. Read `docs/REVIEW_GUIDANCE.md`. Extract:
+   - **Deployment Context** section (instances, database, scale, infrastructure)
+   - **Adversarial Question Bank** sections (all categories with questions)
+   - **Known Non-Issues** section if it exists (to annotate the prompt)
+
+6. **Filter questions by relevance** to the diff:
+   - Read the changed file list from Phase 1
+   - Match file paths and diff content against question categories:
+     - Database/SQL code → include Data Integrity, Concurrency & Scale
+     - HTTP handlers/API code → include Concurrency & Scale, Failure Modes
+     - Auth/security code → include Security
+     - Cron/scheduler code → include Distributed Systems
+     - All diffs → include Resource Exhaustion
+   - Minimum: always include at least 3 questions even after filtering
+   - If filtering removes all questions, use the full bank
+
+7. **Construct the adversarial prompt** using the template from `references/adversarial-review-prompt.md`:
+   - Insert deployment context
+   - Insert filtered questions
+   - Select perspective variants based on deployment context (SRE, Scale, Security, Distributed — these stack)
+   - If Known Non-Issues exist, append: "Note: the following have been reviewed and confirmed as non-issues for this project: {list}. Do not report these unless circumstances have materially changed."
+
+8. **Generate the diff for the isolated reviewer:**
+   ```bash
+   git diff HEAD~{N} > /tmp/harness-adversarial-diff.patch
+   ```
+
+9. **Shell out to `claude -p`** with the constructed prompt and diff. This is the critical isolation step — no conversation context crosses this boundary:
+   ```bash
+   cat /tmp/harness-adversarial-diff.patch | claude -p "{constructed_prompt}" --output-format text
+   ```
+   Use `timeout: 300000` (5 minutes) on the Bash call.
+
+10. **Parse the adversarial review output:**
+    - Look for `VERDICT: FAIL` or `VERDICT: PASS`
+    - Extract individual findings with their severity (CRITICAL, HIGH, MEDIUM, LOW)
+    - If the command fails or times out, log the failure and proceed to Phase 4 — adversarial review is additive, not blocking
+
+11. **Integrate findings into the review cycle:**
+    - **CRITICAL findings:** These MUST be fixed before proceeding to Phase 4. Fix inline, commit, and re-run verification.
+    - **HIGH/MEDIUM findings:** Add to the fix queue. These will be addressed alongside Phase 4 agent findings.
+    - **LOW findings:** Note in the report but do not block.
+    - **PASS verdict:** Proceed to Phase 4 normally.
+
+12. Clean up:
+    ```bash
+    rm -f /tmp/harness-adversarial-diff.patch
+    ```
+
+### Phase 4: Review Loop
+
+13. Set `cycle = 1`, `max_cycles = 3`, `failing_agents = all 5 review agents`.
+
+14. **Review cycle loop** — repeat until all pass or `cycle > max_cycles`:
 
    a. Spawn each agent in `failing_agents` **in parallel** via the Agent tool, passing each the git diff from Phase 1. Use these pr-review-toolkit agent types:
 
@@ -67,6 +126,7 @@ Optional: The **adr** plugin enables architecture compliance checking in Phase 5
    Each agent prompt should include:
    - The full diff (from Phase 1 scope)
    - The changed file list
+   - Any HIGH/MEDIUM findings from Phase 3 adversarial review that haven't been fixed yet (so agents don't duplicate effort but can validate fixes)
    - Instruction: "Review these local changes (not a PR). Return your findings in your standard format. End with a verdict: PASS (no critical/important issues) or FAIL (critical/important issues found)."
 
    b. Wait for all agents to complete. Collect results.
@@ -85,34 +145,34 @@ Optional: The **adr** plugin enables architecture compliance checking in Phase 5
       - Set `failing_agents = only agents that failed`
       - Increment `cycle`
 
-6. After loop exits:
+15. After loop exits:
    - If all passed: review is green
    - If max cycles reached with failures remaining: note unresolved issues
 
-### Phase 4: Code Simplification
+### Phase 5: Code Simplification
 
-7. Spawn the `pr-review-toolkit:code-simplifier` agent scoped to the changed files. This agent modifies code directly — let it make improvements.
+16. Spawn the `pr-review-toolkit:code-simplifier` agent scoped to the changed files. This agent modifies code directly — let it make improvements.
 
-8. If the simplifier made changes, commit and re-run verification:
+17. If the simplifier made changes, commit and re-run verification:
    ```bash
    git add {changed files}
    git commit -m "refactor: simplify code from review"
    ```
 
-### Phase 5: ADR Compliance
+### Phase 6: ADR Compliance
 
-9. Check if `docs/ARCHITECTURE.md` exists AND the `adr` plugin is available (i.e., `/adr:review` is a recognized command).
+18. Check if `docs/ARCHITECTURE.md` exists AND the `adr` plugin is available (i.e., `/adr:review` is a recognized command).
 
-10. **If both exist:**
+19. **If both exist:**
     - Run `/adr:review` against the diff from Phase 1
     - Report any CRITICAL or WARNING violations
     - If the diff introduces new architectural patterns that aren't covered by existing ADRs, note them for `/harness:reflect` — do NOT create new ADRs during review. The bar for flagging is high: only note patterns that represent genuinely new architectural decisions, not routine implementation choices.
 
-11. **If either is missing:** Skip silently — not every project uses ADRs or has the adr plugin installed.
+20. **If either is missing:** Skip silently — not every project uses ADRs or has the adr plugin installed.
 
-### Phase 6: Resolution
+### Phase 7: Resolution
 
-12. If unresolved issues remain after max cycles:
+21. If unresolved issues remain after max cycles:
     - Present options:
       ```
       ## Review: {N} unresolved issues after {max_cycles} cycles
@@ -125,20 +185,29 @@ Optional: The **adr** plugin enables architecture compliance checking in Phase 5
       Which approach?
       ```
 
-13. If user chooses to fix now, apply fixes and re-run verification.
+22. If user chooses to fix now, apply fixes and re-run verification.
 
 ### Report
 
-14. Output:
+23. Output:
     ```
     ## Review Complete
 
     **Scope:** {diff description}
     **Verification:** {passing — with evidence}
+    **Adversarial review:** {PASS | FAIL — N findings (breakdown by severity) | skipped}
     **Review cycles:** {N} of {max_cycles}
     **Agents:** {passed}/5 passed
     **Simplification:** {changes made | no changes needed}
     **ADR compliance:** {N violations | compliant | skipped}
+
+    ### Adversarial Review Findings
+    | Severity | Finding | Status |
+    |----------|---------|--------|
+    | CRITICAL | {title} | fixed |
+    | HIGH | {title} | fixed |
+    | MEDIUM | {title} | deferred |
+    {or "No production failure patterns found."}
 
     ### Per-Agent Results
     | Agent | Status | Issues Found | Issues Resolved |

--- a/plugins/harness/commands/review.md
+++ b/plugins/harness/commands/review.md
@@ -87,13 +87,24 @@ Context-isolated adversarial review using `claude -p`. This phase catches produc
    ```
    If the diff is empty, skip the adversarial review with status "skipped — empty diff" and proceed to Phase 4.
 
-9. **Shell out to `claude -p`** with the constructed prompt and diff. Write the prompt to a temp file first to avoid shell escaping issues with deployment context or question content:
+9. **Invoke `claude -p`** with the constructed prompt and diff. This is the critical isolation step — no conversation context crosses this boundary.
+
+   **Important:** Do NOT interpolate the prompt into a shell string (e.g., `claude -p "{prompt}"`). The prompt contains newlines, quotes, and backticks from REVIEW_GUIDANCE.md that will break shell parsing. Instead:
+   - Write the constructed prompt to a temp file
+   - Combine the prompt and diff into a single input, then pipe to `claude -p`
    ```bash
    ADVERSARIAL_PROMPT=$(mktemp /tmp/harness-adversarial-prompt-XXXXXX.md)
-   # Write the constructed prompt to $ADVERSARIAL_PROMPT
-   cat "$ADVERSARIAL_DIFF" | claude -p "$(cat "$ADVERSARIAL_PROMPT")" --output-format text
+   # Write the constructed prompt to $ADVERSARIAL_PROMPT via the Write tool
+   # Then invoke claude with the prompt file, piping the diff as context:
+   claude -p "$(cat "$ADVERSARIAL_PROMPT")" < "$ADVERSARIAL_DIFF" --output-format text
    ```
-   Use `timeout: 300000` (5 minutes) on the Bash call. This is the critical isolation step — no conversation context crosses this boundary.
+   Alternatively, concatenate the prompt and diff into a single file and pipe it:
+   ```bash
+   COMBINED=$(mktemp /tmp/harness-adversarial-combined-XXXXXX.md)
+   cat "$ADVERSARIAL_PROMPT" "$ADVERSARIAL_DIFF" > "$COMBINED"
+   cat "$COMBINED" | claude -p - --output-format text
+   ```
+   Use `timeout: 300000` (5 minutes) on the Bash call.
 
 10. **Parse the adversarial review output:**
     - Look for `VERDICT: FAIL` or `VERDICT: PASS`
@@ -110,7 +121,7 @@ Context-isolated adversarial review using `claude -p`. This phase catches produc
 
 12. Clean up:
     ```bash
-    rm -f "$ADVERSARIAL_DIFF" "$ADVERSARIAL_PROMPT"
+    rm -f "$ADVERSARIAL_DIFF" "$ADVERSARIAL_PROMPT" "$COMBINED" 2>/dev/null
     ```
 
 ### Phase 4: Review Loop

--- a/plugins/harness/commands/review.md
+++ b/plugins/harness/commands/review.md
@@ -80,31 +80,37 @@ Context-isolated adversarial review using `claude -p`. This phase catches produc
    - Select perspective variants based on deployment context (SRE, Scale, Security, Distributed — these stack)
    - If Known Non-Issues exist, append: "Note: the following have been reviewed and confirmed as non-issues for this project: {list}. Do not report these unless circumstances have materially changed."
 
-8. **Generate the diff for the isolated reviewer:**
+8. **Generate the diff for the isolated reviewer** using a unique temp file to avoid collisions with concurrent reviews:
    ```bash
-   git diff HEAD~{N} > /tmp/harness-adversarial-diff.patch
+   ADVERSARIAL_DIFF=$(mktemp /tmp/harness-adversarial-XXXXXX.patch)
+   git diff HEAD~{N} > "$ADVERSARIAL_DIFF"
    ```
+   If the diff is empty, skip the adversarial review with status "skipped — empty diff" and proceed to Phase 4.
 
-9. **Shell out to `claude -p`** with the constructed prompt and diff. This is the critical isolation step — no conversation context crosses this boundary:
+9. **Shell out to `claude -p`** with the constructed prompt and diff. Write the prompt to a temp file first to avoid shell escaping issues with deployment context or question content:
    ```bash
-   cat /tmp/harness-adversarial-diff.patch | claude -p "{constructed_prompt}" --output-format text
+   ADVERSARIAL_PROMPT=$(mktemp /tmp/harness-adversarial-prompt-XXXXXX.md)
+   # Write the constructed prompt to $ADVERSARIAL_PROMPT
+   cat "$ADVERSARIAL_DIFF" | claude -p "$(cat "$ADVERSARIAL_PROMPT")" --output-format text
    ```
-   Use `timeout: 300000` (5 minutes) on the Bash call.
+   Use `timeout: 300000` (5 minutes) on the Bash call. This is the critical isolation step — no conversation context crosses this boundary.
 
 10. **Parse the adversarial review output:**
     - Look for `VERDICT: FAIL` or `VERDICT: PASS`
     - Extract individual findings with their severity (CRITICAL, HIGH, MEDIUM, LOW)
-    - If the command fails or times out, log the failure and proceed to Phase 4 — adversarial review is additive, not blocking
+    - If the output contains no parseable `VERDICT:` line, treat as inconclusive — set status to "inconclusive — could not parse verdict" and report the raw output
+    - If the command fails or times out, print a warning: "Adversarial review skipped: {reason}. Proceeding with agent review." Set the adversarial review status to "skipped — {reason}" for the final report
 
 11. **Integrate findings into the review cycle:**
     - **CRITICAL findings:** These MUST be fixed before proceeding to Phase 4. Fix inline, commit, and re-run verification.
     - **HIGH/MEDIUM findings:** Add to the fix queue. These will be addressed alongside Phase 4 agent findings.
     - **LOW findings:** Note in the report but do not block.
     - **PASS verdict:** Proceed to Phase 4 normally.
+    - **Inconclusive/skipped:** Proceed to Phase 4. Note in the report.
 
 12. Clean up:
     ```bash
-    rm -f /tmp/harness-adversarial-diff.patch
+    rm -f "$ADVERSARIAL_DIFF" "$ADVERSARIAL_PROMPT"
     ```
 
 ### Phase 4: Review Loop

--- a/plugins/harness/references/adversarial-review-prompt.md
+++ b/plugins/harness/references/adversarial-review-prompt.md
@@ -179,9 +179,9 @@ Not every question applies to every diff. Before sending to `claude -p`, filter 
 
 The adversarial review verdict integrates with the harness review cycle:
 
-- **FAIL with CRITICAL findings:** Blocks the review. Must be addressed before Phase 3 agents run.
-- **FAIL with only HIGH/MEDIUM findings:** Proceeds to Phase 3, findings are added to the fix queue alongside agent findings.
-- **PASS:** Proceeds to Phase 3 normally. The adversarial review serves as a pre-filter, not a replacement for the 5 specialized agents.
+- **FAIL with CRITICAL findings:** Blocks the review. Must be addressed before Phase 4 (Review Loop) agents run.
+- **FAIL with only HIGH/MEDIUM findings:** Proceeds to Phase 4, findings are added to the fix queue alongside agent findings.
+- **PASS:** Proceeds to Phase 4 normally. The adversarial review serves as a pre-filter, not a replacement for the 5 specialized agents.
 
 ### False Positive Handling
 

--- a/plugins/harness/references/adversarial-review-prompt.md
+++ b/plugins/harness/references/adversarial-review-prompt.md
@@ -1,0 +1,191 @@
+# Adversarial Review Prompt Reference
+
+Default prompt templates, question bank, and perspective definitions for the harness adversarial production review phase.
+
+## Prompt Template
+
+The adversarial review shells out to `claude -p` with **only the diff and this prompt**. No conversation context, no intent, no session history. The reviewer sees code the way a production incident investigator sees a post-mortem diff.
+
+### Core Prompt
+
+```
+You are a production incident investigator reviewing code that has already
+shipped and caused an outage. Your job is to find what caused the outage.
+
+## Deployment Context
+
+{DEPLOYMENT_CONTEXT from docs/REVIEW_GUIDANCE.md}
+
+## Your Task
+
+For each changed function or significant code block in the diff below,
+answer EVERY question in the checklist. If a question does not apply,
+explain WHY it does not apply — do not skip silently.
+
+{QUESTIONS from docs/REVIEW_GUIDANCE.md, filtered to relevant categories}
+
+## Rules
+
+- Do NOT say "the code looks good." Find the failure mode.
+- Do NOT compliment the code. You are investigating a production outage.
+- If you cannot find a failure mode for a question, explain precisely why
+  the code is resilient to that failure pattern. Show your reasoning.
+- Rank each finding by severity:
+  - CRITICAL: Will cause data loss, outage, or security breach in production
+  - HIGH: Will cause degraded service, incorrect results, or resource exhaustion
+  - MEDIUM: May cause issues under specific conditions (scale, timing, topology)
+  - LOW: Defense-in-depth concern, not immediately exploitable
+- For each finding, provide:
+  - The specific code location (function name, line context)
+  - The failure scenario (what triggers it)
+  - The production impact (what the user/system experiences)
+  - The fix (concrete code change, not vague advice)
+
+## Output Format
+
+### Findings
+
+For each finding:
+```
+**[SEVERITY] Finding: {title}**
+Location: {function/file context from the diff}
+Scenario: {what triggers this failure}
+Impact: {what happens in production}
+Fix: {concrete change}
+```
+
+### Verdict
+
+End with exactly one of:
+- `VERDICT: FAIL — {N} findings ({critical} critical, {high} high, {medium} medium)`
+- `VERDICT: PASS — no production failure modes found (with reasoning)`
+
+## The Diff
+
+```diff
+{DIFF}
+```
+```
+
+### Perspective Variants
+
+When `docs/REVIEW_GUIDANCE.md` contains deployment context that matches specific perspectives, the prompt is augmented with a perspective preamble. These stack — a project with cron jobs and external APIs gets both the SRE and distributed systems perspectives.
+
+#### SRE / On-Call Perspective
+
+Activated when: deployment context mentions multi-instance, load balancer, kubernetes, or cron jobs.
+
+```
+You are the on-call SRE who got paged at 2 AM because of this code.
+You've seen this pattern before — deterministic backoff without jitter,
+cron jobs without distributed locks, connection pools without limits.
+Your pager history IS your checklist. Find what pages you.
+```
+
+#### Scale Engineer Perspective
+
+Activated when: deployment context mentions high request volume, large datasets, or database tables.
+
+```
+You are a scale engineer reviewing code that runs against production
+datasets 1000x larger than the test fixtures. Every fetchAll() is an OOM
+kill. Every unbounded query is a full table scan. Every in-memory cache
+is a memory leak. Find what breaks at scale.
+```
+
+#### Security Auditor Perspective
+
+Activated when: code touches authentication, authorization, user input handling, or external API calls.
+
+```
+You are a security auditor and an attacker controls every input to this
+code. Every string is an injection vector. Every permission check has a
+TOCTOU race. Every external call leaks internal state. Find the exploit.
+```
+
+#### Distributed Systems Perspective
+
+Activated when: deployment context mentions multiple instances, message queues, or shared state.
+
+```
+You are a distributed systems engineer. This code runs on N instances
+that share nothing except the database. Every in-memory lock is useless.
+Every assumption of single-execution is wrong. Every "read then write"
+is a race condition. Find the coordination failure.
+```
+
+## Default Question Bank
+
+These are the starter questions created during `/harness:init`. Projects extend this bank in `docs/REVIEW_GUIDANCE.md` as bugs escape review.
+
+### Concurrency & Scale
+
+- What happens when 1,000 concurrent requests hit this simultaneously?
+- What happens when the input data is 1000x larger than test fixtures?
+- What happens when the connection pool is exhausted?
+- Does this use deterministic backoff without jitter? (thundering herd)
+- Are there goroutine/thread leaks under error paths?
+- Does fetchAll/collect load unbounded data into memory?
+
+### Distributed Systems
+
+- What happens when two instances run this behind a load balancer?
+- What happens when this scheduled task fires on multiple replicas simultaneously?
+- What happens during a rolling deployment where old and new code versions run simultaneously?
+- Are in-memory locks or caches being used where distributed coordination is needed?
+- Is there a read-modify-write pattern without optimistic locking or CAS?
+
+### Failure Modes & Resilience
+
+- What happens when the upstream API/service is down for 5 minutes?
+- What happens when network latency is 2 seconds instead of 50ms?
+- What happens when a dependent service returns malformed data instead of an error?
+- Are retries idempotent? What happens if the first request succeeded but the response was lost?
+- Is there a circuit breaker, or will failures cascade?
+
+### Resource Exhaustion
+
+- What happens when this runs for 30 days without restart?
+- Does memory grow unbounded with input size or over time?
+- Are file handles, connections, or streams always closed on error paths?
+- Are there background processes that accumulate without cleanup?
+
+### Data Integrity
+
+- What happens if this operation is interrupted halfway through?
+- Are multi-step mutations wrapped in a transaction?
+- Can concurrent writes produce inconsistent state?
+- Does the code handle duplicate delivery (at-least-once semantics)?
+
+### Security
+
+- What happens if an attacker controls the input to this function?
+- Are there TOCTOU (time-of-check-to-time-of-use) races in permission checks?
+- Does this code log, expose, or transmit sensitive data?
+- Are SQL queries parameterized, or is there string interpolation?
+
+## Filtering Questions by Relevance
+
+Not every question applies to every diff. Before sending to `claude -p`, filter the question bank:
+
+1. **By file type:** Skip distributed systems questions for pure frontend CSS changes.
+2. **By deployment context:** Skip multi-instance questions for single-instance SQLite projects.
+3. **By diff content:** If the diff touches database code, include Data Integrity. If it touches HTTP handlers, include Concurrency & Scale. If it touches auth code, include Security.
+4. **Minimum questions:** Always include at least 3 questions, even after filtering. If filtering removes all questions, fall back to the full bank — the model will explain why each doesn't apply.
+
+## Interpreting Results
+
+### Pass/Fail Integration
+
+The adversarial review verdict integrates with the harness review cycle:
+
+- **FAIL with CRITICAL findings:** Blocks the review. Must be addressed before Phase 3 agents run.
+- **FAIL with only HIGH/MEDIUM findings:** Proceeds to Phase 3, findings are added to the fix queue alongside agent findings.
+- **PASS:** Proceeds to Phase 3 normally. The adversarial review serves as a pre-filter, not a replacement for the 5 specialized agents.
+
+### False Positive Handling
+
+The adversarial prompt is intentionally aggressive. Some findings will be false positives. When a finding is determined to be a false positive:
+
+- Do NOT add a question to suppress it — the aggressiveness is the point
+- If the same false positive recurs 3+ times across reviews, note it in `docs/REVIEW_GUIDANCE.md` under a `## Known Non-Issues` section with rationale

--- a/plugins/harness/references/adversarial-review-prompt.md
+++ b/plugins/harness/references/adversarial-review-prompt.md
@@ -114,6 +114,20 @@ Every assumption of single-execution is wrong. Every "read then write"
 is a race condition. Find the coordination failure.
 ```
 
+## Escape Category to Question Bank Mapping
+
+When `/harness:reflect` categorizes an escape, use this mapping to route the new question to the correct Question Bank section:
+
+| Escape Category | Question Bank Heading |
+|----------------|----------------------|
+| `concurrency` | Concurrency & Scale |
+| `distributed` | Distributed Systems |
+| `failure-modes` | Failure Modes & Resilience |
+| `resource-exhaustion` | Resource Exhaustion |
+| `data-integrity` | Data Integrity |
+| `security` | Security |
+| `logic` | (create new section or add to most relevant existing section) |
+
 ## Default Question Bank
 
 These are the starter questions created during `/harness:init`. Projects extend this bank in `docs/REVIEW_GUIDANCE.md` as bugs escape review.

--- a/plugins/harness/references/adversarial-review-prompt.md
+++ b/plugins/harness/references/adversarial-review-prompt.md
@@ -8,7 +8,7 @@ The adversarial review shells out to `claude -p` with **only the diff and this p
 
 ### Core Prompt
 
-```
+````
 You are a production incident investigator reviewing code that has already
 shipped and caused an outage. Your job is to find what caused the outage.
 
@@ -65,7 +65,7 @@ End with exactly one of:
 ```diff
 {DIFF}
 ```
-```
+````
 
 ### Perspective Variants
 


### PR DESCRIPTION
## Summary

Adds a context-isolated adversarial review phase to `/harness:review` that dramatically improves production bug catch rates. Based on [research](https://blog.katanaquant.com/p/the-bug-that-shipped) showing models catch deployment-level bugs only 13% of the time in open-ended self-review, but 100% when asked targeted "what breaks?" questions.

The key insight: **subagent reviewers share the same session context as the code author**, making them sympathetic reviewers. This PR adds a `claude -p` invocation that gets **only the diff and targeted scenario questions** — no conversation history, no knowledge of intent. Same model, completely different behavior.

The system is self-learning: when bugs escape review and are caught externally (copilot, PR reviewers, production), `/harness:reflect` captures them as new adversarial questions, making future reviews smarter.

## Changes

- **New: `references/adversarial-review-prompt.md`** — Default adversarial prompt template with 4 perspective variants (SRE, Scale Engineer, Security Auditor, Distributed Systems), 6-category question bank (~25 questions), filtering logic, and result interpretation
- **`review.md`** — New Phase 3: Adversarial Production Review via `claude -p`. Reads `docs/REVIEW_GUIDANCE.md`, filters questions by diff content, constructs perspective-augmented prompt, shells out with only the diff. CRITICAL findings block, HIGH/MEDIUM feed into fix queue. Phases renumbered 4-7.
- **`init.md`** — Scaffolds `docs/REVIEW_GUIDANCE.md` during harness init with repo-analyzed deployment context (Dockerfiles, CI config, database drivers) and filtered question bank. Added to Documentation Map.
- **`reflect.md`** — New Phase 5.5: Review Escape Mining. Detects bugs caught by external reviewers that harness missed, categorizes escapes, formulates new "what breaks?" questions, appends to escape log and question bank.
- **`prune.md`** — 4 new health checks: REVIEW_GUIDANCE.md missing, empty deployment context, orphaned escape log entries, over-indexed question categories.
- **`loop.md`** — Updated phase reference for resolution override (Phase 6 → 7).
- **`harness-pruner.md`** — Steps 19-22 for review guidance auditing with fix procedures.

## Self-Learning Loop

```
init → creates REVIEW_GUIDANCE.md (deployment context + question bank)
  ↓
review Phase 3 → claude -p with isolated context, targeted questions
  ↓
reflect Phase 5.5 → mines for bugs that escaped review
  ↓                  writes new questions to REVIEW_GUIDANCE.md
prune → audits review guidance health, fills gaps
  ↓
review Phase 3 → asks better questions next time
```

## Test plan

- [ ] Run `/harness:init` on a fresh repo — verify `docs/REVIEW_GUIDANCE.md` is created with deployment context and filtered questions
- [ ] Run `/harness:review` on a branch with changes — verify Phase 3 adversarial review executes via `claude -p` and produces findings
- [ ] Verify adversarial review CRITICAL findings block progression to Phase 4
- [ ] Verify adversarial review gracefully degrades on timeout/failure (proceeds to Phase 4)
- [ ] Simulate a review escape scenario in conversation, run `/harness:reflect` — verify escape is captured in REVIEW_GUIDANCE.md
- [ ] Run `/harness:prune` on a project without REVIEW_GUIDANCE.md — verify warning is reported
- [ ] Run `/harness:loop` end-to-end — verify adversarial review integrates into autonomous loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)