### PR TITLE
fix(pr:resolve): make GitHub thread resolution mandatory

### DIFF
--- a/plugins/pr/commands/resolve.md
+++ b/plugins/pr/commands/resolve.md
@@ -62,16 +62,52 @@ For each actionable item: read file, make change, verify tests pass.
 
 After all changes: run project tests, commit with message summarizing fixes, push.
 
-### 5. Offer to Reply and Resolve
+### 5. Reply and Resolve Comments on GitHub
 
-Ask user to choose:
-1. **Reply individually** - Reply to each comment with fix details, resolve threads via `gh api graphql`
-2. **Summary comment** - Post single `gh pr comment` listing all addressed feedback
-3. **Skip** - User handles replies manually
+After pushing fixes, **you MUST resolve comment threads on GitHub** using the GraphQL API. Do not skip this step.
+
+#### Resolution rules
+
+| Category | GitHub Action |
+|----------|--------------|
+| **Actionable — fixed** | Reply with what you changed, then **resolve the thread** |
+| **Actionable — declined with rationale** | Reply explaining why with clear reasoning, then **resolve the thread** |
+| **Question / Discussion** | Reply if you have useful context, but **leave the thread open** |
+
+#### How to resolve a thread
+
+First, get the thread ID for each review comment. Review comment IDs from the REST API (`/pulls/<number>/comments`) are **not** GraphQL node IDs — you must convert them:
+
+```bash
+# Get the GraphQL node_id for a review comment (REST comment id -> node_id)
+gh api repos/{owner}/{repo}/pulls/comments/<comment_id> --jq '.node_id'
+```
+
+Then resolve the thread using GraphQL:
+
+```bash
+gh api graphql -f query='
+  mutation {
+    resolveReviewThread(input: {threadId: "<NODE_ID>"}) {
+      thread { isResolved }
+    }
+  }
+'
+```
+
+**Important:** The `threadId` must be a GraphQL node ID (starts with `PRRT_` or similar), not a REST integer ID. If you have the REST comment ID, fetch the `node_id` field first as shown above.
+
+#### Reply to individual comments
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/comments/<comment_id>/replies -f body='<your reply>'
+```
+
+Reply **before** resolving so the reviewer sees what was done.
 
 ### 6. Report Completion
 
-Report files modified, commit SHA, and remaining questions/discussions. Suggest `/pr:update` to sync PR description.
+Report files modified, commit SHA, and which comments were resolved vs left open. Suggest `/pr:update` to sync PR description.
 
 ## Common Mistakes
 
@@ -80,4 +116,7 @@ Report files modified, commit SHA, and remaining questions/discussions. Suggest 
 | Blindly implementing all feedback | Evaluate each comment critically |
 | Not testing after changes | Always verify before pushing |
 | Not replying to reviewers | Always communicate what was addressed |
+| Addressing comments but not resolving threads on GitHub | Always resolve threads for fixed/declined items via `gh api graphql` |
+| Resolving question/discussion threads | Only resolve threads where you made a fix or gave a definitive decline with rationale |
+| Using REST comment ID as GraphQL threadId | Fetch `node_id` from REST API first, then pass that to the GraphQL mutation |
 | jq filters with `!=` in double quotes | Always use **single quotes** around jq expressions, or use `gh api --jq` flag |


### PR DESCRIPTION
## Summary
- Replace optional "offer to reply and resolve" step with mandatory thread resolution workflow
- Add explicit resolution rules: fixed/declined items get resolved, questions/discussions stay open
- Add GraphQL mutation commands and REST-to-GraphQL node ID conversion instructions
- Add 3 new common mistake entries for thread resolution pitfalls

## Test plan
- [ ] Run `/pr:resolve` on a PR with actionable comments and verify threads are marked resolved on GitHub
- [ ] Verify question/discussion threads are left open
- [ ] Confirm REST comment ID → GraphQL node ID conversion works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)