### PR TITLE
feat: add tracked Codex skill pack support

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,64 +1,82 @@
 # Installing Belayer for Codex
 
-Belayer installs native Codex skills through `belayer init`.
+Belayer uses native Codex skill discovery, following the same basic pattern as Superpowers: expose a single `skills/` tree and mount it into `~/.agents/skills/`.
 
-## Quick Install
+## Quick Install from a Repo Checkout
 
-1. Install the Codex CLI so `codex` is on your `PATH`.
-2. Run:
+If you are working from a local clone of this repository:
+
+1. Refresh the generated Codex skill pack from the plugin source:
 
    ```bash
-   belayer init
+   go run ./cmd/gencodexskills
+   ```
+
+2. Mount the generated `skills/` tree into Codex's discovery directory:
+
+   ```bash
+   mkdir -p ~/.agents/skills
+   ln -s /absolute/path/to/belayer/skills ~/.agents/skills/belayer
    ```
 
 3. Restart Codex.
 
-## What `belayer init` Does
+This gives you a repo-local install that updates whenever you regenerate `skills/`.
 
-- Writes generated Belayer skills to:
+## Quick Install from the Belayer CLI
 
-  ```text
-  ~/.belayer/agent-assets/codex/<version>/skills/
-  ```
-
-- Mounts that skill tree at:
-
-  ```text
-  ~/.agents/skills/belayer
-  ```
-
-- Installs:
-  - `harness-init`
-  - `harness-brainstorm`
-  - `harness-bug`
-  - `harness-refactor`
-  - `harness-refactor-status`
-  - `harness-plan`
-  - `harness-orchestrate`
-  - `harness-review`
-  - `harness-reflect`
-  - `harness-prune`
-  - `harness-complete`
-  - `harness-loop`
-  - `harness-batch`
-  - `pr-author`
-  - `pr-review`
-  - `pr-resolve`
-  - `pr-update`
-  - `pr-automate`
-  - `strangler-fig`
-
-## Repair / Reinstall
-
-Re-run:
+If you installed Belayer as a binary:
 
 ```bash
 belayer init
 ```
 
-That is the supported repair path.
+When `codex` is on your `PATH`, `belayer init`:
 
-If you need to clear the installed Belayer Codex pack first:
+- writes generated Belayer skills to `~/.belayer/agent-assets/codex/<version>/skills/`
+- mounts that tree at `~/.agents/skills/belayer`
+- uses a symlink when possible and falls back to a copy if the platform blocks symlinks
+
+Restart Codex after the install completes.
+
+## Single Source of Truth
+
+- `plugins/` is the authored workflow source shared with Claude Code
+- `skills/` is the generated Codex projection of that source
+- command `description:` frontmatter in `plugins/*/commands/*.md` becomes the Codex `SKILL.md` description field
+- static skills under `plugins/*/skills/` are copied into the Codex pack with local reference paths rewritten automatically
+
+Do not hand-edit `skills/`. Regenerate it from `plugins/`.
+
+## Updating
+
+After changing any file under `plugins/`:
+
+```bash
+go run ./cmd/gencodexskills
+go test . -run 'TestCodexSkillFiles|TestTrackedCodexSkillsSnapshot|TestPluginVersion'
+```
+
+If you installed from a repo checkout through the symlink, Codex will pick up the refreshed content after restart.
+
+If you installed through `belayer init`, rerun `belayer init`.
+
+## Repair / Reinstall
+
+Repo checkout install:
+
+```bash
+rm -rf ~/.agents/skills/belayer
+ln -s /absolute/path/to/belayer/skills ~/.agents/skills/belayer
+```
+
+Belayer CLI install:
+
+```bash
+belayer init
+```
+
+If you need to clear the cached Belayer Codex pack first:
 
 ```bash
 rm -rf ~/.agents/skills/belayer
@@ -69,7 +87,7 @@ Then run `belayer init` again and restart Codex.
 
 ## Troubleshooting
 
-### Codex skills do not appear
+### Skills do not appear
 
 1. Verify `codex` is installed:
 
@@ -77,13 +95,13 @@ Then run `belayer init` again and restart Codex.
    command -v codex
    ```
 
-2. Verify the mounted skill tree exists:
+2. Verify the mount exists:
 
    ```bash
    ls -la ~/.agents/skills/belayer
    ```
 
-3. Verify the generated versioned tree exists:
+3. If using the Belayer CLI install, verify the cached pack exists:
 
    ```bash
    ls -la ~/.belayer/agent-assets/codex

--- a/README.md
+++ b/README.md
@@ -86,23 +86,55 @@ Belayer provides contracts: setter expects spec.md in and produces per-repo spec
 This keeps belayer agent-agnostic. Your nodes could be Claude Code sessions, Codex, OpenCode, custom scripts, or anything else that fulfills the contract.
 </details>
 
-## Claude Code Marketplace
+## Claude Code Marketplace and Codex Skills
 
-This repository is a valid [Claude Code marketplace](https://github.com/anthropics/claude-code-plugins) plugin repository. It vendors two plugins that are automatically available when you work in this project:
+This repo now follows the same broad cross-agent pattern used by Superpowers: keep the workflow content in one authored tree, then expose thin runtime-specific install layers.
+
+- `plugins/` is the authored source of truth for Belayer workflows
+- `skills/` is the generated native Codex skill pack derived from those same plugin files
+- `go run ./cmd/gencodexskills` refreshes the tracked Codex pack after plugin edits
+
+Belayer currently ships three shared workflow packs:
 
 - **harness** (`plugins/harness/`) — 3-tier documentation system with living execution plans: brainstorm, bug, refactor, plan, orchestrate, complete, and the strangler-fig refactoring skill
 - **pr** (`plugins/pr/`) — Pull request lifecycle management: authoring, reviewing, resolving, and updating PRs
+- **explorer** (`plugins/explorer/`) — Submit a spec into the belayer pipeline from an interactive agent session
 
-### Installing the plugins
+### Claude Code
 
-These plugins are vendored in the `plugins/` directory and are picked up automatically by Claude Code when working in this repo. No additional installation is needed for contributors.
+This repository is a valid [Claude Code marketplace](https://github.com/anthropics/claude-code-plugins) plugin repository. The vendored plugins under `plugins/` are picked up automatically when you work in this repo.
 
-If you want to use these plugins in **other projects**, install them from the marketplace:
+If you want to use them in other projects, install them from the marketplace:
 
 ```bash
 claude plugin add donovan-yohan/belayer --path plugins/harness
 claude plugin add donovan-yohan/belayer --path plugins/pr
+claude plugin add donovan-yohan/belayer --path plugins/explorer
 ```
+
+### Codex
+
+Codex uses native skill discovery from `~/.agents/skills/`. Belayer supports that in two ways:
+
+For contributors working from this checkout:
+
+```bash
+go run ./cmd/gencodexskills
+mkdir -p ~/.agents/skills
+ln -s /absolute/path/to/belayer/skills ~/.agents/skills/belayer
+```
+
+Then restart Codex.
+
+If you are using the installed Belayer CLI instead of a repo checkout, run:
+
+```bash
+belayer init
+```
+
+When `codex` is on your `PATH`, `belayer init` writes a versioned pack under `~/.belayer/agent-assets/codex/<pack-version>/skills/` and mounts it at `~/.agents/skills/belayer`.
+
+Codex installation, repair steps, and troubleshooting live in [`.codex/INSTALL.md`](/Users/donovanyohan/Documents/Programs/personal/belayer/.codex/INSTALL.md).
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ belayer init
 
 When `codex` is on your `PATH`, `belayer init` writes a versioned pack under `~/.belayer/agent-assets/codex/<pack-version>/skills/` and mounts it at `~/.agents/skills/belayer`.
 
-Codex installation, repair steps, and troubleshooting live in [`.codex/INSTALL.md`](/Users/donovanyohan/Documents/Programs/personal/belayer/.codex/INSTALL.md).
+Codex installation, repair steps, and troubleshooting live in [`.codex/INSTALL.md`](.codex/INSTALL.md).
 
 ## Prerequisites
 

--- a/agentassets.go
+++ b/agentassets.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 )
 
+//go:generate go run ./cmd/gencodexskills
+
 //go:embed plugins/harness/commands/*.md plugins/pr/commands/*.md plugins/explorer/commands/*.md plugins/harness/skills/strangler-fig all:plugins/harness/.claude-plugin/plugin.json all:plugins/pr/.claude-plugin/plugin.json all:plugins/explorer/.claude-plugin/plugin.json
 var FS embed.FS
 

--- a/agentassets.go
+++ b/agentassets.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -119,10 +121,10 @@ func CodexSkillFiles() (map[string][]byte, error) {
 	for _, plugin := range plugins {
 		for _, command := range plugin.Commands {
 			target := path.Join(command.CodexSkillName(), "SKILL.md")
-			files[target] = []byte(command.RenderCodexSkill())
+			files[target] = []byte(command.RenderCodexSkill(plugins))
 		}
 		for _, skill := range plugin.Skills {
-			if err := appendStaticSkill(files, skill); err != nil {
+			if err := appendStaticSkill(files, skill, plugins); err != nil {
 				return nil, err
 			}
 		}
@@ -138,8 +140,9 @@ func (c CommandSpec) CodexSkillName() string {
 	return Invocation("codex", c.Plugin, c.Name)
 }
 
-func (c CommandSpec) RenderCodexSkill() string {
-	body := rewriteForCodex(c.Body, "")
+func (c CommandSpec) RenderCodexSkill(plugins []PluginSpec) string {
+	body := rewriteForCodex(c.Body, "", plugins)
+	description := rewriteForCodex(c.Description, "", plugins)
 	return fmt.Sprintf(`---
 name: %s
 description: %s
@@ -149,7 +152,7 @@ description: %s
 > Claude alias: %s
 
 %s
-`, c.CodexSkillName(), c.Description, c.SourcePath, c.ClaudeCommand(), strings.TrimSpace(body))
+`, c.CodexSkillName(), description, c.SourcePath, c.ClaudeCommand(), strings.TrimSpace(body))
 }
 
 func loadPlugins() ([]PluginSpec, error) {
@@ -258,7 +261,7 @@ func extractTitle(body string) string {
 	return ""
 }
 
-func appendStaticSkill(files map[string][]byte, skill StaticSkillSpec) error {
+func appendStaticSkill(files map[string][]byte, skill StaticSkillSpec, plugins []PluginSpec) error {
 	var paths []string
 	if err := fs.WalkDir(FS, skill.SourceDir, func(current string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -283,20 +286,49 @@ func appendStaticSkill(files map[string][]byte, skill StaticSkillSpec) error {
 			return fmt.Errorf("read %s: %w", sourcePath, err)
 		}
 		if path.Base(sourcePath) == "SKILL.md" {
-			raw = []byte(rewriteForCodex(string(raw), prefix))
+			raw = []byte(rewriteForCodex(string(raw), prefix, plugins))
 		}
 		files[target] = raw
 	}
 	return nil
 }
 
-func rewriteForCodex(content, sourcePrefix string) string {
+// WriteSkillFiles writes the given file map to targetRoot, removing the directory first.
+func WriteSkillFiles(targetRoot string, files map[string][]byte) error {
+	if err := os.RemoveAll(targetRoot); err != nil {
+		return fmt.Errorf("remove %s: %w", targetRoot, err)
+	}
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", targetRoot, err)
+	}
+
+	paths := make([]string, 0, len(files))
+	for relPath := range files {
+		paths = append(paths, relPath)
+	}
+	sort.Strings(paths)
+
+	for _, relPath := range paths {
+		target := filepath.Join(targetRoot, filepath.FromSlash(relPath))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("create parent dir for %s: %w", target, err)
+		}
+		if err := os.WriteFile(target, files[relPath], 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", target, err)
+		}
+	}
+	return nil
+}
+
+func rewriteForCodex(content, sourcePrefix string, plugins []PluginSpec) string {
 	rewritten := content
-	// Rewrite /<plugin>:<command> → <plugin>-<command> for all loaded plugins.
-	plugins, _ := Plugins()
 	for _, p := range plugins {
-		re := regexp.MustCompile(`/` + regexp.QuoteMeta(p.Name) + `:([a-z-]+)`)
-		rewritten = re.ReplaceAllString(rewritten, p.Name+"-$1")
+		// Rewrite /<plugin>:<command> → <plugin>-<command>
+		slashRef := regexp.MustCompile(`/` + regexp.QuoteMeta(p.Name) + `:([a-z-]+)`)
+		rewritten = slashRef.ReplaceAllString(rewritten, p.Name+"-$1")
+		// Rewrite Skill("<plugin>:<command>") → Skill("<plugin>-<command>")
+		skillRef := regexp.MustCompile(`Skill\("` + regexp.QuoteMeta(p.Name) + `:([a-z-]+)"`)
+		rewritten = skillRef.ReplaceAllString(rewritten, `Skill("`+p.Name+`-$1"`)
 	}
 	rewritten = superpowersRef.ReplaceAllString(rewritten, "$1")
 	if sourcePrefix != "" {

--- a/agentassets_test.go
+++ b/agentassets_test.go
@@ -12,7 +12,7 @@ func TestPluginVersion(t *testing.T) {
 	if got := MustPluginVersion("harness"); got != "4.0.0" {
 		t.Fatalf("unexpected harness version: %s", got)
 	}
-	if got := MustPluginVersion("pr"); got != "1.3.0" {
+	if got := MustPluginVersion("pr"); got != "1.3.1" {
 		t.Fatalf("unexpected pr version: %s", got)
 	}
 	if got := MustPluginVersion("explorer"); got != "0.2.0" {
@@ -84,11 +84,18 @@ func TestTrackedCodexSkillsSnapshot(t *testing.T) {
 	}
 
 	got := make(map[string][]byte)
-	if err := filepath.Walk("skills", func(current string, info os.FileInfo, err error) error {
+	if err := filepath.WalkDir("skills", func(current string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
+		name := d.Name()
+		if d.IsDir() {
+			if strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasPrefix(name, ".") || strings.EqualFold(name, "Thumbs.db") {
 			return nil
 		}
 
@@ -106,10 +113,6 @@ func TestTrackedCodexSkillsSnapshot(t *testing.T) {
 		t.Fatalf("walk tracked skills snapshot: %v", err)
 	}
 
-	if len(got) != len(want) {
-		t.Fatalf("tracked skills snapshot file count mismatch: got %d want %d", len(got), len(want))
-	}
-
 	var missing []string
 	var mismatched []string
 	for relPath, expected := range want {
@@ -123,9 +126,17 @@ func TestTrackedCodexSkillsSnapshot(t *testing.T) {
 		}
 	}
 
-	if len(missing) > 0 || len(mismatched) > 0 {
+	var extra []string
+	for relPath := range got {
+		if _, ok := want[relPath]; !ok {
+			extra = append(extra, relPath)
+		}
+	}
+
+	if len(missing) > 0 || len(mismatched) > 0 || len(extra) > 0 {
 		sort.Strings(missing)
 		sort.Strings(mismatched)
-		t.Fatalf("tracked skills snapshot is stale; missing=%v mismatched=%v", missing, mismatched)
+		sort.Strings(extra)
+		t.Fatalf("tracked skills snapshot is stale; missing=%v mismatched=%v extra=%v", missing, mismatched, extra)
 	}
 }

--- a/agentassets_test.go
+++ b/agentassets_test.go
@@ -1,6 +1,9 @@
 package belayerassets
 
 import (
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -71,5 +74,58 @@ func TestCodexSkillFiles_RewritesRuntimeReferences(t *testing.T) {
 	// Check that body content (Usage section) is rewritten.
 	if !strings.Contains(send, "explorer-send") {
 		t.Fatalf("expected explorer-send Codex skill reference in explorer send skill")
+	}
+}
+
+func TestTrackedCodexSkillsSnapshot(t *testing.T) {
+	want, err := CodexSkillFiles()
+	if err != nil {
+		t.Fatalf("CodexSkillFiles returned error: %v", err)
+	}
+
+	got := make(map[string][]byte)
+	if err := filepath.Walk("skills", func(current string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel("skills", current)
+		if err != nil {
+			return err
+		}
+		raw, err := os.ReadFile(current)
+		if err != nil {
+			return err
+		}
+		got[filepath.ToSlash(relPath)] = raw
+		return nil
+	}); err != nil {
+		t.Fatalf("walk tracked skills snapshot: %v", err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("tracked skills snapshot file count mismatch: got %d want %d", len(got), len(want))
+	}
+
+	var missing []string
+	var mismatched []string
+	for relPath, expected := range want {
+		actual, ok := got[relPath]
+		if !ok {
+			missing = append(missing, relPath)
+			continue
+		}
+		if string(actual) != string(expected) {
+			mismatched = append(mismatched, relPath)
+		}
+	}
+
+	if len(missing) > 0 || len(mismatched) > 0 {
+		sort.Strings(missing)
+		sort.Strings(mismatched)
+		t.Fatalf("tracked skills snapshot is stale; missing=%v mismatched=%v", missing, mismatched)
 	}
 }

--- a/cmd/gencodexskills/main.go
+++ b/cmd/gencodexskills/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	belayerassets "github.com/donovan-yohan/belayer"
+)
+
+func main() {
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		fatalf("determine working directory: %v", err)
+	}
+
+	targetRoot := filepath.Join(repoRoot, "skills")
+	files, err := belayerassets.CodexSkillFiles()
+	if err != nil {
+		fatalf("generate codex skill files: %v", err)
+	}
+
+	if err := os.RemoveAll(targetRoot); err != nil {
+		fatalf("remove %s: %v", targetRoot, err)
+	}
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		fatalf("create %s: %v", targetRoot, err)
+	}
+
+	paths := make([]string, 0, len(files))
+	for relPath := range files {
+		paths = append(paths, relPath)
+	}
+	sort.Strings(paths)
+
+	for _, relPath := range paths {
+		target := filepath.Join(targetRoot, filepath.FromSlash(relPath))
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			fatalf("create parent directory for %s: %v", target, err)
+		}
+		if err := os.WriteFile(target, files[relPath], 0o644); err != nil {
+			fatalf("write %s: %v", target, err)
+		}
+	}
+
+	fmt.Printf("wrote %d files to %s\n", len(paths), targetRoot)
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/cmd/gencodexskills/main.go
+++ b/cmd/gencodexskills/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 
 	belayerassets "github.com/donovan-yohan/belayer"
 )
@@ -15,36 +14,21 @@ func main() {
 		fatalf("determine working directory: %v", err)
 	}
 
+	if _, err := os.Stat(filepath.Join(repoRoot, "go.mod")); err != nil {
+		fatalf("gencodexskills must be run from the repository root (no go.mod found in %s)", repoRoot)
+	}
+
 	targetRoot := filepath.Join(repoRoot, "skills")
 	files, err := belayerassets.CodexSkillFiles()
 	if err != nil {
 		fatalf("generate codex skill files: %v", err)
 	}
 
-	if err := os.RemoveAll(targetRoot); err != nil {
-		fatalf("remove %s: %v", targetRoot, err)
-	}
-	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
-		fatalf("create %s: %v", targetRoot, err)
+	if err := belayerassets.WriteSkillFiles(targetRoot, files); err != nil {
+		fatalf("write skill files: %v", err)
 	}
 
-	paths := make([]string, 0, len(files))
-	for relPath := range files {
-		paths = append(paths, relPath)
-	}
-	sort.Strings(paths)
-
-	for _, relPath := range paths {
-		target := filepath.Join(targetRoot, filepath.FromSlash(relPath))
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			fatalf("create parent directory for %s: %v", target, err)
-		}
-		if err := os.WriteFile(target, files[relPath], 0o644); err != nil {
-			fatalf("write %s: %v", target, err)
-		}
-	}
-
-	fmt.Printf("wrote %d files to %s\n", len(paths), targetRoot)
+	fmt.Printf("wrote %d files to %s\n", len(files), targetRoot)
 }
 
 func fatalf(format string, args ...any) {

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,10 +1,43 @@
 # Plugin Development
 
-Patterns, conventions, and authoring rules for the `plugins/harness/` and `plugins/pr/` Claude Code plugins shipped with belayer.
+Patterns, conventions, and authoring rules for the shared Belayer workflow packs shipped to Claude Code and Codex.
 
 ## Current State
 
-Belayer ships three plugins: **harness** (documentation lifecycle), **pr** (pull request lifecycle), and **explorer** (spec submission). All are embedded via `embed.FS` and installed by `belayer init`.
+Belayer ships three workflow packs: **harness** (documentation lifecycle), **pr** (pull request lifecycle), and **explorer** (spec submission).
+
+- Claude consumes them from `plugins/*/`
+- Codex consumes them from the generated `skills/` tree
+- `agentassets.go` is the runtime adapter that turns the authored plugin source into Codex-native `SKILL.md` directories
+
+## Cross-Agent Source Of Truth
+
+Belayer follows a thin-runtime-layer model similar to Superpowers:
+
+- Author workflow content once under `plugins/*/commands/*.md` and `plugins/*/skills/*`
+- Treat command frontmatter `description:` as the canonical trigger text for both agents
+- Generate the Codex-facing `skills/` projection from that same source via `go run ./cmd/gencodexskills`
+- Never hand-edit `skills/`; it is a tracked build artifact used for repo-checkout Codex installs
+
+When you change any authored plugin file, refresh and verify the Codex pack:
+
+```bash
+go run ./cmd/gencodexskills
+go test . -run 'TestCodexSkillFiles|TestTrackedCodexSkillsSnapshot|TestPluginVersion'
+```
+
+`TestTrackedCodexSkillsSnapshot` is the drift check. If it fails, the checked-in `skills/` tree is stale.
+
+## Runtime Overrides And Data Mapping
+
+Belayer still authors the shared workflows in the Claude marketplace shape, but the Codex projection is generated mechanically:
+
+- `/harness:plan` becomes `harness-plan`
+- `/pr:author` becomes `pr-author`
+- `superpowers:writing-plans` becomes `writing-plans`
+- static skill references under `plugins/*/skills/*` are rewritten to local paths inside the generated Codex skill directory
+
+Keep runtime-specific deltas constrained to these adapter rules. Do not fork the underlying workflow text just to satisfy one agent.
 
 ## Key Patterns
 

--- a/internal/plugins/codex.go
+++ b/internal/plugins/codex.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 
 	belayerassets "github.com/donovan-yohan/belayer"
 )
@@ -73,31 +72,7 @@ func writeCodexSkillFiles(versionPath string) error {
 	if err != nil {
 		return fmt.Errorf("generate codex skill files: %w", err)
 	}
-
-	if err := os.RemoveAll(versionPath); err != nil {
-		return fmt.Errorf("remove versioned skill path %s: %w", versionPath, err)
-	}
-	if err := os.MkdirAll(versionPath, 0o755); err != nil {
-		return fmt.Errorf("create versioned skill path %s: %w", versionPath, err)
-	}
-
-	paths := make([]string, 0, len(files))
-	for relPath := range files {
-		paths = append(paths, relPath)
-	}
-	sort.Strings(paths)
-
-	for _, relPath := range paths {
-		target := filepath.Join(versionPath, relPath)
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return fmt.Errorf("create parent dir for %s: %w", target, err)
-		}
-		if err := os.WriteFile(target, files[relPath], 0o644); err != nil {
-			return fmt.Errorf("write %s: %w", target, err)
-		}
-	}
-
-	return nil
+	return belayerassets.WriteSkillFiles(versionPath, files)
 }
 
 func copyDir(src, dst string) error {

--- a/internal/plugins/registry.go
+++ b/internal/plugins/registry.go
@@ -15,7 +15,7 @@ const (
 
 	// Plugin versions — keep in sync with plugins/*/.claude-plugin/plugin.json
 	HarnessVersion  = "4.0.0"
-	PRVersion       = "1.3.0"
+	PRVersion       = "1.3.1"
 	ExplorerVersion = "0.2.0"
 )
 

--- a/plugins/pr/.claude-plugin/plugin.json
+++ b/plugins/pr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pr",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Pull request lifecycle management - authoring, reviewing, resolving, and updating PRs. Review uses pr-review-toolkit agents for multi-perspective analysis.",
   "author": {
     "name": "donovanyohan"

--- a/plugins/pr/commands/automate.md
+++ b/plugins/pr/commands/automate.md
@@ -166,16 +166,18 @@ gh api repos/{owner}/{repo}/issues/<number>/comments --paginate --jq '.[] | {id,
 
 **Categorize each comment:**
 
+**Default bias: implement everything actionable.** Agents are fast — the cost of implementing is low, the cost of deferring is high. Never decline actionable feedback as "better in a follow-up PR."
+
 | Category | Criteria | Automated Action |
 |----------|----------|-----------------|
-| **Actionable** | Requests a code change | Make the change |
+| **Actionable** | Requests a code change or suggests an improvement | Make the change — no exceptions, no deferring |
 | **Question** | Asks for clarification | **HARD STOP** |
 | **Discussion** | Debate about approach | **HARD STOP** |
 | **Resolved** | Already addressed | Skip |
 
 **If any Question or Discussion items exist → STOP.** Report to user with a summary of what needs human input.
 
-**For Actionable items:**
+**For Actionable items (implement ALL of them):**
 1. Read each referenced file
 2. Make the requested change
 3. Run project tests to verify no regressions

--- a/plugins/pr/commands/resolve.md
+++ b/plugins/pr/commands/resolve.md
@@ -39,8 +39,7 @@ gh api repos/{owner}/{repo}/issues/<number>/comments --paginate --jq '.[] | {id,
 
 | Category | Criteria | Action |
 |----------|----------|--------|
-| **Actionable** | Requests code change | Verify correctness, then make the change |
-| **Suggestion** | Proposes improvement or alternative approach | Verify it's sound, then implement it. If the reviewer took time to suggest it, it's worth doing now |
+| **Actionable** | Requests code change or suggests an improvement | Verify correctness, then make the change. If the reviewer took time to suggest it, it's worth doing now |
 | **Question** | Asks for clarification | Draft response AND make any code change implied by the question (add comment, rename, clarify logic) |
 | **Discussion** | Debate about approach | Pick the best option and implement it. If genuinely ambiguous, ask the user — do NOT defer to a follow-up PR |
 | **Resolved** | Already addressed | Skip |

--- a/plugins/pr/commands/resolve.md
+++ b/plugins/pr/commands/resolve.md
@@ -33,12 +33,19 @@ gh api repos/{owner}/{repo}/issues/<number>/comments --paginate --jq '.[] | {id,
 
 ### 2. Categorize Comments
 
+**Default bias: implement everything.** Agents are fast and capable — the cost of implementing feedback is low, the cost of deferring is high (context loss, stale PRs, reviewer fatigue). Treat every comment as work to do in THIS PR unless it literally cannot be done here.
+
+**Evaluate correctness, not effort.** The question is never "is this too much work?" — it's "is this technically sound?" Read the surrounding code, understand the reviewer's intent, and verify the suggestion wouldn't introduce a bug or regression. If it's correct, implement it regardless of scope. If it's wrong, decline with a clear technical explanation of why.
+
 | Category | Criteria | Action |
 |----------|----------|--------|
-| **Actionable** | Requests code change | Make the change |
-| **Question** | Asks for clarification | Draft response |
-| **Discussion** | Debate about approach | Summarize options |
+| **Actionable** | Requests code change | Verify correctness, then make the change |
+| **Suggestion** | Proposes improvement or alternative approach | Verify it's sound, then implement it. If the reviewer took time to suggest it, it's worth doing now |
+| **Question** | Asks for clarification | Draft response AND make any code change implied by the question (add comment, rename, clarify logic) |
+| **Discussion** | Debate about approach | Pick the best option and implement it. If genuinely ambiguous, ask the user — do NOT defer to a follow-up PR |
 | **Resolved** | Already addressed | Skip |
+
+**The "follow-up PR" trap:** Never categorize work as "out of scope" or "better in a separate PR" unless it would require changes to files/systems completely unrelated to this PR's purpose. Reviewer feedback on code IN this PR belongs IN this PR.
 
 ### 3. Present Action Plan
 
@@ -71,7 +78,7 @@ After pushing fixes, **you MUST resolve comment threads on GitHub** using the Gr
 | Category | GitHub Action |
 |----------|--------------|
 | **Actionable — fixed** | Reply with what you changed, then **resolve the thread** |
-| **Actionable — declined with rationale** | Reply explaining why with clear reasoning, then **resolve the thread** |
+| **Actionable — declined (rare)** | Reply explaining why with a specific technical justification. Only valid reasons: (1) the suggestion is technically incorrect — would introduce a bug, break a contract, or cause a regression (explain what and why), (2) the change would break an unrelated system, (3) it requires access/permissions you don't have, (4) the user explicitly told you not to. "Too much work" and "better as a follow-up" are NOT valid reasons. Then **resolve the thread** |
 | **Question / Discussion** | Reply if you have useful context, but **leave the thread open** |
 
 #### How to resolve a thread
@@ -113,7 +120,10 @@ Report files modified, commit SHA, and which comments were resolved vs left open
 
 | Mistake | Fix |
 |---------|-----|
-| Blindly implementing all feedback | Evaluate each comment critically |
+| Deferring feedback to a "follow-up PR" | Implement it now. The reviewer gave feedback on THIS code — address it in THIS PR. Agents are fast; use that. |
+| Categorizing suggestions as "out of scope" | If the reviewer commented on code in this PR, it's in scope. Period. |
+| Declining feedback because it's "a lot of work" | That's exactly what agents are for. Implement it. |
+| Implementing a suggestion without verifying correctness | Read the surrounding code first. If the suggestion would introduce a bug, decline with a specific technical explanation — don't blindly apply it |
 | Not testing after changes | Always verify before pushing |
 | Not replying to reviewers | Always communicate what was addressed |
 | Addressing comments but not resolving threads on GitHub | Always resolve threads for fixed/declined items via `gh api graphql` |

--- a/skills/explorer-send/SKILL.md
+++ b/skills/explorer-send/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: explorer-send
+description: Use when a spec.md is ready for implementation and needs to be submitted to the belayer pipeline
+---
+
+> Generated from Claude plugin command: plugins/explorer/commands/send.md
+> Claude alias: /explorer:send
+
+# Send Spec to Pipeline
+
+Submit a spec document to the belayer pipeline for autonomous implementation.
+
+## Usage
+
+```
+explorer-send path/to/spec.md
+explorer-send path/to/spec.md --detach
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+1. **Parse arguments:** Extract the file path from the command arguments. If no path is provided, ask the user which spec file to submit. Note any additional flags (e.g., `--detach`).
+
+2. **Validate the spec file:**
+   - Check that the file exists using the Read tool
+   - Check that the file is non-empty
+   - If validation fails, report the error and stop
+
+3. **Resolve the absolute path:** Convert the spec file path to an absolute path so `belayer climb` can find it regardless of working directory.
+
+4. **Submit to pipeline:** Run belayer climb via the Bash tool:
+   ```bash
+   belayer climb --file <absolute-path-to-spec> [--detach]
+   ```
+   Pass `--detach` if the user included it or asked to run in the background.
+
+5. **Report result:** Relay the output to the user. On success, belayer reports the Temporal workflow ID. On failure, it reports what went wrong (e.g., worker not running, Temporal not reachable).
+
+## Notes
+
+- This command shells out to `belayer climb` — the belayer worker and Temporal must be running
+- No spec validation or linting is performed — belayer is pipes, the spec goes in as-is
+- The climb runs from the current working directory, so the pipeline operates on the current repo
+- Use `--detach` to return immediately while the pipeline runs in the background

--- a/skills/harness-batch/SKILL.md
+++ b/skills/harness-batch/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: harness-batch
+description: Use when executing a living plan via Claude Code's /batch tool for worktree-isolated parallel execution, or when user says "batch", "batch execute", "run batch", "parallel batch", "run the plan in parallel", "execute without checkpoints", "hands-off execution", or "use batch mode"
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/batch.md
+> Claude alias: /harness:batch
+
+# Batch
+
+Execute a living plan by delegating to Claude Code's built-in `/batch` tool for parallel, worktree-isolated agent execution. Alternative to `harness-orchestrate` — trades per-task checkpoints and user approval gates for faster, fully parallel execution with PR-per-unit output.
+
+## Usage
+
+```
+harness-batch
+harness-batch docs/exec-plans/active/{file}.md
+```
+
+## When to use `harness-batch` vs `harness-orchestrate`
+
+| Aspect | `harness-batch` | `harness-orchestrate` |
+|---|---|---|
+| Execution | All independent units in parallel via `/batch` | Sequential with per-task user checkpoints |
+| Isolation | Git worktree per unit | In-process agents |
+| Output | PR per unit | Commits on current branch |
+| User interaction | Approve batch plan once, then hands-off | Approve after each task |
+| Best for | Large plans with many independent tasks | Plans with complex dependencies or need for tight control |
+
+## Architecture
+
+- Orchestrator (main agent, Opus) owns coordination, never writes code
+- `/batch` handles parallel agent dispatch, git worktree isolation, and PR creation
+- Orchestrator manages plan lifecycle: loading, batch instruction construction, plan updates, and post-batch review
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+### Phase 1: Load Plan
+
+1. Locate the plan:
+   - If a path argument was provided, use it
+   - Otherwise, list `docs/exec-plans/active/` and use the most recently modified file
+   - If no active plans exist, suggest running `harness-brainstorm` → `harness-plan` first
+
+2. Read the full plan. Extract:
+   - Task list (from `### Task N:` headers or Progress checklist)
+   - Progress section (which tasks are already completed)
+   - Current state of Surprises, Drift, and Decision Log tables
+
+3. If any tasks are already marked complete in Progress, skip them. Resume from the first incomplete task.
+
+### Phase 2: Construct Batch Instruction
+
+4. Build a `/batch` instruction from the plan's remaining tasks. The instruction should:
+   - Summarize the overall goal from the plan
+   - Include the absolute project path so agents can orient themselves
+   - List each remaining task with its full specification and acceptance criteria
+   - Reference relevant files, architectural docs, and codebase patterns from the plan context
+   - Include outputs or context from any already-completed tasks that subsequent tasks depend on
+
+   ```
+   /batch Implement the following tasks from {plan title}:
+
+   Project: {absolute path to project}
+   Architecture: see docs/ARCHITECTURE.md, docs/DESIGN.md
+   Previously completed: {list of completed tasks and their key outputs, or "none"}
+
+   Task {N}: {task name}
+   {full task specification from plan}
+   Acceptance criteria: {criteria}
+   Key files: {relevant files and modules}
+
+   Task {M}: {task name}
+   ...
+
+   Context:
+   - Follow existing patterns in the codebase
+   - Run tests/build/lint to verify each change
+   - Commit changes with descriptive messages
+   ```
+
+5. `/batch` will research the codebase, decompose the work into independent units (5-30), and present a plan for your review. Review the proposed decomposition against your plan's tasks:
+   - Verify all plan tasks are covered
+   - Confirm the decomposition respects task dependencies (dependent tasks should be in the same unit)
+   - Approve when satisfied, or provide corrections
+
+### Phase 3: Monitor Batch Execution
+
+6. `/batch` spawns one background agent per unit, each in an isolated git worktree. Each agent implements its unit, runs tests, and opens a PR. Wait for `/batch` to report completion before proceeding to Phase 4.
+
+7. As units complete and PRs are created, collect:
+   - What each unit implemented
+   - Any surprises or deviations from the plan
+   - PR links for each unit
+
+### Phase 4: Update Living Plan
+
+8. After batch completes, update the plan file:
+
+   **a) Update Progress** — check off completed tasks with timestamp:
+   ```markdown
+   - [x] Task {N}: {name} _(completed {YYYY-MM-DD})_
+   ```
+
+   **b) Add Surprises row** if anything unexpected occurred:
+   ```markdown
+   | {date} | {what was unexpected} | {how it affects the plan} | {what was done} |
+   ```
+
+   **c) Add Plan Drift row** for any deviations:
+   ```markdown
+   | Task {N} | {what the plan said} | {what actually happened} | {why} |
+   ```
+
+   **d) Add Decision Log row** for non-trivial decisions:
+   ```markdown
+   | {date} | Implementation | {decision} | {rationale} |
+   ```
+
+   **e) Update Last Updated** timestamp in the plan's status line.
+
+   **f) If the plan's source is a refactor scope doc** (check for `Refactor Scope:` in the plan header), also update the scope doc's step statuses. When batch finishes all planned steps and hits an async gate, update the scope doc and output the gate info:
+   ```
+   Step {N} ({name}): completed
+   Step {M} ({name}): in_progress — {status}
+
+   Gate before Step {X}: {gate condition}
+
+   This refactor is paused at a gate. Return in a new session and run:
+     harness-refactor-status
+   ```
+
+### Phase 5: Micro-Review
+
+9. Review the PRs created by `/batch`:
+
+   a) For each PR, check the diff for obvious issues:
+   ```bash
+   gh pr diff {pr-number}
+   ```
+
+   b) Scan for:
+   - Stale docs contradicted by the diff (new modules not in ARCHITECTURE.md, changed patterns not in DESIGN.md)
+   - Obvious code issues (unused imports, debug logging left in, TODO comments that should be resolved)
+   - Test coverage gaps (new code paths without corresponding tests)
+   - Cross-PR consistency (changes in one PR that should be reflected in another)
+
+   c) Fix any stale docs immediately while context is fresh.
+
+   d) Note any code issues in the checkpoint report — they'll be caught thoroughly by `harness-review` later.
+
+### Phase 6: Checkpoint
+
+10. Report final status with PR links:
+
+    ```
+    ## Batch Execution Complete
+
+    **Progress:** {M} of {total} tasks done
+    **PRs created:** {list of PR links}
+    **Surprises:** {any entries, or "none"}
+    **Drift:** {any deviations, or "none"}
+    **Docs:** {what was updated, or "current"}
+    **Code notes:** {any issues spotted, or "clean"}
+    ```
+
+11. If any tasks remain (due to dependency chains or batch limitations), ask the user whether to run another `/batch` round for the remaining tasks.
+
+### Phase 7: Completion
+
+12. When all tasks are complete, run a final integration check using the project's build and test commands (check CLAUDE.md or the plan for the correct commands):
+
+    ```bash
+    # Example for Go projects:
+    go test ./...
+    go build ./...
+    ```
+
+13. Report final status:
+
+    ```
+    ## All Tasks Complete
+
+    **Progress:** {total} of {total} tasks done
+    **PRs to merge:** {list of PR links}
+    **Total surprises:** {N}
+    **Total drift entries:** {N}
+    **Decisions logged:** {N}
+
+    ## Next Step
+
+    Merge the PRs, then run `harness-review` to:
+    - Simplify code
+    - Run multi-perspective code review (6 agents)
+    - Fix or defer findings
+
+    Then `harness-reflect` → `harness-complete`.
+    ```
+
+## Orchestrator Rules
+
+**DO:**
+- Write a detailed `/batch` instruction that includes full task specs and context from the plan
+- Review `/batch`'s proposed decomposition before approving execution
+- Ensure dependent tasks land in the same batch unit (they must not be split across parallel agents)
+- Update living plan after batch completes (progress, surprises, drift, decisions)
+- Run micro-review on all PRs to catch stale docs and obvious issues
+- Run integration checks yourself after all PRs are merged
+
+**DON'T:**
+- Write code yourself — pure control plane only
+- Skip living plan updates after batch execution
+- Skip micro-reviews on batch PRs
+- Approve a batch decomposition that splits dependent tasks across units
+- Mark the project done without running a final build/test check yourself

--- a/skills/harness-brainstorm/SKILL.md
+++ b/skills/harness-brainstorm/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: harness-brainstorm
+description: Use when starting new feature work, creative design, or when user says "brainstorm", "design a feature", or "let's think about"
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/brainstorm.md
+> Claude alias: /harness:brainstorm
+
+# Brainstorm
+
+Design through collaborative dialogue, saved as a versioned design document in the 3-tier documentation system.
+
+## Usage
+
+```
+harness-brainstorm                    # Start brainstorming
+harness-brainstorm add user auth      # Brainstorm with initial topic
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+1. Verify the project has been initialized (check for "Documentation Map" with "When to look here" column in CLAUDE.md). If not, suggest running `harness-init` first.
+
+2. Read `docs/DESIGN.md` and `docs/design-docs/index.md` to understand existing design context. This grounds the brainstorming in what already exists.
+
+2.5. **Surface past learnings** (if available):
+   - Follow the consultation pattern defined in `_learnings-format.md` § "Consulting Learnings"
+   - Match learnings against the brainstorm topic
+   - Surface the top 3 most relevant learnings before starting the brainstorm dialogue (using the output format from `_learnings-format.md`)
+   - Record the IDs of consulted learnings for inclusion in the design doc frontmatter (step 3's HARNESS_OVERRIDES `consulted-learnings` field)
+   - If LEARNINGS.md doesn't exist or has no active learnings, skip silently
+
+3. **Invoke `brainstorming`** using the Skill tool: `Skill("brainstorming")`. Then follow the loaded skill's full process (explore context, clarify questions, propose approaches, present design). You MUST use the Skill tool — do not replicate the brainstorming methodology from memory.
+
+   <HARNESS_OVERRIDES>
+   The following overrides REPLACE conflicting instructions from brainstorming.
+   These take ABSOLUTE PRECEDENCE over any path, save location, or handoff instruction in that skill:
+
+   - **Save location:** Save specs to `docs/design-docs/{YYYY-MM-DD}-{kebab-name}-design.md` — NOT `docs/superpowers/specs/`. This is non-negotiable.
+   - **Handoff:** Do NOT invoke `writing-plans` or any other skill at the end. Do NOT treat "invoke writing-plans" as a terminal state. Instead, after writing the design doc, proceed to step 4 below.
+   - **Spec Review Loop:** When the brainstorming skill dispatches its spec-document-reviewer subagent, the reviewer's `[SPEC_FILE_PATH]` must point to `docs/design-docs/`, not `docs/superpowers/specs/`.
+   - **Visual Companion:** Skip the visual companion offer — harness does not ship the brainstorm server.
+   - **Frontmatter:** Every design doc written to `docs/design-docs/` MUST start with YAML frontmatter:
+     ```yaml
+     ---
+     status: current
+     created: {YYYY-MM-DD}
+     branch: {result of `git branch --show-current`}
+     supersedes:
+     implemented-by:
+     consulted-learnings: [{learning IDs from step 2.5, or empty}]
+     ---
+     ```
+     Insert this frontmatter block at the very top of the file, before the H1 title. The `branch` field must be the actual current git branch, not a placeholder.
+   </HARNESS_OVERRIDES>
+
+4. After the design doc is written, update `docs/design-docs/index.md` — append a line under **Current Designs**:
+   ```markdown
+   - [{date}-{name}-design]({date}-{name}-design.md) — {one-line purpose} ({date})
+   ```
+
+5. If the design introduces new principles, patterns, or significant decisions, update `docs/DESIGN.md`:
+   - Add to the "Current State" bullets if a new pattern was established
+   - Add to the "Key Decisions" table if a non-trivial decision was made
+
+6. Guide user to next step:
+   ```
+   Design saved to: docs/design-docs/{filename}.md
+
+   ## Next Steps
+
+   1. `harness-plan` — Create the implementation plan from this design
+   2. `harness-orchestrate` — Execute the plan with agent teams
+   3. `harness-complete` — Reflect, review, and create PR
+
+   Run `harness-plan` to continue.
+   ```

--- a/skills/harness-bug/SKILL.md
+++ b/skills/harness-bug/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: harness-bug
+description: Use when investigating a bug, diagnosing an error, or when user says "debug", "fix bug", "investigate issue", or "root cause"
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/bug.md
+> Claude alias: /harness:bug
+
+# Bug
+
+Investigate a bug through systematic debugging, saved as a versioned bug analysis document.
+
+## Usage
+
+```
+harness-bug                              # Start bug investigation
+harness-bug login fails after timeout    # With initial description
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+1. Verify the project has been initialized (check for "Documentation Map" with "When to look here" column in CLAUDE.md). If not, suggest running `harness-init` first.
+
+2. Read `docs/bug-analyses/index.md` to understand prior investigations. If the directory doesn't exist, create it with an empty index.
+
+2.5. **Check prior learnings** (if available):
+   - Follow the consultation pattern defined in `_learnings-format.md` § "Consulting Learnings"
+   - Match learnings against the bug's affected area and symptoms
+   - If relevant learnings are found, surface them before starting systematic debugging — they may accelerate diagnosis
+   - Also check for recurrence per the "Recurrence Detection" section in `_learnings-format.md`: if a prior learning's recommendation directly addresses this bug class, note it explicitly
+   - If LEARNINGS.md doesn't exist or has no matches, skip silently
+
+3. **Invoke `systematic-debugging`** using the Skill tool: `Skill("systematic-debugging")`. Then follow the loaded skill's full debug cycle: reproduce, bisect, hypothesize, verify root cause. You MUST use the Skill tool — do not replicate the debugging methodology from memory.
+
+4. When debugging reaches confirmed root cause, save findings to `docs/bug-analyses/{YYYY-MM-DD}-{kebab-name}-bug-analysis.md`:
+
+    ```markdown
+    # Bug Analysis: {Title}
+
+    > **Status**: Confirmed | **Date**: {date}
+    > **Severity**: {Critical/High/Medium/Low}
+    > **Affected Area**: {module/component}
+
+    ## Symptoms
+    - {what the user observed}
+
+    ## Reproduction Steps
+    1. {steps to reproduce}
+
+    ## Root Cause
+    {confirmed root cause from systematic debugging}
+
+    ## Evidence
+    - {code references, logs, test output that confirm the diagnosis}
+
+    ## Impact Assessment
+    - {what's affected, blast radius}
+
+    ## Recommended Fix Direction
+    {high-level approach — detailed plan comes from harness-plan}
+
+    ## Architecture Review
+
+    _Populated after root cause confirmation._
+    ```
+
+4.5. **Architecture review** — With root cause confirmed, step back and answer: *"Why was it possible for this bug to be written, and how do we prevent it in the future?"*
+   - Read `references/architecture-review-prompt.md`. If the file cannot be found, STOP and print: "ERROR: Missing reference file: references/architecture-review-prompt.md. The harness plugin may be installed incorrectly. Architecture review cannot proceed."
+   - Conduct the review across all four dimensions: systemic spread, design gap, testing gaps, harness context gaps
+   - Replace the placeholder `## Architecture Review` section in the bug analysis document with the completed findings
+   - Each dimension produces actionable findings or an explicit "nothing systemic" signal — no forced output, but the section is always written (use "None" templates when clean)
+   - These findings directly expand the scope of the fix plan created by `harness-plan`
+
+4.6. **Write learnings from root cause + architecture review:**
+   - Produce one learning per dimension that has actionable findings, using the categories below. Follow the `_learnings-format.md` spec for format, IDs, and scaffold.
+   - Check if `docs/LEARNINGS.md` exists. If not, create it with the scaffold from `_learnings-format.md` § "LEARNINGS.md Scaffold".
+   - Determine the next learning ID: use today's date (`YYYYMMDD`) and a short kebab-case slug from the learning topic. Format: `L-YYYYMMDD-slug`. See `_learnings-format.md` § "ID Format" for details.
+
+   | Finding dimension | Learning category |
+   |-------------------|-------------------|
+   | Systemic spread | `patterns` |
+   | Design gap | `architecture` |
+   | Testing gaps | `testing` |
+   | Root cause itself | `debugging` |
+   | Harness context gaps | No learning (flagged for the plan) |
+
+   - Only write a learning if the finding is actionable. "None — isolated to this call site" produces no learning for that dimension.
+   - `harness-bug` intentionally does not produce `review-escape` category learnings — review escapes are detected by `harness-reflect`'s Review Escape Mining phase.
+   - Each learning must be forward-looking: "When doing X, always check Y because Z." Not just "X was broken because of Y."
+   - Source field: `harness-bug {YYYY-MM-DD}`
+
+5. Update `docs/bug-analyses/index.md` — append a line:
+    ```markdown
+    - [{date}-{name}-bug-analysis]({date}-{name}-bug-analysis.md) — {one-line summary} ({date})
+    ```
+
+6. Guide user to next step:
+    ```
+    Bug analysis saved to: docs/bug-analyses/{filename}.md
+
+    ## Next Steps
+
+    1. `harness-plan docs/bug-analyses/{filename}.md` — Create the fix implementation plan
+    2. `harness-orchestrate` — Execute the plan with agent teams
+    3. `harness-complete` — Reflect, review, and create PR
+
+    Run `harness-plan docs/bug-analyses/{filename}.md` to continue.
+    ```
+
+**IMPORTANT:** Do NOT attempt to fix the bug during investigation. The bug command produces a diagnosis + architecture review; `harness-plan` turns it into an executable fix plan that addresses the instance, systemic spread, and missing guardrails.

--- a/skills/harness-complete/SKILL.md
+++ b/skills/harness-complete/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-complete
-description: Use when ready to archive the plan and create the PR, when user says "we're done", "complete this", "wrap up", or after /harness:reflect finishes
+description: Use when ready to archive the plan and create the PR, when user says "we're done", "complete this", "wrap up", or after harness-reflect finishes
 ---
 
 > Generated from Claude plugin command: plugins/harness/commands/complete.md

--- a/skills/harness-complete/SKILL.md
+++ b/skills/harness-complete/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: harness-complete
+description: Use when ready to archive the plan and create the PR, when user says "we're done", "complete this", "wrap up", or after /harness:reflect finishes
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/complete.md
+> Claude alias: /harness:complete
+
+# Complete
+
+Plan archival, prune health check, and PR creation. Run after `harness-review` and `harness-reflect`.
+
+## Usage
+
+```
+harness-complete                # Complete most recent active plan
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+### Phase 1: Identify Plan
+
+1. List files in `docs/exec-plans/active/`.
+2. If multiple plans exist, ask user which to complete. If only one, confirm it.
+3. Read the full plan — verify it has:
+   - Progress section with tasks checked off
+   - Outcomes & Retrospective section filled in (by `harness-reflect`)
+   - If retrospective is empty, suggest running `harness-reflect` first
+
+### Phase 2: Verification Gate
+
+4. **Apply `verification-before-completion`** using the Skill tool: `Skill("verification-before-completion")`. Follow the loaded skill to run the project's verification commands (tests, build, lint, typecheck). All must pass before proceeding. Do not archive or create a PR with failing verification.
+
+### Phase 3: Plan Archival
+
+5. Change plan status from Active to Completed:
+   ```markdown
+   > **Status**: Completed | **Created**: {date} | **Completed**: {date}
+   ```
+
+6. Add completion entry to Decision Log:
+   ```markdown
+   | {date} | Retrospective | Plan completed | {summary} |
+   ```
+
+7. Move the plan file:
+   ```bash
+   mv docs/exec-plans/active/{file} docs/exec-plans/completed/{file}
+   ```
+
+7.5. **Archive the source design doc:**
+   - Read the plan's header to find the `Design Doc:` path (or `Bug Analysis:` or `Refactor Scope:`)
+   - If a source design doc is found, update its YAML frontmatter:
+     - Change `status:` to `implemented`
+     - Set `implemented-by: docs/exec-plans/completed/{file}`
+   - If the design doc has no YAML frontmatter (legacy), add one:
+     ```yaml
+     ---
+     status: implemented
+     created: {infer from filename date prefix, or use file creation date}
+     branch: {current branch}
+     implemented-by: docs/exec-plans/completed/{file}
+     ---
+     ```
+
+### Phase 4: Deleted-Code Audit
+
+8. Check if any modules/directories were deleted during this plan's lifetime:
+   ```bash
+   git diff $(git log --diff-filter=A --format=%H -- docs/exec-plans/active/{file} | tail -1)...HEAD --diff-filter=D --name-only
+   ```
+   For each deleted path, verify no Tier 2/3 doc still describes it as existing code. Fix any stale references before archiving — confident docs about nonexistent code is the most dangerous staleness.
+
+### Phase 5: Tier 2 Summary Updates
+
+9. Update `docs/PLANS.md`:
+   - Move entry from Active Plans table to Completed Plans table
+   - Add completion date
+
+10. Update `docs/DESIGN.md` if any new patterns or key decisions were established.
+
+11. Update `docs/ARCHITECTURE.md` if any new modules were created or boundaries changed.
+
+11.5. **Update design-docs index with archival:**
+   - Read `docs/design-docs/index.md`
+   - If the index does NOT have `## Current Designs` and `## Archived` sections:
+     - Restructure the index: add `## Current Designs` header above the existing table
+     - Add a `Status` column to the table
+     - Add `## Archived` section below with its own table (same columns)
+     - Move all design docs with frontmatter `status: implemented` or `status: superseded` to the Archived table
+     - Keep docs with `status: current` or no frontmatter in the Current Designs table
+   - If the index already has Current/Archived sections:
+     - Move the just-archived design doc from Current to Archived
+     - Update its Status column to "Implemented"
+   - Status badge vocabulary for the index: `Current` | `Implemented` | `Superseded` | `Stale`
+
+### Phase 6: Prune Health Check
+
+12. Execute `harness-prune` inline to verify docs health after all updates. Report any issues.
+
+### Phase 7: PR Creation
+
+13. Create the pull request:
+    - If the `pr:author` command is available, invoke it
+    - Otherwise, use `gh pr create` directly with:
+      - Title derived from plan title
+      - Body summarizing: goal, tasks completed, key decisions, surprises
+      - Link to the completed plan in the PR description
+
+### Report
+
+14. Output:
+    ```
+    ## Complete
+
+    ### Plan
+    - Archived: docs/exec-plans/completed/{file}
+    - Tasks: {M} completed, {D} deviated, {K} surprises
+
+    ### Tier 2 Updates
+    - PLANS.md: updated
+    - DESIGN.md: {updated | no changes}
+    - ARCHITECTURE.md: {updated | no changes}
+
+    ### Prune Health: {HEALTHY | NEEDS ATTENTION}
+
+    ### PR: #{number} — {url}
+    ```

--- a/skills/harness-init/SKILL.md
+++ b/skills/harness-init/SKILL.md
@@ -1,0 +1,483 @@
+---
+name: harness-init
+description: Use when initializing structured documentation for a repository, when CLAUDE.md exceeds 120 lines, or when user says "set up docs" or "initialize harness"
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/init.md
+> Claude alias: /harness:init
+
+# Init
+
+Transform a monolithic CLAUDE.md into a 3-tier progressive disclosure documentation system.
+
+- **Tier 1: CLAUDE.md** — 60-120 line map with trigger-based navigation
+- **Tier 2: docs/ARCHITECTURE.md, DESIGN.md, PLANS.md** — domain summary files
+- **Tier 3: docs/design-docs/, exec-plans/, references/** — deep knowledge directories
+
+> "Give the agent a map, not a 1,000-page manual."
+
+## Usage
+
+```
+harness-init              # Full guided extraction
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+### Phase 1: Analyze
+
+1. Read the project's `CLAUDE.md` and count lines.
+2. If under 120 lines and already has a "Documentation Map" section with a "When to look here" column, report "Already initialized (3-tier)" and stop.
+3. If it has a "Documentation Map" but NO "When to look here" column, this is a v1 harness — proceed with migration (Phase 4 will handle `docs/guides/` migration).
+4. Scan for extractable content by reading CLAUDE.md headers and body:
+
+   **Extract to Tier 2 summary files:**
+
+   | Content Pattern | Tier 2 Target | Tier 3 Directory |
+   |----------------|---------------|------------------|
+   | Architecture, modules, packages, dependencies | `docs/ARCHITECTURE.md` | None (self-contained) |
+   | Design principles, patterns, conventions, core beliefs | `docs/DESIGN.md` | `docs/design-docs/` |
+   | Plans, active work, tech debt | `docs/PLANS.md` | `docs/exec-plans/` |
+
+   **Discover extra Tier 2 files based on repo content:**
+
+   | Trigger | Tier 2 Target |
+   |---------|---------------|
+   | Auth code, encryption, security patterns found in repo | `docs/SECURITY.md` |
+   | Frontend framework code (React, Vue, etc.) found | `docs/FRONTEND.md` |
+   | Testing patterns, quality standards, coverage targets | `docs/QUALITY.md` |
+   | Other significant domains with substantial CLAUDE.md content | `docs/{DOMAIN}.md` |
+
+5. **Extract Quick Reference commands** — scan CLAUDE.md for build/test/lint/format/run commands.
+
+6. **Extract Key Patterns** — identify critical conventions (max 10) that agents MUST know.
+
+7. Present the extraction plan to the user:
+   ```
+   ## Extraction Plan
+
+   CLAUDE.md is {N} lines. Proposing 3-tier structure:
+
+   ### Tier 2 Domain Summaries
+   | File | Content Source | ~Lines |
+   |------|---------------|--------|
+   | docs/ARCHITECTURE.md | {sections} | ~{N} |
+   | docs/DESIGN.md | {sections} | ~{N} |
+   | docs/PLANS.md | (generated from exec-plans/) | ~20 |
+   | docs/{DISCOVERED}.md | {sections} | ~{N} |
+
+   ### Tier 3 Deep Knowledge
+   - docs/design-docs/ (index.md + core-beliefs.md)
+   - docs/exec-plans/active/ and completed/
+   - docs/references/
+
+   ### CLAUDE.md Map
+   - Quick Reference: {N} commands
+   - Key Patterns: {N} items
+   - Documentation Map: {N} categories
+
+   Remaining CLAUDE.md: ~{N} lines
+
+   Proceed? (y/n)
+   ```
+
+### Phase 2: Scaffold Core Structure
+
+8. Create directories:
+   ```bash
+   mkdir -p docs/design-docs docs/bug-analyses docs/refactor-scopes docs/exec-plans/active docs/exec-plans/completed docs/references
+   ```
+
+8.5. Generate `docs/LEARNINGS.md`:
+
+    ```markdown
+    # Learnings
+
+    Persistent learnings captured across sessions. Append-only, merge-friendly.
+
+    Status: `active` | `superseded`
+    Categories: `architecture` | `testing` | `patterns` | `workflow` | `debugging` | `performance` | `review-escape`
+
+    ---
+    ```
+
+8.7. Generate `docs/REVIEW_GUIDANCE.md` — the self-learning adversarial review configuration:
+
+    First, analyze the repository to pre-populate deployment context and relevant question categories:
+    - Check for `Dockerfile`, `docker-compose.yml`, `fly.toml`, `render.yaml`, Kubernetes manifests → infer deployment topology (single instance, multi-instance, serverless)
+    - Check for database drivers/ORMs in dependencies → infer database type
+    - Check for cron/scheduler code → flag distributed systems questions
+    - Check for HTTP server/handler code → flag concurrency questions
+    - Check for auth/security middleware → flag security questions
+    - Check CI config for deployment targets → infer scale
+
+    Then generate the file. Read `references/adversarial-review-prompt.md` for the full default question bank. Include only question categories relevant to the detected project characteristics — but always include Resource Exhaustion and Failure Modes as baseline categories.
+
+    ```markdown
+    # Review Guidance
+
+    Production failure patterns and adversarial questions for this project.
+    Updated automatically when bugs escape review — the harness learns from its mistakes.
+
+    ## Deployment Context
+
+    - Instances: {detected or "unknown — update when deployment topology is known"}
+    - Database: {detected or "unknown"}
+    - Scale: {detected or "unknown — update with approximate request volume and data size"}
+    - Infrastructure: {detected or "unknown — list queues, cron, caches, external APIs"}
+
+    ## Adversarial Question Bank
+
+    Questions asked during isolated adversarial review (`harness-review` Phase 3).
+    Each question targets a production failure pattern. Add new questions when bugs
+    escape review — see Escape Log below.
+
+    ### Failure Modes & Resilience
+    (populated from references/adversarial-review-prompt.md)
+
+    ### Resource Exhaustion
+    (populated from references/adversarial-review-prompt.md)
+
+    ## Escape Log
+
+    Bugs that escaped harness review and were caught externally.
+    Each entry feeds back into the question bank above.
+
+    | Date | Bug | Caught By | Category | Question Added |
+    |------|-----|-----------|----------|----------------|
+    ```
+
+    **Populating the question bank:** Read `references/adversarial-review-prompt.md` for the full default question bank. Copy the actual questions (not just placeholders) into the relevant category sections. Always include Failure Modes & Resilience and Resource Exhaustion. Add other categories based on repo detection:
+    - Concurrency & Scale (if HTTP handlers found)
+    - Distributed Systems (if multi-instance deployment or cron detected)
+    - Data Integrity (if database code found)
+    - Security (if auth code found)
+
+9. Generate `docs/ARCHITECTURE.md` using the matklad format. Analyze the project's directory structure, key modules, and build system to produce:
+
+   ```markdown
+   # Architecture
+
+   This document describes the high-level architecture of {project}.
+   If you want to familiarize yourself with the codebase, you are in the right place.
+
+   ## Bird's Eye View
+
+   {2-3 paragraphs derived from CLAUDE.md project description and repo analysis:
+    what problem does this solve, what goes in, what comes out}
+
+   ## Code Map
+
+   This section talks briefly about various important directories and data structures.
+
+   ### `{module/directory}`
+
+   {What it does, why it exists. 2-4 sentences derived from CLAUDE.md and directory analysis.}
+
+   **Architecture Invariant:** {What this module deliberately does NOT do or depend on — infer from existing patterns, dependency structure, and any stated conventions}
+
+   {Repeat for each significant module/directory}
+
+   ## Cross-Cutting Concerns
+
+   {Extract from CLAUDE.md: error handling patterns, testing philosophy, logging, build system, etc.}
+   ```
+
+   **Rules for generating ARCHITECTURE.md:**
+   - Name files, modules, types — but don't hyperlink (links rot). Say "see `AgentLoader`" and let the reader use symbol search.
+   - Architecture Invariants — call out what something deliberately does NOT do (absences are invisible in code)
+   - API Boundaries — mark where layers meet and what contracts exist
+   - Codemap only, not atlas — what each module is for, not how it works internally
+   - Keep short — every contributor/agent re-reads this. Brevity matters.
+   - Stable content only — things unlikely to change frequently
+
+10. Generate `docs/DESIGN.md` following the Tier 2 domain summary convention:
+
+    ```markdown
+    # Design
+
+    {2-3 sentence overview: design philosophy of this project}
+
+    ## Current State
+
+    - {3-5 bullet points extracted from CLAUDE.md about current design patterns/conventions}
+
+    ## Key Decisions
+
+    | Decision | Rationale | Source |
+    |----------|-----------|--------|
+    | {extracted from CLAUDE.md or ADRs if they exist} | {why} | {reference} |
+
+    ## Deep Docs
+
+    | Document | Purpose |
+    |----------|---------|
+    | `design-docs/core-beliefs.md` | Agent-first operating principles |
+
+    ## See Also
+
+    - [Architecture](ARCHITECTURE.md) — module boundaries and invariants
+    - [Plans](PLANS.md) — active and completed execution plans
+    ```
+
+11. Generate `docs/PLANS.md`:
+
+    ```markdown
+    # Plans
+
+    Execution plans for active and completed work.
+
+    ## Current State
+
+    - {List any existing active plans, or "No active plans"}
+
+    ## Active Plans
+
+    | Plan | Created | Status |
+    |------|---------|--------|
+    | {scan exec-plans/active/ for files} | {date} | Active |
+
+    ## Completed Plans
+
+    | Plan | Created | Completed |
+    |------|---------|-----------|
+    | {scan exec-plans/completed/ for files} | {date} | {date} |
+
+    ## Tech Debt
+
+    {If a tech-debt-tracker.md exists, summarize. Otherwise: "No tech debt tracked yet."}
+    ```
+
+12. Generate `docs/design-docs/index.md`:
+
+    ```markdown
+    # Design Documents
+
+    ## Current Designs
+
+    (no designs yet)
+
+    ## Archived
+
+    ### Implemented
+
+    ### Superseded
+
+    ### Stale
+    ```
+
+12a. Generate `docs/bug-analyses/index.md`:
+
+    ```markdown
+    # Bug Analyses
+
+    (no analyses yet)
+    ```
+
+12b. Generate `docs/refactor-scopes/index.md`:
+
+    ```markdown
+    # Refactor Scopes
+
+    (no scopes yet)
+    ```
+
+13. Generate `docs/design-docs/core-beliefs.md`:
+
+    ```markdown
+    # Core Beliefs
+
+    Operating principles for this project's documentation and agent workflow.
+
+    ## Repository Is the System of Record
+
+    Anything an agent can't access in-context while running effectively doesn't exist.
+    Knowledge that lives in chat threads, documents, or people's heads is not accessible.
+    Repository-local, versioned artifacts (code, markdown, schemas, executable plans) are all the agent can see.
+
+    ## CLAUDE.md Is a Map, Not a Manual
+
+    CLAUDE.md stays under 120 lines. It tells agents WHERE to look, not HOW to do things.
+    Detailed guidance lives in Tier 2 summaries and Tier 3 deep docs.
+
+    ## Plans Are Living Documents
+
+    Execution plans accumulate progress, surprises, decisions, and drift during implementation.
+    They are updated at every stopping point, not reconstructed after the fact.
+
+    ## Reflect Early and Often
+
+    Lightweight reflection runs after each task to catch stale docs immediately.
+    Full reflection runs at completion to mine for deeper learnings.
+
+    ## Structure Prevents Decay
+
+    Semantic categories (architecture, design, plans, references) tell agents and humans
+    what belongs where. A flat "guides/" directory decays into a junk drawer.
+    ```
+
+### Phase 3: Discover Extra Categories
+
+14. Scan the repository for extra domain signals:
+    - Check for auth/security directories or code → propose `docs/SECURITY.md`
+    - Check for frontend framework (React, Vue, etc.) → propose `docs/FRONTEND.md`
+    - Check for testing patterns beyond basic test commands → propose `docs/QUALITY.md`
+    - Check CLAUDE.md for other substantial domain sections
+
+15. Present discovered categories to user for approval:
+    ```
+    ## Discovered Categories
+
+    Based on repository analysis, these additional Tier 2 summaries are recommended:
+
+    | File | Trigger | Approve? |
+    |------|---------|----------|
+    | docs/SECURITY.md | Found src/auth/, security middleware | y/n |
+    | docs/FRONTEND.md | Found React components, Redux store | y/n |
+    ```
+
+16. Create approved Tier 2 files following the domain summary convention (same format as DESIGN.md).
+
+### Phase 4: Migrate Existing Content
+
+17. If `docs/guides/` exists (v1 harness migration):
+    - Read each guide file
+    - Determine which Tier 2/3 category it belongs to
+    - Move content to the appropriate location:
+      - Architecture-related → merge into `docs/ARCHITECTURE.md`
+      - Design/patterns → merge into `docs/DESIGN.md` or create `docs/design-docs/{topic}.md`
+      - Testing → merge into `docs/QUALITY.md` or keep as `docs/design-docs/testing.md`
+      - Other → create appropriate `docs/design-docs/{topic}.md`
+    - Update `docs/design-docs/index.md` with migrated files
+    - Remove `docs/guides/` directory after migration (ask user for confirmation)
+
+18. If `docs/plans/` exists (legacy plan location):
+    - Identify design docs vs implementation plans by filename pattern (`*-design.md` vs `*-plan.md`)
+    - Move design docs to `docs/design-docs/`
+    - Move implementation plans to `docs/exec-plans/active/` or `docs/exec-plans/completed/`
+    - Ask user which plans are still active vs completed
+    - Remove `docs/plans/` after migration (ask user for confirmation)
+
+### Phase 5: Rewrite CLAUDE.md
+
+19. Rewrite CLAUDE.md as the Tier 1 map:
+
+    ```markdown
+    # {Project Name}
+
+    {2-3 sentences: what this project is, primary language/framework, role in larger system}
+
+    ## Quick Reference
+
+    | Action | Command |
+    |--------|---------|
+    | Build | `{extracted build command}` |
+    | Test | `{extracted test command}` |
+    | Lint | `{extracted lint command}` |
+    | Format | `{extracted format command}` |
+    | Run | `{extracted run command}` |
+
+    ## Documentation Map
+
+    | Category | Path | When to look here |
+    |----------|------|-------------------|
+    | Architecture | `docs/ARCHITECTURE.md` | Understanding module boundaries, package layering, where code lives |
+    | Design | `docs/DESIGN.md` | Design principles, core beliefs, pattern decisions |
+    | Plans | `docs/PLANS.md` | Active work, completed plans, tech debt tracking |
+    | Learnings | `docs/LEARNINGS.md` | Past learnings, corrections, patterns discovered across sessions |
+    | Review Guidance | `docs/REVIEW_GUIDANCE.md` | Adversarial review questions, escape log, deployment context |
+    | Bug Analyses | `docs/bug-analyses/` | When investigating bugs, understanding past root causes |
+    | Refactor Scopes | `docs/refactor-scopes/` | When planning refactoring, reviewing past extraction patterns |
+    | References | `docs/references/` | External library docs, API specs, llms.txt files |
+    | {Discovered} | `docs/{DISCOVERED}.md` | {trigger condition} |
+    | ADRs | `docs/adrs/` | Architecture decision records |
+
+    ## Key Patterns
+
+    - {critical convention 1 — rules that, if violated, break things}
+    - {critical convention 2}
+    - {max 10 bullets}
+
+    ## Workflow
+
+    > brainstorm → plan → orchestrate → review → reflect → complete
+
+    | Step | Command | Purpose |
+    |------|---------|---------|
+    | 1a | `harness-brainstorm` | Design through collaborative dialogue |
+    | 1b | `harness-bug` | Investigate and diagnose a bug |
+    | 1c | `harness-refactor` | Scope incremental refactoring |
+    | 2 | `harness-plan` | Create living implementation plan |
+    | 3 | `harness-orchestrate` | Execute with agent teams + micro-reflects |
+    | 4 | `harness-review` | Code simplification + multi-perspective review |
+    | 5 | `harness-reflect` | Full reflection, conversation mining, retrospective |
+    | 6 | `harness-complete` | Archive plan, prune check, and create PR |
+    ```
+
+    Target: 60-120 lines. Every line earns its place in the context window.
+
+    **Rules:**
+    - Only include rows in Documentation Map for files/dirs that actually exist
+    - Omit Risk Contract and ADRs rows if those aren't set up yet
+    - Do NOT include hyperlinks in paths (just backtick code format) — links rot
+
+### Phase 6: Integrate
+
+20. Check if `docs/adrs/` exists. If not, inform user and suggest `/adr:init`.
+
+21. Read `~/.claude/CLAUDE.md`. If it does not contain a "Harness Documentation System" section, append:
+
+    ```markdown
+
+    # ═══════════════════════════════════════════════════
+    # Harness Documentation System
+    # ═══════════════════════════════════════════════════
+
+    **IMPORTANT**: For projects with a Documentation Map in their CLAUDE.md:
+    - New features/creative work → use `harness-brainstorm` (design through dialogue)
+    - Create implementation plan → use `harness-plan` (living execution plan)
+    - Execute the plan → use `harness-orchestrate` (agent teams + micro-reflects)
+    - Work complete → use `harness-complete` (reflect + review + PR)
+    - Quick doc check → use `harness-reflect` (lightweight, any time)
+    - Docs feel stale/bloated → use `harness-prune` (audit and fix)
+    - Adding project knowledge → update the appropriate `docs/*.md` file, NOT CLAUDE.md
+    - CLAUDE.md is a **map**, not a manual — keep under 120 lines
+    ```
+
+    If the section exists but uses the old routing (references `docs/guides/` or misses brainstorm/orchestrate), update it in place.
+
+### Phase 7: Report
+
+22. Output summary:
+    ```
+    ## Harness Initialized (3-Tier)
+
+    ### Structure Created
+    - Tier 1: CLAUDE.md ({N} lines)
+    - Tier 2: {list of docs/*.md summary files}
+    - Tier 3: docs/design-docs/, docs/exec-plans/, docs/references/
+
+    ### Content Migrated
+    - {N} guide files migrated from docs/guides/ (if applicable)
+    - {N} plans migrated from docs/plans/ (if applicable)
+
+    ### Integration
+    - Global routing: {installed | updated | already present}
+    - ADRs: {already exist | suggest running /adr:init}
+
+    ### Files Created
+    - docs/ARCHITECTURE.md
+    - docs/DESIGN.md
+    - docs/PLANS.md
+    - docs/LEARNINGS.md
+    - docs/REVIEW_GUIDANCE.md
+    - docs/design-docs/index.md
+    - docs/design-docs/core-beliefs.md
+    - {any discovered Tier 2 files}
+
+    ### Next Steps
+    - `harness-brainstorm` — start a new feature design
+    - `harness-prune` — verify docs health
+    ```

--- a/skills/harness-loop/SKILL.md
+++ b/skills/harness-loop/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: harness-loop
+description: Use when running the full implementation cycle autonomously after a brainstorm/bug/refactor session, when user says "loop", "run it all", "implement end to end", or "take it from here"
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/loop.md
+> Claude alias: /harness:loop
+
+# Loop
+
+Autonomous end-to-end execution: plan, orchestrate, review, fix, reflect, and complete — with no user checkpoints. Surfaces a decision summary at the end.
+
+**Prerequisite:** A design document must already exist (from `harness-brainstorm`, `harness-bug`, or `harness-refactor`).
+
+**"Execute inline"** means: use the **Skill tool** to invoke the command (e.g., `Skill("harness:plan")`), then follow the loaded skill's instructions step-by-step within this conversation, applying any LOOP_OVERRIDES specified here. You MUST invoke the Skill tool — do NOT write the output from memory or conversation context. The skill's methodology exists to catch things your memory will miss.
+
+## Usage
+
+```
+harness-loop                                    # Loop from most recent design doc
+harness-loop docs/design-docs/{file}.md         # Loop from specific design doc
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+### Phase 1: Locate Design & Initialize Decision Log
+
+1. Locate the design document:
+   - If a path argument was provided, use it
+   - Otherwise, search for the most recently modified context document across:
+     - `docs/design-docs/*-design.md`
+     - `docs/bug-analyses/*-bug-analysis.md`
+     - `docs/refactor-scopes/*-refactor-scope.md`
+   - If no context document found, STOP and tell the user to run `harness-brainstorm`, `harness-bug`, or `harness-refactor` first
+
+2. Read the design document. Verify it has a **goal**, **approach**, and **key decisions** section. If any are missing, STOP and tell the user the design doc appears incomplete.
+
+2.3. **Run lightweight health check:**
+   - Scan `docs/design-docs/index.md` (if it exists):
+     - Count entries with Status "Current" vs total entries
+     - Check if index has Current/Archived sections
+   - Check if `docs/LEARNINGS.md` exists
+   - Check CLAUDE.md line count (should be under 120)
+   - Calculate health score: start at 10, subtract 1 for each:
+     - CLAUDE.md over 120 lines
+     - No LEARNINGS.md file
+     - Index missing Current/Archived sections
+     - More than 5 design docs without any status badge
+     - Any design doc with `status: current` older than 30 days
+   - Output one-line health summary: `Harness health: {N}/10 ({brief details})`
+   - If score < 5, note: "Consider running `harness-prune` after this loop completes"
+   - **This check is advisory only — never block the loop based on health score**
+   - Append health check result to the Loop Decision Log
+
+2.5. **Detect multi-goal mode:** If the located document contains a `## Goals` section with a dependency table, it is a refactor scope doc. Switch to multi-goal mode:
+   - Extract the goal dependency graph from the Goals table
+   - Read each individual goal design doc from the scope's sub-directory (`docs/refactor-scopes/{scope-name}/`)
+   - Determine the default branch: `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'` — fall back to checking for `main` then `master` if that fails
+   - Skip to "Multi-Goal Execution" (below Phase 9)
+
+3. Derive a **slug** from the design doc filename for use in all loop artifacts. Strip the suffix (`-design.md`, `-bug-analysis.md`, `-refactor-scope.md`) to get the slug. For example, `docs/design-docs/auth-refactor-design.md` → slug `auth-refactor`.
+
+4. Create the **Loop Decision Log** file at `docs/exec-plans/active/.loop-decision-log-{slug}.md`:
+   ```markdown
+   # Loop Decision Log: {slug}
+   | Phase | Decision | Rationale | Alternatives Considered |
+   |-------|----------|-----------|------------------------|
+   ```
+   Append to this file after every autonomous decision throughout the loop. This persists across context and provides recovery state if the loop crashes. The slug-based path ensures multiple concurrent loops do not collide.
+
+### Phase 2: Plan
+
+5. Execute `harness-plan` inline, passing the design doc path. Plan executes autonomously by default and requires no overrides.
+
+   <MANDATORY>
+   You MUST use the Skill tool to invoke `harness-plan` and then follow its loaded instructions step-by-step. Do NOT write the plan from memory or conversation context — the plan skill's methodology systematically extracts deliverables from the design doc, which is exactly what prevents missed deliverables. Writing a plan "from what you remember" is the #1 cause of loop failures.
+
+   If the Skill tool is unavailable, you MUST at minimum:
+   1. Re-read the design doc's full deliverable/approach sections
+   2. List every deliverable explicitly mentioned
+   3. Create a plan task for each one
+   4. Cross-check: does every deliverable have a task? If not, add the missing tasks.
+   </MANDATORY>
+
+6. **Deliverable traceability check (REQUIRED before proceeding):**
+   After the plan is created, verify completeness:
+   1. Re-read the design doc's "Approach", "Deliverables", or "Deliverable Summary" sections (and any review addenda like CEO/eng review accepted scope)
+   2. List every deliverable mentioned, including those with specific target locations (e.g., "Mermaid diagram — for README.md")
+   3. For each deliverable, verify a task exists in the plan
+   4. If ANY deliverable has no corresponding task, add it to the plan NOW
+   5. Append the traceability table to the plan file:
+      ```markdown
+      ## Deliverable Traceability
+      | Design Doc Deliverable | Plan Task |
+      |----------------------|-----------|
+      | {deliverable 1} | Task {N} |
+      | {deliverable 2} | Task {N} |
+      ```
+   6. Append traceability result to decision log
+
+7. Append to decision log: which design doc was used, any ambiguities resolved during planning.
+
+8. Note the plan file path in `docs/exec-plans/active/` for subsequent phases.
+
+### Phase 3: Orchestrate (Autonomous)
+
+9. Execute `harness-orchestrate` inline with the following overrides:
+
+   <LOOP_OVERRIDES>
+   These overrides REPLACE conflicting instructions from harness-orchestrate:
+
+   - **No checkpoints:** Do not output checkpoint status blocks or wait for user input between tasks. This overrides orchestrate's "Checkpoint after EVERY task" HARNESS_OVERRIDES entry. Proceed immediately to the next task after updating the living plan.
+   - **Auto-resolve blockers:** If a worker reports a surprise or blocker, append it to the decision log and make a judgment call:
+     - **Fundamental** (would require changing the design doc's approach or affects 3+ unstarted tasks): STOP the loop via Emergency Stop
+     - **Tactical** (unexpected API shape, missing test fixture, localized workaround): resolve and continue
+   - **Decision logging:** For every non-trivial decision, append to the Loop Decision Log file.
+   </LOOP_OVERRIDES>
+
+10. When orchestrate completes, append summary to decision log: tasks completed, surprises, drift entries.
+
+### Phase 4: Review
+
+11. **Deliverable coverage check (REQUIRED before code quality review):**
+    1. Re-read the design doc's deliverable list (same source as Phase 2 step 6)
+    2. Run `git diff --name-only` and `git status` to see all changed/new files
+    3. For each deliverable, verify at least one file was changed or created that addresses it
+    4. If ANY deliverable has no corresponding file change, flag it as a **SIGNIFICANT** gap — this is a planning failure, not a code quality issue
+    5. If gaps are found: create tasks for the missing deliverables and execute them (via `harness-orchestrate` inline with Phase 3 LOOP_OVERRIDES) BEFORE proceeding to the code quality review
+    6. Append coverage check results to decision log
+
+12. Execute `harness-review` inline with the following overrides:
+
+   <LOOP_OVERRIDES>
+   These overrides REPLACE conflicting instructions from harness-review:
+
+   - **No resolution prompt:** Do not present the Phase 7 resolution options (review.md steps 21-22). Do not wait for user selection. Findings are auto-triaged as described below.
+   </LOOP_OVERRIDES>
+
+13. **Auto-triage findings** using this rule:
+    - **Minor** (affects only readability, maintainability, or style — e.g., naming, comments, simplification, formatting): fix inline immediately
+    - **Significant** (could cause incorrect behavior at runtime or in production — e.g., logic bugs, missing tests, security concerns, silent failures, inadequate error handling): collect into a fix task list
+    - **When in doubt, treat as significant.**
+    - Append each triage decision to the decision log with rationale
+
+14. If significant issues exist, proceed to Phase 5. Otherwise, skip to Phase 6.
+
+### Phase 5: Fix Cycle (max 2 iterations)
+
+15. Set `fix_iteration = 1`. Create a lightweight fix plan at `docs/exec-plans/active/.loop-fix-plan-{slug}.md`:
+    ```markdown
+    # Fix Plan (Loop Iteration {fix_iteration})
+
+    > **Status**: Active | **Created**: {date}
+    > **Source**: Review findings from harness-loop
+
+    ## Progress
+
+    - [ ] Fix 1: {finding description}
+    - [ ] Fix 2: {finding description}
+    ...
+
+    ---
+
+    ### Task 1: {finding description}
+    **File:** {file path}
+    **Finding:** {what the reviewer found}
+    **Fix:** {what needs to change}
+
+    ### Task 2: ...
+    ```
+
+16. Execute `harness-orchestrate` inline with:
+    - The fix plan path (not the original plan)
+    - Same `LOOP_OVERRIDES` as Phase 3 (no checkpoints, auto-resolve, decision logging)
+
+17. Re-run `harness-review` inline (with Phase 4 LOOP_OVERRIDES) scoped to the fix commits only.
+
+18. If new significant issues are found AND `fix_iteration == 1`:
+    - Set `fix_iteration = 2`
+    - Append to decision log: "Entering fix cycle iteration 2"
+    - Repeat steps 15-17
+
+19. If issues remain after iteration 2:
+    - Append all unresolved issues to the decision log as "deferred"
+    - Do NOT enter a third cycle — proceed to Phase 6
+
+20. Clean up: delete `docs/exec-plans/active/.loop-fix-plan-{slug}.md`
+
+### Phase 6: Reflect (Autonomous)
+
+21. Execute `harness-reflect` inline with the following overrides:
+
+    <LOOP_OVERRIDES>
+    These overrides REPLACE conflicting instructions from harness-reflect:
+
+    - **Skip user retrospective prompt:** Do not ask "What worked well? What didn't?" (reflect Phase 6 step 15). Instead, auto-fill the Outcomes & Retrospective section using:
+      - The Loop Decision Log file
+      - Conversation-mined learnings
+      - Summary of review findings and how they were resolved
+    - **Auto-approve doc fixes:** Apply all staleness fixes and doc updates without asking for confirmation. For file deletions: add a tombstone note to the file AND append the path to the decision log — do not delete the file.
+    </LOOP_OVERRIDES>
+
+22. Check if prune is warranted:
+    - Did reflect detect deleted-code staleness?
+    - Has the project not been pruned in 30+ days? Check: `git log --all --oneline --grep="prune" --since="30 days ago"`
+    - If either condition is true, execute `harness-prune --fix` inline
+    - Append decision to log: whether prune was run and why
+
+### Phase 7: Complete (Autonomous)
+
+23. Execute `harness-complete` inline with the following overrides:
+
+    <LOOP_OVERRIDES>
+    These overrides REPLACE conflicting instructions from harness-complete:
+
+    - **No plan selection prompt:** Do not prompt for plan selection (complete Phase 1 step 2). Use the plan created in Phase 2 at the noted path. If other active plans exist, ignore them.
+    - **Auto-proceed past reflect check:** Reflect was already run in Phase 6 — skip the "suggest running harness-reflect" gate (complete Phase 1 step 3)
+    - **Skip prune health check:** Do not run Phase 6 of complete (prune was already handled in this loop's Phase 6 step 19)
+    </LOOP_OVERRIDES>
+
+### Phase 8: PR Decision
+
+24. Determine whether to open a PR by checking:
+    - **Remote exists?** `git remote -v` — if no remote, skip PR
+    - **Not on main/master?** If on main/master, skip PR (work is already on trunk)
+    - **PR workflow present?** Check for `.github/` directory or CLAUDE.md mentions of PR requirements
+    - **Project convention?** Check if CLAUDE.md has PR instructions
+
+25. If conditions favor a PR:
+    - Try invoking `pr-author`. If the command is not recognized, fall back to `gh pr create`
+    - Append to decision log: "Opened PR — {rationale}"
+
+26. If conditions are unclear or unfavorable:
+    - Append to decision log: "Skipped PR — {rationale}"
+    - Include recommendation in the final summary
+
+### Phase 9: Final Summary
+
+**Note:** If in multi-goal mode, skip this section — use the Multi-Goal Summary above instead.
+
+27. Read the full Loop Decision Log file. Output the complete summary:
+
+    ```
+    ## Loop Complete
+
+    **Design:** {design doc path}
+    **Plan:** {archived plan path}
+
+    ### Execution Summary
+    - Tasks: {completed} completed, {deviated} deviated
+    - Review cycles: {1 or 2}
+    - Review findings: {total} total, {resolved} resolved, {deferred} deferred
+    - Prune: {ran — health status | skipped}
+
+    ### Decisions Made ({total} total)
+
+    {Full decision log table, grouped by phase}
+
+    ### Deferred Items
+    - {any unresolved review findings}
+    - {any file deletions that were logged instead of executed}
+    - {or "None"}
+
+    ### PR
+    - {PR #{number} — {url}}
+    - {or "Skipped — {reason}. Run `pr-author` to create manually."}
+    ```
+
+28. Clean up: delete `docs/exec-plans/active/.loop-decision-log-{slug}.md`
+
+## Multi-Goal Execution
+
+When loop receives a refactor scope doc (detected by `## Goals` table), it executes each goal through the full pipeline independently.
+
+### Goal Graph Traversal
+
+1. **Determine goal readiness:** For each goal in the dependency graph:
+   - Check if all dependencies are complete (merged PR or completed in this session)
+   - Goals with no unmet dependencies are "ready"
+
+2. **Execute ready goals:**
+   - If multiple goals are ready simultaneously (parallel), execute them concurrently:
+     - Each goal runs in a separate worktree (via EnterWorktree)
+     - Worktrees branch from the default branch, or from the prior goal's branch if sequential
+   - If only one goal is ready, execute it in the current worktree
+
+3. **Per-goal pipeline:** For each goal, run the full loop pipeline:
+   - Phase 2: Plan (from the goal's individual design doc)
+   - Phase 3: Orchestrate (with LOOP_OVERRIDES — no checkpoints, auto-resolve)
+   - Phase 4: Review (with LOOP_OVERRIDES — auto-triage)
+   - Phase 5: Fix cycle (if needed)
+   - Phase 6: Reflect (with LOOP_OVERRIDES — auto-approve doc fixes)
+   - Phase 7: Complete
+   - Phase 8: PR (create PR for this goal)
+
+4. **After each goal completes:**
+   - Update the refactor scope doc: mark the goal as complete in a new `## Goal Status` section
+   - Re-evaluate the dependency graph for newly unblocked goals
+   - Continue until all goals are complete or a fundamental blocker is hit
+
+### Branch Strategy
+
+- **Default branch detection:** `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'` with fallback to `main` then `master`
+- **Independent goals (parallel):** Each worktree branches from the default branch
+- **Sequential goals:** Branch from the prior goal's branch
+  ```
+  Goal 1: branches from default branch
+  Goal 2 (depends on 1): branches from goal-1's branch
+  Goal 3 (depends on 1): branches from goal-1's branch (parallel with goal 2)
+  Goal 4 (depends on 2, 3): branches from the default branch after all dependencies are merged
+  ```
+
+### Multi-Goal Summary
+
+When all goals complete (or the loop stops), output:
+
+```
+## Refactor Loop Complete
+
+**Scope:** {scope doc path}
+
+### Goals
+| # | Goal | Status | PR |
+|---|------|--------|----|
+| 1 | {name} | complete | #{number} |
+| 2 | {name} | complete | #{number} |
+| 3 | {name} | blocked | — |
+
+### Execution Summary
+- Goals: {completed}/{total} complete
+- Total review cycles: {N}
+- Total decisions: {N}
+
+### Decisions Made
+{Full decision log table}
+
+### Deferred Items
+- {any unresolved items}
+- {or "None"}
+```
+
+## Emergency Stop
+
+If at ANY point during the loop:
+- Verification fails and cannot be auto-fixed after 2 attempts
+- A worker reports a fundamental blocker (would require changing the design approach or affects 3+ unstarted tasks)
+- The fix cycle produces more issues than it resolves
+- A required file (plan, design doc) cannot be read or is corrupted
+- A tool call returns an unrecoverable error (permission denied, authentication failure)
+
+Then STOP the loop immediately and output:
+
+```
+## Loop Stopped
+
+**Phase:** {which phase failed}
+**Reason:** {what went wrong}
+**State:** {what has been completed so far}
+**Decision Log:** {read and include full contents of .loop-decision-log-{slug}.md}
+
+The plan remains active at: docs/exec-plans/active/{file}
+
+To resume manually:
+- Fix the issue
+- Run `harness-orchestrate` to continue execution
+- Then `harness-review` → `harness-reflect` → `harness-complete`
+```

--- a/skills/harness-loop/SKILL.md
+++ b/skills/harness-loop/SKILL.md
@@ -12,7 +12,7 @@ Autonomous end-to-end execution: plan, orchestrate, review, fix, reflect, and co
 
 **Prerequisite:** A design document must already exist (from `harness-brainstorm`, `harness-bug`, or `harness-refactor`).
 
-**"Execute inline"** means: use the **Skill tool** to invoke the command (e.g., `Skill("harness:plan")`), then follow the loaded skill's instructions step-by-step within this conversation, applying any LOOP_OVERRIDES specified here. You MUST invoke the Skill tool — do NOT write the output from memory or conversation context. The skill's methodology exists to catch things your memory will miss.
+**"Execute inline"** means: use the **Skill tool** to invoke the command (e.g., `Skill("harness-plan")`), then follow the loaded skill's instructions step-by-step within this conversation, applying any LOOP_OVERRIDES specified here. You MUST invoke the Skill tool — do NOT write the output from memory or conversation context. The skill's methodology exists to catch things your memory will miss.
 
 ## Usage
 

--- a/skills/harness-orchestrate/SKILL.md
+++ b/skills/harness-orchestrate/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: harness-orchestrate
+description: Use when executing a living plan with agent teams, or when user says "orchestrate", "execute the plan", "start building", or "run the plan"
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/orchestrate.md
+> Claude alias: /harness:orchestrate
+
+# Orchestrate
+
+Execute a living plan using subagent-driven development with per-task living plan updates, micro-reviews, and user checkpoints.
+
+## Usage
+
+```
+harness-orchestrate
+harness-orchestrate docs/exec-plans/active/{file}.md
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+### Phase 1: Load Plan
+
+1. Locate the plan:
+   - If a path argument was provided, use it
+   - Otherwise, list `docs/exec-plans/active/` and use the most recently modified file
+   - If no active plans exist, suggest running `harness-brainstorm` → `harness-plan` first
+
+2. Read the full plan. Extract:
+   - Task list (from `### Task N:` headers or Progress checklist)
+   - Progress section (which tasks are already completed)
+   - Current state of Surprises, Drift, and Decision Log tables
+
+3. If any tasks are already marked complete in Progress, skip them. Resume from the first incomplete task.
+
+### Phase 2: Execute with Subagent-Driven Development
+
+4. **Invoke `subagent-driven-development`** using the Skill tool: `Skill("subagent-driven-development")`. Then follow the loaded skill's full process (dispatch implementer subagents per task, spec compliance review, code quality review, handle implementer status). You MUST use the Skill tool — do not replicate the SDD methodology from memory.
+
+   <HARNESS_OVERRIDES>
+   The following overrides REPLACE conflicting instructions from subagent-driven-development.
+   These take ABSOLUTE PRECEDENCE over any path, handoff, or workflow instruction in that skill:
+
+   - **Plan location:** The plan is in `docs/exec-plans/active/`, NOT `docs/superpowers/plans/`. Provide the full task text from the plan to implementer subagents — do not make them read the plan file.
+   - **No worktree setup:** Do NOT invoke `using-git-worktrees`. Harness manages its own workflow context.
+   - **No final code reviewer or finishing-a-development-branch:** Do NOT dispatch the "final code reviewer subagent for entire implementation" step, and do NOT invoke `finishing-a-development-branch`. Harness uses `harness-review` for holistic review instead. After all tasks complete (each having passed their individual two-stage reviews), proceed directly to Phase 3 below.
+   - **Parallel dispatch for independent tasks:** SDD normally processes tasks sequentially. Override this when the plan contains independent tasks (no shared files, no data dependencies). For independent tasks, use `dispatching-parallel-agents` to run them concurrently. If agent teams are available (TeamCreate, SendMessage), use them for coordination — create a named team, dispatch named workers, and collect results via SendMessage. After all parallel workers complete, run the two-stage review (spec + quality) on each task's changes before proceeding. Parallel dispatch is an optimization, not a requirement — fall back to sequential if uncertain about independence.
+   - **Living plan updates after EVERY task:** After each task completes (after both reviews pass), update the plan file immediately:
+     - **Progress:** Check off the completed task: `- [x] Task {N}: {name} _(completed {YYYY-MM-DD})_`
+     - **Surprises:** If the implementer reported anything unexpected, add a row: `| {date} | {what} | {plan impact} | {action taken} |`
+     - **Drift:** If the implementer deviated from the plan, add a row: `| Task {N} | {plan said} | {actually happened} | {why} |`
+     - **Decision Log:** If a non-trivial decision was made, add a row: `| {date} | Implementation | {decision} | {rationale} |`
+     - **Last Updated:** Update the timestamp in the plan's status line.
+   - **Micro-review after EVERY task:** After updating the plan, check the task's diff (`git diff HEAD~1`) for:
+     - Stale docs contradicted by the diff (new modules not in ARCHITECTURE.md, changed patterns not in DESIGN.md)
+     - Obvious code issues (unused imports, debug logging, unresolved TODOs)
+     - Test coverage gaps
+     Fix any stale docs immediately. Note code issues for `harness-review`.
+   - **Checkpoint after EVERY task:** After the micro-review, report status to the user and wait for feedback:
+     ```
+     ## Task {N} Complete
+
+     **Progress:** {M} of {total} tasks done
+     **Surprises:** {any new entries, or "none"}
+     **Drift:** {any deviations, or "none"}
+     **Docs:** {what was updated, or "current"}
+     **Code notes:** {any issues spotted, or "clean"}
+
+     Ready for next task. Continue? (y/n)
+     ```
+     Apply any user corrections before proceeding to the next task.
+   - **Refactor scope awareness:** If the plan header contains `Refactor Scope:`, also update the scope doc's step statuses after each task. When orchestrate finishes all planned steps and hits an async gate, output the gate info:
+     ```
+     Step {N} ({name}): completed
+     Step {M} ({name}): in_progress — {status}
+
+     Gate before Step {X}: {gate condition}
+
+     This refactor is paused at a gate. Return in a new session and run:
+       harness-refactor-status
+     ```
+   </HARNESS_OVERRIDES>
+
+### Phase 3: Completion
+
+5. When all tasks are complete, report final status:
+
+   ```
+   ## All Tasks Complete
+
+   **Progress:** {total} of {total} tasks done
+   **Total surprises:** {N}
+   **Total drift entries:** {N}
+   **Decisions logged:** {N}
+
+   ## Next Step
+
+   Run `harness-review` to:
+   - Simplify code
+   - Run multi-perspective code review
+   - Fix or defer findings
+
+   Then `harness-reflect` → `harness-complete`.
+   ```

--- a/skills/harness-plan/SKILL.md
+++ b/skills/harness-plan/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: harness-plan
+description: Use when creating an implementation plan from a design doc, bug analysis, or refactor scope, or when user says "create a plan", "plan this", or "write the plan"
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/plan.md
+> Claude alias: /harness:plan
+
+# Plan
+
+Create a living execution plan from a design document, saved as a versioned artifact with built-in progress tracking.
+
+## Usage
+
+```
+harness-plan                                    # Plan from most recent design doc
+harness-plan docs/design-docs/{file}.md         # Plan from specific design doc
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+1. Verify the project has been initialized (check for "Documentation Map" with "When to look here" in CLAUDE.md). If not, suggest `harness-init` first.
+
+2. Locate the design document:
+   - If a path argument was provided, use it
+   - Otherwise, search for the most recently modified context document across:
+     - `docs/design-docs/*-design.md`
+     - `docs/bug-analyses/*-bug-analysis.md`
+     - `docs/refactor-scopes/*-refactor-scope.md`
+   - **Frontmatter filtering:** For each candidate, check if it has YAML frontmatter with a `status` field. Skip documents with `status: implemented`, `status: superseded`, or `status: stale`. Only consider documents with `status: current` or no frontmatter (legacy/unknown).
+   - If no eligible context document found, suggest running `harness-brainstorm`, `harness-bug`, or `harness-refactor` first
+
+3. Read the design document fully. Extract:
+   - The design title and goal
+   - Key decisions made during brainstorming
+   - Architecture approach and tech stack
+   - Components/tasks implied by the design
+   - **If the context document is a refactor scope:** Skip steps already marked `completed` in the scope doc. Plan only the next batch of actionable steps (up to the next async gate). Use `Refactor Scope:` instead of `Design Doc:` in the plan header.
+
+3.5. **Consult learnings** (if available):
+   - Follow the consultation pattern defined in `_learnings-format.md` § "Consulting Learnings"
+   - Match learnings against the modules and areas being planned (extracted from the design document in step 3)
+   - Surface relevant learnings so the plan can incorporate their recommendations
+   - Record consulted learning IDs for inclusion in the plan header (step 5)
+   - If LEARNINGS.md doesn't exist or has no matches, skip silently
+
+4. **Invoke `writing-plans`** using the Skill tool: `Skill("writing-plans")`. Then follow the loaded skill's full process to produce bite-sized TDD tasks with exact file paths, code, and commands. You MUST use the Skill tool — do not write the plan from memory or replicate the planning methodology without loading it.
+
+   <HARNESS_OVERRIDES>
+   The following overrides REPLACE conflicting instructions from writing-plans.
+   These take ABSOLUTE PRECEDENCE over any path, save location, header, or handoff instruction in that skill:
+
+   - **Save location:** Do NOT save to `docs/superpowers/plans/`. The plan will be saved in step 5 below to `docs/exec-plans/active/`.
+   - **Plan header:** Do NOT include "use subagent-driven-development" or "use executing-plans" in the header. The plan header is defined in step 5 below and references `harness-orchestrate`.
+   - **Execution handoff:** Do NOT invoke `subagent-driven-development`, `executing-plans`, or any other execution skill. After producing the plan content, STOP and let step 5 wrap it with the living document format.
+   - **Plan Review Loop:** When dispatching the plan-document-reviewer subagent, the reviewer's `[PLAN_FILE_PATH]` must point to `docs/exec-plans/active/`, not `docs/superpowers/plans/`. The `[SPEC_FILE_PATH]` must point to the design doc from step 2 (in `docs/design-docs/`, `docs/bug-analyses/`, or `docs/refactor-scopes/`).
+   </HARNESS_OVERRIDES>
+
+5. After writing-plans produces its output, wrap it with the living document sections and save to `docs/exec-plans/active/{YYYY-MM-DD}-{kebab-name}.md`:
+
+   ```markdown
+   # {Plan Title}
+
+   > **Status**: Active | **Created**: {date} | **Last Updated**: {date}
+   > **Design Doc**: `docs/design-docs/{design-doc-filename}` (or **Refactor Scope**: / **Bug Analysis**: with matching path)
+   > **Consulted Learnings**: {L-YYYYMMDD-slug, L-YYYYMMDD-slug from step 3.5, or "None"}
+   > **For Claude:** Use harness-orchestrate to execute this plan.
+
+   ## Decision Log
+
+   | Date | Phase | Decision | Rationale |
+   |------|-------|----------|-----------|
+   | {date} | Design | {decisions from brainstorming design doc} | {rationale} |
+
+   ## Progress
+
+   - [ ] Task 1: {name}
+   - [ ] Task 2: {name}
+   - [ ] ...
+
+   ## Surprises & Discoveries
+
+   _None yet — updated during execution by harness-orchestrate._
+
+   ## Plan Drift
+
+   _None yet — updated when tasks deviate from plan during execution._
+
+   ---
+
+   {writing-plans output — full tasks with bite-sized steps}
+
+   ---
+
+   ## Outcomes & Retrospective
+
+   _Filled by harness-complete when work is done._
+
+   **What worked:**
+   -
+
+   **What didn't:**
+   -
+
+   **Learnings to codify:**
+   -
+   ```
+
+6. Update `docs/PLANS.md` — add the new plan to the Active Plans table.
+
+7. Report:
+   ```
+   Plan saved to: docs/exec-plans/active/{filename}.md
+
+   ## Next Steps
+
+   1. `harness-orchestrate` — Execute this plan with agent teams + micro-reflects
+   2. `harness-complete` — When done: reflect, review, and create PR
+
+   Run `harness-orchestrate` to begin execution.
+   ```

--- a/skills/harness-prune/SKILL.md
+++ b/skills/harness-prune/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: harness-prune
+description: Use when auditing docs for staleness, broken links, or bloat. Also use when user says "docs feel stale", "prune docs", or when CLAUDE.md exceeds 120 lines.
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/prune.md
+> Claude alias: /harness:prune
+
+# Prune
+
+Audit documentation for staleness, broken links, orphaned guides, and bloat. Produces a health report and can apply fixes.
+
+## Usage
+
+```
+harness-prune               # Full documentation audit with fix suggestions
+harness-prune --fix         # Audit and auto-apply safe fixes
+```
+
+## Checks
+
+| Check | Severity |
+|-------|----------|
+| CLAUDE.md exceeds 120 lines | warn |
+| Documentation Map missing "When to look here" column (v1 format) | warn |
+| Broken Documentation Map links | error |
+| Orphaned Tier 2 files (not in Documentation Map) | warn |
+| Orphaned Tier 3 files (not in any index or Deep Docs table) | warn |
+| Stale Tier 2/3 docs (90+ days unchanged) | info |
+| Stale active plans (30+ days old) | warn |
+| Missing design-docs/index.md entries | warn |
+| PLANS.md Active Plans table doesn't match exec-plans/active/ | warn |
+| Tier 2 Deep Docs tables reference missing files | error |
+| Broken cross-references between docs | error |
+| Code Map paths that don't exist on filesystem | error |
+| Design-docs index lacks Current/Archived separation | warn |
+| Superseded design docs without "superseded by" marker | warn |
+| PLANS.md references features for deleted modules | warn |
+| REVIEW_GUIDANCE.md missing (harness initialized but no review guidance) | warn |
+| REVIEW_GUIDANCE.md Deployment Context is empty/placeholder ("unknown") | warn |
+| REVIEW_GUIDANCE.md Escape Log entries without matching question in bank | warn |
+| REVIEW_GUIDANCE.md question categories with zero escapes after 5+ reviews | info |
+| LEARNINGS.md contains legacy `L-NNN` sequential IDs (should be `L-YYYYMMDD-slug`) | warn |
+| Index files use legacy markdown table format (should be bullet lists) | warn |
+
+## Invocation
+
+**IMMEDIATELY invoke the Task tool:**
+
+```
+subagent_type: "harness:harness-pruner"
+prompt: |
+  Audit the harness documentation system for this project.
+
+  Arguments: [user's arguments]
+
+  ## Instructions
+
+  1. Read CLAUDE.md and verify it has a "Documentation Map" section
+  2. Run ALL audit checks (see your agent instructions and the Checks table)
+  3. Produce the full prune report with severity, location, and suggested fix for every issue
+  4. Calculate health classification (HEALTHY / NEEDS ATTENTION / UNHEALTHY)
+  5. Present the report to the user
+
+  If --fix flag is present:
+  - After presenting the report, automatically apply safe fixes:
+    - Add missing files to docs/design-docs/index.md
+    - Remove broken links from Documentation Map
+    - Create docs/REVIEW_GUIDANCE.md from default scaffold if missing (read references/adversarial-review-prompt.md for default question bank)
+    - Add escape log questions to matching bank categories if orphaned
+    - Migrate legacy `L-NNN` learning IDs to `L-YYYYMMDD-slug` format (using date from source metadata)
+    - Convert legacy table-format index files to bullet list format
+  - For destructive fixes (deleting files, modifying CLAUDE.md), still ask for confirmation
+
+  If no --fix flag:
+  - Present the report and ask: "Would you like me to fix the errors and warnings automatically?"
+  - Apply fixes only if user approves
+```
+
+## Quick Health Mode
+
+When invoked from a health-check context (e.g., from `harness-loop` at session start), prune can run in quick mode:
+
+```
+harness-prune --quick
+```
+
+In quick mode, the pruner runs only these fast checks:
+- Check 1: CLAUDE.md Size
+- Check 4: Broken Map Links
+- Check 9: Missing Index Entries
+- Check 13: Code Map Ghost Paths
+- Check 16: Missing Frontmatter
+- Check 17: Frontmatter Status Consistency
+
+Output is a single health score line only:
+```
+Harness health: {N}/10 ({error count} errors, {warning count} warnings)
+```
+
+No full report is generated in quick mode. This keeps session-start latency low.

--- a/skills/harness-refactor-status/SKILL.md
+++ b/skills/harness-refactor-status/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: harness-refactor-status
+description: Use when resuming an in-progress refactoring, checking goal progress, or when user says "refactor status", "where are we", or "continue refactoring"
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/refactor-status.md
+> Claude alias: /harness:refactor-status
+
+# Refactor Status
+
+Resume checkpoint for multi-session refactoring. Reads the active refactor scope document, derives goal status from git and GitHub state, and guides the user to the next executable goal.
+
+## Usage
+
+```
+harness-refactor-status                                        # Check most recent refactor
+harness-refactor-status docs/refactor-scopes/{file}.md         # Check specific refactor
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+1. Locate the active refactor scope document:
+   - If a path argument was provided (`$ARGUMENTS`), use it
+   - Otherwise, find the most recently modified `*-refactor-scope.md` in `docs/refactor-scopes/`
+   - If no scope doc found, suggest running `harness-refactor` first
+
+2. Read the scope document. Extract:
+   - Title and refactor type
+   - The Goals table (goal names, dependencies, production safety strategy)
+
+3. Derive goal status from git/GitHub state. For each goal:
+   - Check if a branch exists: `git branch --list "*{goal-name}*" --all`
+   - Check if a PR exists: `gh pr list --search "{goal-name}" --state all --json number,state,title,url 2>/dev/null`
+   - Derive status:
+     - `complete` = PR merged (state=MERGED)
+     - `in_progress` = branch exists or PR open (state=OPEN)
+     - `blocked` = dependencies not complete
+     - `pending` = not started (no branch, no PR)
+
+4. Display goal status:
+
+   ```
+   ## Refactor Status: {Title}
+
+   **Type**: {refactor type}
+   **Target**: {target being refactored}
+
+   | # | Goal | Status | PR |
+   |---|------|--------|----|
+   | 1 | {goal name} | complete | #142 |
+   | 2 | {goal name} | in_progress | #145 (open) |
+   | 3 | {goal name} | blocked (depends on 2) | — |
+   | 4 | {goal name} | pending | — |
+
+   **Progress**: {completed}/{total} goals complete
+   ```
+
+5. Show which goals are currently unblocked and ready to execute:
+
+   ```
+   ### Ready to Execute
+   - Goal {N}: {name} — all dependencies met
+   ```
+
+   If no goals are ready (all blocked or complete), say so.
+
+6. Guide user to next action:
+
+   ```
+   ## Next Steps
+
+   Run `harness-loop docs/refactor-scopes/{scope}/{goal}-design.md` to execute the next goal.
+   Or run `harness-loop docs/refactor-scopes/{date}-{scope}-refactor-scope.md` to execute all remaining goals.
+   ```

--- a/skills/harness-refactor/SKILL.md
+++ b/skills/harness-refactor/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: harness-refactor
+description: Use when planning an incremental refactoring, extracting responsibilities from a large class, or when user says "refactor", "extract", "strangler fig", or "decompose"
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/refactor.md
+> Claude alias: /harness:refactor
+
+# Refactor
+
+Scope an incremental refactoring using the Strangler Fig pattern, saved as a versioned refactor scope document with a goal dependency graph and individual goal design docs for multi-session execution.
+
+## Usage
+
+```
+harness-refactor                                    # Start refactoring scoping
+harness-refactor extract auth from UserController   # With initial target
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+1. Verify the project has been initialized (check for "Documentation Map" with "When to look here" column in CLAUDE.md). If not, suggest running `harness-init` first.
+
+2. Read `docs/refactor-scopes/index.md` to understand prior refactoring efforts. If the directory doesn't exist, create it with an empty index.
+
+3. **Invoke the `harness:strangler-fig` skill** using the Skill tool: `Skill("harness:strangler-fig")`. Then follow the loaded skill's full interactive scoping dialogue through all three phases: identify extraction target, dependency & seam analysis, and map the strangler fig steps. You MUST use the Skill tool — do not replicate the scoping methodology from memory.
+
+4. When scoping is complete, save the refactor scope doc to `docs/refactor-scopes/{YYYY-MM-DD}-{kebab-name}-refactor-scope.md`:
+
+   ```markdown
+   # Refactor Scope: {Title}
+
+   > **Status**: Scoped | **Date**: {date}
+   > **Refactor Type**: {backend extraction / frontend extraction / pure code / mixed}
+   > **Target**: {the code being refactored}
+
+   ## Current State
+   - {what the target does today, its responsibilities}
+   - {why it needs refactoring — size, complexity, coupling}
+
+   ## Extraction Targets
+   - {responsibility 1} → {new module/component}
+   - {responsibility 2} → {new module/component}
+
+   ## Dependency Map
+   - **Consumers**: {who calls/imports the target}
+   - **Dependencies**: {what the target depends on}
+   - **Seams identified**: {natural boundaries for coexistence}
+
+   ## Risk Assessment
+   - {blast radius}
+   - {what could break during transition}
+   - {mitigation strategies}
+
+   ## Goals
+
+   | # | Goal | Description | Depends On | Production Safety |
+   |---|------|-------------|------------|-------------------|
+   | 1 | {kebab-name} | {one-line summary} | — | {feature flag / unconsumed scaffolding / additive-only / safe deletion} |
+   | 2 | {kebab-name} | {one-line summary} | 1 | {strategy} |
+   | 3 | {kebab-name} | {one-line summary} | 1 | {strategy} |
+   | 4 | {kebab-name} | {one-line summary} | 2, 3 | {strategy} |
+
+   ### Execution Order
+   - {describe which goals can run in parallel and which are sequential}
+   - {e.g., "Goals 2 and 3 can run in parallel (both depend only on goal 1)"}
+
+   ### Merge Criteria
+   {Criteria the reviewer should verify before merging each goal's PR. These are advisory — the agent writes all the code upfront.}
+   ```
+
+5. Create individual goal design docs in `docs/refactor-scopes/{scope-name}/` (where `{scope-name}` is the kebab name used in the scope file). Each goal gets its own design doc named `{N}-{goal-kebab-name}-design.md`:
+
+   ```markdown
+   # {Goal Title}
+
+   > **Status**: Ready | **Date**: {date}
+   > **Refactor Scope**: [{scope name}](../{date}-{scope-name}-refactor-scope.md)
+   > **Goal**: {N} of {total}
+   > **Depends On**: {goal numbers or "none"}
+   > **Branch Base**: {default branch / goal-N branch name}
+
+   ## Goal
+   {What this goal accomplishes — one production-safe unit of work}
+
+   ## Production Safety
+   {How this PR is safe to merge: feature flag, unconsumed scaffolding, additive-only, etc.}
+
+   ## Approach
+   {Implementation details — files to create/modify, patterns to follow}
+
+   ## Rollback
+   {How to reverse this goal's changes if needed}
+
+   ## Merge Criteria
+   {Conditions to verify before merging this PR — tests pass, no regressions, etc. Advisory documentation for the human reviewer.}
+
+   ## Key Decisions
+   | Decision | Rationale |
+   |----------|-----------|
+   | {decision} | {why} |
+   ```
+
+   For the **Branch Base** field: Goal 1 uses "default branch". Each subsequent goal that depends on a prior goal uses that prior goal's branch name as its base.
+
+6. Update `docs/refactor-scopes/index.md` — append a line:
+   ```markdown
+   - [{date}-{name}-refactor-scope]({date}-{name}-refactor-scope.md) — {one-line summary} ({date})
+   ```
+
+7. Guide the user to next steps:
+   ```
+   Refactor scope saved to: docs/refactor-scopes/{filename}.md
+   Goal design docs saved to: docs/refactor-scopes/{scope-name}/
+
+   ## Next Steps
+
+   1. `harness-loop docs/refactor-scopes/{date}-{scope}-refactor-scope.md` — Execute all goals with full pipeline per goal
+   2. `harness-loop docs/refactor-scopes/{scope}/{goal}-design.md` — Execute a single goal
+   3. `harness-refactor-status` — Check progress between sessions
+
+   Run `harness-loop docs/refactor-scopes/{date}-{scope}-refactor-scope.md` to begin.
+   ```
+
+**IMPORTANT:** When the strangler-fig skill transitions to output, do NOT invoke writing-plans directly. Instead, output the Next Steps above and let the user invoke `harness-loop` or `harness-plan`.

--- a/skills/harness-refactor/SKILL.md
+++ b/skills/harness-refactor/SKILL.md
@@ -25,7 +25,7 @@ harness-refactor extract auth from UserController   # With initial target
 
 2. Read `docs/refactor-scopes/index.md` to understand prior refactoring efforts. If the directory doesn't exist, create it with an empty index.
 
-3. **Invoke the `harness:strangler-fig` skill** using the Skill tool: `Skill("harness:strangler-fig")`. Then follow the loaded skill's full interactive scoping dialogue through all three phases: identify extraction target, dependency & seam analysis, and map the strangler fig steps. You MUST use the Skill tool — do not replicate the scoping methodology from memory.
+3. **Invoke the `harness:strangler-fig` skill** using the Skill tool: `Skill("harness-strangler-fig")`. Then follow the loaded skill's full interactive scoping dialogue through all three phases: identify extraction target, dependency & seam analysis, and map the strangler fig steps. You MUST use the Skill tool — do not replicate the scoping methodology from memory.
 
 4. When scoping is complete, save the refactor scope doc to `docs/refactor-scopes/{YYYY-MM-DD}-{kebab-name}-refactor-scope.md`:
 

--- a/skills/harness-reflect/SKILL.md
+++ b/skills/harness-reflect/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: harness-reflect
+description: Use when capturing learnings and updating docs after review, when user says "reflect", "retrospective", "update docs", or after /harness:review completes
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/reflect.md
+> Claude alias: /harness:reflect
+
+# Reflect
+
+Full documentation reconciliation, conversation mining, and retrospective. Run after `harness-review`, before `harness-complete`.
+
+## Usage
+
+```
+harness-reflect                    # Diff from active plan creation or last 5 commits
+harness-reflect HEAD~3             # Diff last 3 commits
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+### Phase 1: Diff-First Discovery
+
+1. Determine the diff scope:
+   - If a commit reference was provided, use it: `git diff {ref}...HEAD`
+   - Otherwise, check for an active plan in `docs/exec-plans/active/`. If one exists, diff from its creation date.
+   - Fallback: diff the last 5 commits: `git diff HEAD~5...HEAD`
+
+2. Build a **change profile** from the diff:
+   ```bash
+   git diff {ref}...HEAD --stat
+   git diff {ref}...HEAD --name-only
+   ```
+   Extract:
+   - Directories and modules touched
+   - Types of changes (new files, modified files, deleted files)
+   - Domains affected (testing, API, auth, build, frontend, etc.)
+
+### Phase 2: Selective Doc Loading
+
+3. Read the Documentation Map from CLAUDE.md (just the table — not the whole file).
+
+4. Match the change profile against Documentation Map categories:
+   - Changes to module code → load `docs/ARCHITECTURE.md`
+   - Changes to patterns/conventions → load `docs/DESIGN.md`
+   - Changes matching discovered categories → load the relevant `docs/{DOMAIN}.md`
+
+5. Read ONLY the matched Tier 2 files. Scan their "Deep Docs" tables. If any Tier 3 files are relevant to the diff, read those too (on-demand).
+
+6. If `docs/adrs/` exists, list ADR filenames and read title lines. Load any ADRs whose topic overlaps with the change profile.
+
+### Phase 3: Staleness Check & Fix
+
+7. For each loaded doc, check if the diff contradicts or obsoletes anything:
+   - Does the diff add a new module not mentioned in ARCHITECTURE.md?
+   - Does the diff **delete** a module/directory still listed in ARCHITECTURE.md Code Map or DESIGN.md?
+   - Does the diff change a pattern described in DESIGN.md?
+   - Does the diff affect something described in a Tier 3 doc?
+
+8. **Deleted-code audit**: Extract deleted files/directories from the diff (`--diff-filter=D`). For each:
+   - Search all loaded Tier 2/3 docs for references to the deleted path
+   - Flag any doc that describes the deleted code as if it still exists
+   - This is the highest-priority staleness fix — confident docs about nonexistent code actively mislead
+
+9. For each stale finding, fix it in-place:
+   - Add new modules to ARCHITECTURE.md Code Map
+   - **Remove or mark as removed** deleted modules from ARCHITECTURE.md Code Map
+   - Update DESIGN.md Current State bullets
+   - **Remove or update** DESIGN.md sections that describe deleted functionality
+   - Update Tier 3 docs that reference changed code
+   - If a dedicated doc exists for a deleted module (e.g., `docs/TUI.md`), delete the file or replace contents with a tombstone pointing to what replaced it
+
+10. If an active plan exists in `docs/exec-plans/active/`:
+   - Check if any surprises or drift should be recorded
+   - Update the plan's Surprises & Discoveries table if something unexpected was found
+   - Update the plan's Plan Drift table if a doc fix implies the implementation deviated
+
+### Phase 4: Plan vs. Actual
+
+11. Read the active plan fully. Compare the plan's Progress/Drift tables against the actual diff. The living plan already has most of this data from orchestration. Fill any gaps:
+    - Tasks that were completed but not checked off
+    - Drift entries that should have been recorded
+    - Surprises discovered but not logged
+
+### Phase 5: Conversation Mining
+
+12. Scan the current conversation history for:
+    - **User corrections** — instances where the user corrected approach or output
+    - **Rejected approaches** — things proposed that the user pushed back on
+    - **Incorrect assumptions** — things assumed about the codebase that turned out false
+    - **New patterns** — approaches discovered that worked well and should be documented
+    - **Process feedback** — meta-feedback about the workflow
+
+13. Categorize each finding as:
+    - **doc-update** — corrects or adds to an existing Tier 2/3 doc
+    - **adr-candidate** — represents a significant architectural decision
+    - **no-action** — interesting but one-off
+
+14. Codify findings:
+    - For each **doc-update**: edit the relevant doc in place
+    - For each **adr-candidate**: if `docs/adrs/` exists, create a new ADR with status Proposed. If not, inform user and suggest `/adr:init`.
+    - If ADRs were created, execute `/adr:update` inline.
+
+14.5. **Write learnings** from conversation mining:
+   - For each **doc-update** finding that represents a reusable, forward-looking insight (not just a one-off correction), also write it as a learning entry to `docs/LEARNINGS.md`
+   - If `docs/LEARNINGS.md` doesn't exist, create it with the scaffold:
+     ```markdown
+     # Learnings
+
+     Persistent learnings captured across sessions. Append-only, merge-friendly.
+
+     Status: `active` | `superseded`
+     Categories: `architecture` | `testing` | `patterns` | `workflow` | `debugging` | `performance` | `review-escape`
+
+     ---
+     ```
+   - Determine the next learning ID: use today's date (`YYYYMMDD`) and a short kebab-case slug from the learning topic. Format: `L-YYYYMMDD-slug`. See `_learnings-format.md` § "ID Format" for details.
+   - Append each learning:
+     ```markdown
+
+     ### L-{YYYYMMDD}-{slug}: {one-line insight}
+     - status: active
+     - category: {matching domain: architecture|testing|patterns|workflow|debugging|performance|review-escape}
+     - source: harness-reflect {YYYY-MM-DD}
+     - branch: {current git branch}
+
+     {Actionable recommendation for future sessions.}
+
+     ---
+     ```
+   - The learning must be actionable — "when doing X, check Y" not "X was broken"
+
+### Phase 5.5: Review Escape Mining
+
+This phase feeds the self-learning review system. When bugs escape `harness-review` and are caught by external reviewers (copilot, PR reviewers, QA, production incidents), those escapes become new adversarial questions that improve future reviews.
+
+14.6. **Detect review escapes** — scan the conversation history and available context for bugs that were NOT caught by `harness-review` but were found by:
+   - **External PR review** — copilot suggestions, human reviewer comments
+   - **Manual testing** — bugs found during QA or dogfooding after review passed
+   - **Production incidents** — issues traced to recently reviewed code
+   - **User corrections during this session** — user pointing out bugs in code that passed review
+
+   Indicators of an escape:
+   - User says "copilot found...", "the reviewer said...", "PR feedback..."
+   - User reports a bug in code that was committed after `harness-review` passed
+   - Conversation contains a bug fix for code that was part of the reviewed diff
+   - The `harness-review` report shows all agents PASS but issues were later found
+
+14.7. **Categorize each escape** into the adversarial question bank taxonomy:
+   - `concurrency` — race conditions, thundering herds, lock contention
+   - `distributed` — double-execution, coordination failures, split-brain
+   - `failure-modes` — missing retries, cascade failures, no circuit breaker
+   - `resource-exhaustion` — memory leaks, unbounded growth, connection exhaustion
+   - `data-integrity` — partial writes, missing transactions, duplicate processing
+   - `security` — injection, auth bypass, data exposure
+   - `logic` — incorrect behavior, wrong edge case handling (code-level bugs the review agents should have caught)
+
+14.8. **Formulate "what breaks?" questions** for each escape:
+   - Each question must be specific enough to catch this bug class in future reviews
+   - Frame as a scenario, not a fix: "What happens when X?" not "Add jitter to backoff"
+   - Example: A thundering herd escape → "Does retry/backoff logic use jitter, or will concurrent clients synchronize into waves?"
+
+14.9. **Update `docs/REVIEW_GUIDANCE.md`** if it exists:
+
+   a. Append each escape to the **Escape Log** table:
+      ```markdown
+      | {YYYY-MM-DD} | {one-line bug description} | {copilot|reviewer|QA|production|self} | {category} | {question text} |
+      ```
+
+   b. Add the new question to the appropriate **Adversarial Question Bank** category:
+      - If the category exists, append the question under it
+      - If the category doesn't exist, create a new `### {Category}` section
+      - If a similar question already exists, refine it to be more specific rather than adding a duplicate
+
+   c. If the escape was a `logic` category bug (something the existing review agents should have caught), also write a learning to `docs/LEARNINGS.md` with category `review-escape` noting which agent should have caught it and why it might have been missed (confidence threshold too high? wrong framing?)
+
+14.10. If `docs/REVIEW_GUIDANCE.md` does NOT exist, skip this phase. In the final Report, set Review Escape Mining to: "Skipped — docs/REVIEW_GUIDANCE.md not found. Run harness-init or harness-review to enable adversarial review learning."
+
+14.11. Report escape mining results (include in the final Report output):
+   - Number of escapes detected
+   - Questions added/refined
+   - Categories affected
+
+### Phase 6: Outcomes & Retrospective
+
+15. Ask user for their perspective:
+    ```
+    The plan had {N} tasks. {M} completed, {D} deviated, {K} surprises logged.
+
+    What worked well? What didn't? Any learnings to capture?
+    ```
+
+16. Fill in the plan's Outcomes & Retrospective section with:
+    - User's input
+    - Conversation-mined learnings
+    - Summary of surprises and drift
+
+### Phase 7: Design Doc Archival
+
+17. If `docs/design-docs/index.md` exists, check whether the diff supersedes any earlier design docs:
+    - If a newer design doc covers the same topic as an older one, add a `Superseded by` column or marker to the older entry
+    - Separate the index into **Current Designs** and **Archived** sections if not already structured that way
+    - Archived entries should note which doc superseded them
+
+### Phase 7.5: Frontmatter Status Update
+
+17.5. Update frontmatter status on design docs touched by this work:
+   - If an active plan exists and its `Design Doc:` header references a design doc:
+     - If the plan is being completed (all tasks done), update the design doc's YAML frontmatter `status` from `current` to `implemented`
+     - Add `implemented-by: {plan path}` to the frontmatter
+   - Scan `docs/design-docs/` for topic overlaps:
+     - If a newer design doc covers the same topic as an older one, update the older doc's frontmatter `status` to `superseded` and add `supersedes: {path to newer doc}`
+   - When scanning for staleness (Phase 3), respect frontmatter status:
+     - Docs with `status: implemented` or `status: superseded` are correctly archived — do NOT flag as stale
+     - Only docs with `status: current` that reference deleted code are genuinely stale
+
+### Phase 8: Tier 2 Summary Updates
+
+18. Update `docs/PLANS.md`:
+    - Update plan status (not yet archived — that's `harness-complete`)
+
+19. Update `docs/DESIGN.md` if any new patterns or key decisions were established.
+
+20. Update `docs/ARCHITECTURE.md` if any new modules were created or boundaries changed.
+
+### Report
+
+21. Output:
+    ```
+    ## Reflect Complete
+
+    **Scope:** {diff description, e.g., "3 commits, 12 files changed"}
+    **Docs loaded:** {list of Tier 2/3 files checked}
+
+    ### Updates Made
+    - {list of doc files modified with one-line description of what changed}
+    - {or "No updates needed — docs are current"}
+
+    ### Deleted-Code Cleanup
+    - {list of stale references removed, or "No deleted modules detected"}
+
+    ### Plan Updates
+    - {surprises/drift added, or "No active plan" or "No drift detected"}
+
+    ### Conversation Learnings
+    - Doc updates: {N}
+    - ADR candidates: {N}
+    - No-action: {N}
+
+    ### Learnings Written
+    - {N} new learnings added to docs/LEARNINGS.md
+    - {list of learning IDs and one-line summaries}
+
+    ### Review Escape Mining
+    - Escapes detected: {N}
+    - Questions added to REVIEW_GUIDANCE.md: {N}
+    - Categories affected: {list, or "None — no review escapes detected"}
+
+    ### Retrospective
+    - Captured in plan's Outcomes & Retrospective section
+
+    ## Next Step
+
+    Run `harness-complete` to archive the plan and create the PR.
+    ```

--- a/skills/harness-reflect/SKILL.md
+++ b/skills/harness-reflect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-reflect
-description: Use when capturing learnings and updating docs after review, when user says "reflect", "retrospective", "update docs", or after /harness:review completes
+description: Use when capturing learnings and updating docs after review, when user says "reflect", "retrospective", "update docs", or after harness-review completes
 ---
 
 > Generated from Claude plugin command: plugins/harness/commands/reflect.md

--- a/skills/harness-review/SKILL.md
+++ b/skills/harness-review/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: harness-review
+description: Use when implementation is done and code needs quality review, when user says "review the code", "check the code", or after /harness:orchestrate completes all tasks
+---
+
+> Generated from Claude plugin command: plugins/harness/commands/review.md
+> Claude alias: /harness:review
+
+# Review
+
+Multi-agent review loop on local changes using pr-review-toolkit agents. Runs all review agents in parallel, fixes issues, and re-runs failing agents until all pass or max cycles reached. Run after `harness-orchestrate`, before `harness-complete`.
+
+**Compatibility note:** This command no longer uses `review-personas.toml` or the previous multi-persona loop configuration. Any remaining references to it in other docs are legacy and will be cleaned up.
+
+## Usage
+
+```
+harness-review                    # Review changes since active plan creation
+harness-review HEAD~5             # Review last 5 commits
+```
+
+## Prerequisites
+
+This command requires the **pr-review-toolkit** plugin. Verify it is installed by checking if its agents are available (e.g., `pr-review-toolkit:code-reviewer` appears in the agent list). If not installed, STOP and print:
+```
+ERROR: Missing required plugin: pr-review-toolkit
+
+Install it:
+  /plugins add pr-review-toolkit
+```
+
+Optional: The **adr** plugin enables architecture compliance checking in Phase 6. If not installed, Phase 6 is skipped.
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+### Phase 1: Determine Scope
+
+1. Determine the diff scope:
+   - If a commit reference was provided, use it
+   - Otherwise, check for an active plan in `docs/exec-plans/active/`. If one exists, diff from its creation date.
+   - Fallback: diff the last 5 commits
+
+2. Gather the full diff and changed file list:
+   ```bash
+   git diff HEAD~{N} --stat
+   git diff HEAD~{N} --name-only
+   ```
+
+### Phase 2: Verification Gate
+
+3. **Apply `verification-before-completion`** using the Skill tool: `Skill("verification-before-completion")`. Follow the loaded skill to run the project's verification commands (tests, build, lint, typecheck) BEFORE starting review. If verification fails, STOP and fix first. Do not review broken code.
+
+### Phase 3: Adversarial Production Review
+
+Context-isolated adversarial review using the bundled `scripts/adversarial-review.sh` script. This invokes `claude --bare -p` as a **completely separate OS process** — no conversation context, no plugins, no hooks, no shared state. The reviewer sees only the diff and a targeted adversarial prompt. Output is structured JSON validated against a schema.
+
+4. Check if `docs/REVIEW_GUIDANCE.md` exists. If it does not exist, generate it now using the default scaffold (see `harness-init` Phase 2 step 8.7 for the scaffold template, or read `references/adversarial-review-prompt.md` for the default question bank). Commit it:
+   ```bash
+   git add docs/REVIEW_GUIDANCE.md
+   git commit -m "docs: initialize review guidance for adversarial review"
+   ```
+
+5. Read `docs/REVIEW_GUIDANCE.md`. Extract:
+   - **Deployment Context** section (instances, database, scale, infrastructure)
+   - **Adversarial Question Bank** sections (all categories with questions)
+   - **Known Non-Issues** section if it exists (to annotate the prompt)
+
+6. **Filter questions by relevance** to the diff:
+   - Read the changed file list from Phase 1
+   - Match file paths and diff content against question categories:
+     - Database/SQL code → include Data Integrity, Concurrency & Scale
+     - HTTP handlers/API code → include Concurrency & Scale, Failure Modes
+     - Auth/security code → include Security
+     - Cron/scheduler code → include Distributed Systems
+     - All diffs → include Resource Exhaustion
+   - Minimum: always include at least 3 questions even after filtering
+   - If filtering removes all questions, use the full bank
+
+7. **Construct the adversarial prompt** using the template from `references/adversarial-review-prompt.md`:
+   - Insert deployment context
+   - Insert filtered questions
+   - Select perspective variants based on deployment context (SRE, Scale, Security, Distributed — these stack)
+   - If Known Non-Issues exist, append: "Note: the following have been reviewed and confirmed as non-issues for this project: {list}. Do not report these unless circumstances have materially changed."
+   - Write the constructed prompt to a temp file via the Write tool:
+     ```bash
+     ADVERSARIAL_PROMPT=$(mktemp /tmp/harness-adversarial-prompt-XXXXXX.md)
+     ```
+
+8. **Generate the diff:**
+   ```bash
+   ADVERSARIAL_DIFF=$(mktemp /tmp/harness-adversarial-XXXXXX.patch)
+   git diff HEAD~{N} > "$ADVERSARIAL_DIFF"
+   ```
+
+9. **Run the adversarial review script.** The script handles process isolation (`env -u CLAUDECODE`), `--bare` mode, `--json-schema` validation, temp file management, timeouts, and error handling. All of that complexity lives in the script, not here.
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/adversarial-review.sh \
+     --prompt-file "$ADVERSARIAL_PROMPT" \
+     --diff-file "$ADVERSARIAL_DIFF" \
+     --model sonnet \
+     --effort max \
+     --timeout 300
+   ```
+   Use `timeout: 360000` (6 minutes, allowing buffer beyond the script's internal 5-minute timeout) on the Bash call.
+
+   **Exit codes:**
+   | Code | Meaning | Action |
+   |------|---------|--------|
+   | 0 | PASS | Proceed to Phase 4 |
+   | 1 | FAIL — CRITICAL findings | Must fix before Phase 4 |
+   | 2 | FAIL — HIGH/MEDIUM only | Add to fix queue, proceed to Phase 4 |
+   | 3 | Inconclusive | Log warning, proceed to Phase 4 |
+   | 4 | Error/timeout/skip | Log warning, proceed to Phase 4 |
+
+   The script outputs structured JSON to stdout:
+   ```json
+   {
+     "verdict": "FAIL",
+     "findings": [
+       {
+         "severity": "CRITICAL",
+         "title": "Connection pool exhaustion under load",
+         "location": "handleRequest()",
+         "scenario": "1000 concurrent requests",
+         "impact": "Service becomes unresponsive",
+         "fix": "Add connection pool limit with timeout"
+       }
+     ],
+     "summary": "Found 1 critical production failure mode."
+   }
+   ```
+
+10. **Parse the JSON output** and capture the exit code:
+    - Read stdout as JSON — no free-text parsing needed
+    - If the script exited non-zero with no stdout, check stderr for the error JSON
+
+11. **Integrate findings into the review cycle:**
+    - **Exit 1 (CRITICAL):** Fix all CRITICAL findings inline, commit, and re-run verification before proceeding to Phase 4.
+    - **Exit 2 (HIGH/MEDIUM):** Add findings to the fix queue. These will be addressed alongside Phase 4 agent findings.
+    - **Exit 0 (PASS):** Proceed to Phase 4 normally.
+    - **Exit 3/4 (inconclusive/error):** Print a warning with the reason from the JSON output. Proceed to Phase 4 — adversarial review is additive, not blocking.
+
+12. Clean up:
+    ```bash
+    rm -f "$ADVERSARIAL_DIFF" "$ADVERSARIAL_PROMPT" 2>/dev/null
+    ```
+
+### Phase 4: Review Loop
+
+13. Set `cycle = 1`, `max_cycles = 3`, `failing_agents = all 6 review agents`.
+
+14. **Review cycle loop** — repeat until all pass or `cycle > max_cycles`:
+
+   a. Spawn each agent in `failing_agents` **in parallel** via the Agent tool, passing each the git diff from Phase 1. Use these pr-review-toolkit agent types:
+
+   | Agent | `subagent_type` | Focus |
+   |-------|----------------|-------|
+   | Code Reviewer | `pr-review-toolkit:code-reviewer` | Code quality, bugs, logic errors, CLAUDE.md adherence |
+   | Silent Failure Hunter | `pr-review-toolkit:silent-failure-hunter` | Silent failures, error handling, inappropriate fallbacks |
+   | Test Analyzer | `pr-review-toolkit:pr-test-analyzer` | Test coverage completeness, missing edge cases |
+   | Type Design Analyzer | `pr-review-toolkit:type-design-analyzer` | Type design, encapsulation, invariant expression |
+   | Comment Analyzer | `pr-review-toolkit:comment-analyzer` | Comment accuracy, staleness, maintainability |
+   | Learnings Reviewer | `harness:learnings-reviewer` | Checks diff against active learnings for violations |
+
+   Each agent prompt should include:
+   - The full diff (from Phase 1 scope)
+   - The changed file list
+   - Any HIGH/MEDIUM findings from Phase 3 adversarial review that haven't been fixed yet (so agents don't duplicate effort but can validate fixes)
+   - Instruction: "Review these local changes (not a PR). Return your findings in your standard format. End with a verdict: PASS (no critical/important issues) or FAIL (critical/important issues found)."
+
+   b. Wait for all agents to complete. Collect results.
+
+   c. Determine pass/fail for each agent:
+      - **PASS**: No critical or important issues reported
+      - **FAIL**: Critical or important issues found (code-reviewer confidence ≥80, test-analyzer criticality ≥7, type-design-analyzer ratings ≤4, silent-failure-hunter CRITICAL/HIGH, comment-analyzer Critical Issues, learnings-reviewer FAIL verdict)
+
+   d. If all pass → exit loop.
+
+   e. If any fail:
+      - Present findings grouped by agent
+      - Fix all reported issues inline (edit files directly)
+      - Re-run verification (tests/build must still pass after fixes)
+      - Commit fixes: `git commit -am "fix: address review findings (cycle {cycle})"`
+      - Set `failing_agents = only agents that failed`
+      - Increment `cycle`
+
+15. After loop exits:
+   - If all passed: review is green
+   - If max cycles reached with failures remaining: note unresolved issues
+
+### Phase 5: Code Simplification
+
+16. Spawn the code-simplifier agent using the Agent tool with `subagent_type: "pr-review-toolkit:code-simplifier"`, scoped to the changed files. This agent modifies code directly — let it make improvements.
+
+17. If the simplifier made changes, commit and re-run verification:
+   ```bash
+   git add {changed files}
+   git commit -m "refactor: simplify code from review"
+   ```
+
+### Phase 6: ADR Compliance
+
+18. Check if `docs/ARCHITECTURE.md` exists AND the `adr` plugin is available (i.e., `/adr:review` is a recognized command).
+
+19. **If both exist:**
+    - Run `/adr:review` against the diff from Phase 1
+    - Report any CRITICAL or WARNING violations
+    - If the diff introduces new architectural patterns that aren't covered by existing ADRs, note them for `harness-reflect` — do NOT create new ADRs during review. The bar for flagging is high: only note patterns that represent genuinely new architectural decisions, not routine implementation choices.
+
+20. **If either is missing:** Skip silently — not every project uses ADRs or has the adr plugin installed.
+
+### Phase 7: Resolution
+
+21. If unresolved issues remain after max cycles:
+    - Present options:
+      ```
+      ## Review: {N} unresolved issues after {max_cycles} cycles
+
+      Options:
+      1. Fix now — address remaining findings inline
+      2. `harness-orchestrate` — create tasks for significant fixes
+      3. Defer — proceed with findings noted
+
+      Which approach?
+      ```
+
+22. If user chooses to fix now, apply fixes and re-run verification.
+
+### Report
+
+23. Output:
+    ```
+    ## Review Complete
+
+    **Scope:** {diff description}
+    **Verification:** {passing — with evidence}
+    **Adversarial review:** {PASS | FAIL — N findings (breakdown by severity) | skipped}
+    **Review cycles:** {N} of {max_cycles}
+    **Agents:** {passed}/6 passed
+    **Simplification:** {changes made | no changes needed}
+    **ADR compliance:** {N violations | compliant | skipped}
+
+    ### Adversarial Review Findings
+    | Severity | Finding | Status |
+    |----------|---------|--------|
+    | CRITICAL | {title} | fixed |
+    | HIGH | {title} | fixed |
+    | MEDIUM | {title} | deferred |
+    {or "No production failure patterns found."}
+
+    ### Per-Agent Results
+    | Agent | Status | Issues Found | Issues Resolved |
+    |-------|--------|-------------|-----------------|
+    | code-reviewer | pass | 2 | 2 |
+    | silent-failure-hunter | pass | 1 | 1 |
+    | pr-test-analyzer | pass | 0 | 0 |
+    | type-design-analyzer | pass | 0 | 0 |
+    | comment-analyzer | fail | 3 | 1 |
+    | learnings-reviewer | pass | 0 | 0 |
+
+    ### Unresolved Issues
+    - {any remaining issues, or "None"}
+
+    ## Next Step
+
+    Run `harness-complete` to archive the plan and commit all changes.
+    ```

--- a/skills/harness-review/SKILL.md
+++ b/skills/harness-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-review
-description: Use when implementation is done and code needs quality review, when user says "review the code", "check the code", or after /harness:orchestrate completes all tasks
+description: Use when implementation is done and code needs quality review, when user says "review the code", "check the code", or after harness-orchestrate completes all tasks
 ---
 
 > Generated from Claude plugin command: plugins/harness/commands/review.md

--- a/skills/pr-author/SKILL.md
+++ b/skills/pr-author/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: pr-author
+description: Use when ready to submit work for review, when changes need to become a PR, or when asked to create a pull request
+---
+
+> Generated from Claude plugin command: plugins/pr/commands/author.md
+> Claude alias: /pr:author
+
+# Author PR
+
+Creates a PR from current work with quality gates and proper description.
+
+## Usage
+
+```
+pr-author                          # Author PR for current changes
+pr-author --skip-simplify          # Skip code-simplifier check
+pr-author --base develop           # Target different base branch
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+### 1. Detect Current State
+
+```bash
+git status --porcelain
+git branch --show-current
+git log -1 --format="%H %s"
+```
+
+Determine:
+- Are we on the default branch? (need to create branch)
+- Are there uncommitted changes? (need to commit)
+- Is branch pushed? (need to push)
+
+### 2. Branch Creation (if on default branch)
+
+Extract initials from git config:
+```bash
+git config user.name
+```
+
+Parse first letter of each word (e.g., "Donovan Yohan" -> "dy").
+
+Ask user for:
+- Type: `feat`, `fix`, `refactor`, `docs`, `chore`
+- Branch name (kebab-case description)
+
+Create branch: `<initials>/<type>/<name>`
+
+```bash
+git checkout -b <branch-name>
+```
+
+### 3. Code Simplifier Gate
+
+**Skip if `--skip-simplify` flag provided.**
+
+Check if code-simplifier has been run:
+```bash
+git log --oneline -20 | grep -i "simplif"
+```
+
+If no evidence found, run the built-in `/simplify` command to review changed code for reuse, quality, and efficiency. Wait for completion before proceeding.
+
+### 4. Verification Gate
+
+**REQUIRED: Apply `verification-before-completion`** using the Skill tool: `Skill("verification-before-completion")`.
+
+Identify project's verification commands by checking for:
+- `package.json` -> `npm test`, `npm run lint`, `npm run typecheck`
+- `Makefile` -> `make test`, `make lint`
+- `build.gradle.kts` -> `./gradlew test`, `./gradlew spotlessCheck`
+- `pyproject.toml` -> `pytest`, `make lint`
+
+**Run ALL applicable verification commands.** Read full output. Check exit codes.
+
+**Red Flags - STOP if any occur:**
+- Tests failing
+- Lint errors
+- Type errors
+- Build failures
+
+Do NOT proceed to PR creation with failing verification. Fix issues first.
+
+### 5. Commit & Push
+
+If uncommitted changes exist:
+```bash
+git add <specific-files>
+git commit -m "<type>: <description>"
+```
+
+If not pushed:
+```bash
+git push -u origin <branch-name>
+```
+
+### 6. Create PR
+
+Determine the base branch from `--base` argument if provided, otherwise detect the repository default:
+```bash
+BASE="${BASE:-$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)}"
+git diff "$BASE"...HEAD
+git log "$BASE"..HEAD --oneline
+```
+
+Create PR with `gh`:
+```bash
+gh pr create --title "<type>: <concise-title>" --body "$(cat <<'EOF'
+## Summary
+
+<1-3 sentences: WHY these changes matter - business/user impact, not code details>
+
+## Changes
+
+- <Category>: <What changed and why>
+- <Category>: <What changed and why>
+
+## Testing
+
+- <How this was verified>
+- <Edge cases considered>
+
+---
+*Created with `pr-author`*
+EOF
+)"
+```
+
+### 7. Report Result
+
+Output the PR URL and summary of what was done.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Creating PR with failing tests | Run verification first, fix failures |
+| Description lists code changes | Describe WHY and impact, not WHAT |
+| Skipping code-simplifier | Only skip with explicit flag |
+| Committing secrets | Check for .env, credentials before commit |

--- a/skills/pr-automate/SKILL.md
+++ b/skills/pr-automate/SKILL.md
@@ -138,7 +138,7 @@ Capture the PR number and URL for subsequent phases.
 
 ### Phase 2: Review
 
-Invoke `pr-review` using the Skill tool: `Skill("pr:review", args="<PR number>")`. This loads the review command which runs all 6 pr-review-toolkit agents in parallel with proper `subagent_type` parameters and posts inline review comments. You MUST use the Skill tool — do not manually spawn the review agents.
+Invoke `pr-review` using the Skill tool: `Skill("pr-review", args="<PR number>")`. This loads the review command which runs all 6 pr-review-toolkit agents in parallel with proper `subagent_type` parameters and posts inline review comments. You MUST use the Skill tool — do not manually spawn the review agents.
 
 Read the posted review to check for findings.
 
@@ -170,16 +170,18 @@ gh api repos/{owner}/{repo}/issues/<number>/comments --paginate --jq '.[] | {id,
 
 **Categorize each comment:**
 
+**Default bias: implement everything actionable.** Agents are fast — the cost of implementing is low, the cost of deferring is high. Never decline actionable feedback as "better in a follow-up PR."
+
 | Category | Criteria | Automated Action |
 |----------|----------|-----------------|
-| **Actionable** | Requests a code change | Make the change |
+| **Actionable** | Requests a code change or suggests an improvement | Make the change — no exceptions, no deferring |
 | **Question** | Asks for clarification | **HARD STOP** |
 | **Discussion** | Debate about approach | **HARD STOP** |
 | **Resolved** | Already addressed | Skip |
 
 **If any Question or Discussion items exist → STOP.** Report to user with a summary of what needs human input.
 
-**For Actionable items:**
+**For Actionable items (implement ALL of them):**
 1. Read each referenced file
 2. Make the requested change
 3. Run project tests to verify no regressions

--- a/skills/pr-automate/SKILL.md
+++ b/skills/pr-automate/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: pr-automate
+description: Use when automating the full PR lifecycle, when wanting hands-off PR creation through merge, or when asked to automate a pull request
+---
+
+> Generated from Claude plugin command: plugins/pr/commands/automate.md
+> Claude alias: /pr:automate
+
+# Automate PR
+
+Orchestrates the full PR lifecycle: author → review → resolve → merge, with automated decision points. Stops and reports to user when human judgment is needed.
+
+## Usage
+
+```
+pr-automate                    # Full automated flow
+pr-automate --skip-simplify    # Skip code-simplifier gate
+pr-automate --base develop     # Target different base branch
+pr-automate --dry-run          # Author + review only, no resolve or merge
+```
+
+## Hard Stops
+
+**STOP and report to the user immediately if ANY of these occur:**
+1. Verification gate fails (tests, lint, typecheck)
+2. CI checks fail after PR creation
+3. Review agents report critical-severity findings
+4. Resolve categorizes any comment as **Discussion** or **Question** (needs human judgment)
+5. `gh pr merge` fails (branch protection, required human approvals)
+
+## Prerequisites
+
+This command requires the **pr-review-toolkit** plugin. The code-simplifier gate uses the built-in `/simplify` command (skip with `--skip-simplify` if unavailable).
+
+## Invocation
+
+**IMMEDIATELY execute this workflow. All phases run sequentially.**
+
+---
+
+### Phase 0: Check Prerequisites
+
+Verify the `pr-review-toolkit` plugin is installed by checking if its agents are available.
+
+**If not installed, STOP and print:**
+```
+ERROR: Missing required plugin: pr-review-toolkit
+
+Install it:
+  /plugins add pr-review-toolkit
+```
+
+---
+
+### Phase 1: Author
+
+Follow the `pr:author` workflow with automated decisions.
+
+**1a. Detect current state:**
+```bash
+git status --porcelain
+git branch --show-current
+git log -1 --format="%H %s"
+```
+
+Determine: on default branch? uncommitted changes? branch pushed?
+
+**1b. Branch creation (if on default branch):**
+
+Extract initials from `git config user.name` (first letter of each word).
+
+**Automated decision:** Infer type (`feat`, `fix`, `refactor`, `docs`, `chore`) and branch name from the changes. Do NOT ask the user.
+
+```bash
+git checkout -b <initials>/<type>/<inferred-name>
+```
+
+**1c. Code-simplifier gate:**
+
+**Skip if `--skip-simplify` flag provided.**
+
+Check if code-simplifier has been run:
+```bash
+git log --oneline -20 | grep -i "simplif"
+```
+
+If no evidence found, run the built-in `/simplify` command to review changed code for reuse, quality, and efficiency. Wait for completion before proceeding.
+
+**1d. Verification gate:**
+
+Identify project verification commands by checking for `package.json`, `Makefile`, `build.gradle.kts`, `pyproject.toml`.
+
+**Run ALL applicable verification commands.** Read full output. Check exit codes.
+
+**HARD STOP if tests, lint, or typecheck fail.** Do NOT proceed. Report failures to user.
+
+**1e. Commit & push:**
+
+```bash
+git add <specific-files>
+git commit -m "<type>: <description>"
+git push -u origin <branch-name>
+```
+
+**1f. Create PR:**
+
+Determine the base branch from `--base` argument if provided, otherwise detect the repository default:
+```bash
+BASE="${BASE:-$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)}"
+git diff "$BASE"...HEAD
+git log "$BASE"..HEAD --oneline
+```
+
+Create PR with `gh`. Include `--base "$BASE"` if not the default:
+```bash
+gh pr create --title "<type>: <concise-title>" --body "$(cat <<'EOF'
+## Summary
+
+<1-3 sentences: WHY these changes matter>
+
+## Changes
+
+- <Category>: <What changed and why>
+
+## Testing
+
+- <How this was verified>
+
+---
+*Created with `pr-automate`*
+EOF
+)"
+```
+
+Capture the PR number and URL for subsequent phases.
+
+---
+
+### Phase 2: Review
+
+Invoke `pr-review` using the Skill tool: `Skill("pr:review", args="<PR number>")`. This loads the review command which runs all 6 pr-review-toolkit agents in parallel with proper `subagent_type` parameters and posts inline review comments. You MUST use the Skill tool — do not manually spawn the review agents.
+
+Read the posted review to check for findings.
+
+**HARD STOP if any agent reports critical-severity findings.** Report to user.
+
+**If `--dry-run` flag provided, STOP here.** Report PR URL and review findings to user.
+
+---
+
+### Phase 3: Wait for CI
+
+Poll for CI check completion:
+```bash
+gh pr checks <number> --watch
+```
+
+**HARD STOP if any required check fails.** Report failing checks to user with details.
+
+---
+
+### Phase 4: Resolve
+
+Fetch all PR comments in parallel using `--jq` with **single-quoted** filters (prevents zsh `!` expansion errors):
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate --jq '.[] | {id, path, line, body, user: .user.login}'
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate --jq '[.[] | select(.body != "") | {id, state, body, user: .user.login}]'
+gh api repos/{owner}/{repo}/issues/<number>/comments --paginate --jq '.[] | {id, body, user: .user.login}'
+```
+
+**Categorize each comment:**
+
+| Category | Criteria | Automated Action |
+|----------|----------|-----------------|
+| **Actionable** | Requests a code change | Make the change |
+| **Question** | Asks for clarification | **HARD STOP** |
+| **Discussion** | Debate about approach | **HARD STOP** |
+| **Resolved** | Already addressed | Skip |
+
+**If any Question or Discussion items exist → STOP.** Report to user with a summary of what needs human input.
+
+**For Actionable items:**
+1. Read each referenced file
+2. Make the requested change
+3. Run project tests to verify no regressions
+4. Commit and push:
+   ```bash
+   git add <changed-files>
+   git commit -m "fix: address review feedback"
+   git push
+   ```
+5. Reply to each resolved comment with fix details:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<number>/comments/<comment_id>/replies \
+     -f body="Fixed: <description of change>"
+   ```
+
+---
+
+### Phase 5: Merge
+
+Verify merge conditions:
+```bash
+gh pr checks <number>
+gh pr view <number> --json reviewDecision,mergeStateStatus,mergeable
+```
+
+If all checks pass and PR is mergeable:
+```bash
+gh pr merge <number> --delete-branch
+```
+
+Uses the repo's default merge strategy (no `--squash`, `--merge`, or `--rebase` flag).
+
+**HARD STOP if merge fails** (branch protection, required approvals, merge conflicts). Report to user.
+
+### Report Result
+
+Output final summary:
+```markdown
+## PR Automated Successfully
+
+**PR:** #<number> - <title>
+**URL:** <url>
+**Status:** Merged ✓
+
+### Phases completed:
+1. ✓ Authored PR from branch changes
+2. ✓ Review posted (N findings)
+3. ✓ CI checks passed
+4. ✓ Resolved N actionable comments
+5. ✓ Merged via repo default strategy
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Proceeding after verification failure | STOP immediately, report to user |
+| Trying to resolve Discussion comments | STOP, these need human judgment |
+| Merging with failing CI | Wait for all checks to pass first |
+| Using --squash or --merge flags | Use no flag — let repo default decide |
+| Proceeding when review agents find critical issues | STOP, report critical-severity findings to user |
+| Skipping test run after resolve changes | Always verify before pushing fixes |
+| Running without pr-review-toolkit | Install: `/plugins add pr-review-toolkit` |
+| jq filters with `!=` in double quotes | Always use **single quotes** around jq expressions, or use `gh api --jq` flag |

--- a/skills/pr-resolve/SKILL.md
+++ b/skills/pr-resolve/SKILL.md
@@ -37,12 +37,19 @@ gh api repos/{owner}/{repo}/issues/<number>/comments --paginate --jq '.[] | {id,
 
 ### 2. Categorize Comments
 
+**Default bias: implement everything.** Agents are fast and capable — the cost of implementing feedback is low, the cost of deferring is high (context loss, stale PRs, reviewer fatigue). Treat every comment as work to do in THIS PR unless it literally cannot be done here.
+
+**Evaluate correctness, not effort.** The question is never "is this too much work?" — it's "is this technically sound?" Read the surrounding code, understand the reviewer's intent, and verify the suggestion wouldn't introduce a bug or regression. If it's correct, implement it regardless of scope. If it's wrong, decline with a clear technical explanation of why.
+
 | Category | Criteria | Action |
 |----------|----------|--------|
-| **Actionable** | Requests code change | Make the change |
-| **Question** | Asks for clarification | Draft response |
-| **Discussion** | Debate about approach | Summarize options |
+| **Actionable** | Requests code change | Verify correctness, then make the change |
+| **Suggestion** | Proposes improvement or alternative approach | Verify it's sound, then implement it. If the reviewer took time to suggest it, it's worth doing now |
+| **Question** | Asks for clarification | Draft response AND make any code change implied by the question (add comment, rename, clarify logic) |
+| **Discussion** | Debate about approach | Pick the best option and implement it. If genuinely ambiguous, ask the user — do NOT defer to a follow-up PR |
 | **Resolved** | Already addressed | Skip |
+
+**The "follow-up PR" trap:** Never categorize work as "out of scope" or "better in a separate PR" unless it would require changes to files/systems completely unrelated to this PR's purpose. Reviewer feedback on code IN this PR belongs IN this PR.
 
 ### 3. Present Action Plan
 
@@ -75,7 +82,7 @@ After pushing fixes, **you MUST resolve comment threads on GitHub** using the Gr
 | Category | GitHub Action |
 |----------|--------------|
 | **Actionable — fixed** | Reply with what you changed, then **resolve the thread** |
-| **Actionable — declined with rationale** | Reply explaining why with clear reasoning, then **resolve the thread** |
+| **Actionable — declined (rare)** | Reply explaining why with a specific technical justification. Only valid reasons: (1) the suggestion is technically incorrect — would introduce a bug, break a contract, or cause a regression (explain what and why), (2) the change would break an unrelated system, (3) it requires access/permissions you don't have, (4) the user explicitly told you not to. "Too much work" and "better as a follow-up" are NOT valid reasons. Then **resolve the thread** |
 | **Question / Discussion** | Reply if you have useful context, but **leave the thread open** |
 
 #### How to resolve a thread
@@ -117,7 +124,10 @@ Report files modified, commit SHA, and which comments were resolved vs left open
 
 | Mistake | Fix |
 |---------|-----|
-| Blindly implementing all feedback | Evaluate each comment critically |
+| Deferring feedback to a "follow-up PR" | Implement it now. The reviewer gave feedback on THIS code — address it in THIS PR. Agents are fast; use that. |
+| Categorizing suggestions as "out of scope" | If the reviewer commented on code in this PR, it's in scope. Period. |
+| Declining feedback because it's "a lot of work" | That's exactly what agents are for. Implement it. |
+| Implementing a suggestion without verifying correctness | Read the surrounding code first. If the suggestion would introduce a bug, decline with a specific technical explanation — don't blindly apply it |
 | Not testing after changes | Always verify before pushing |
 | Not replying to reviewers | Always communicate what was addressed |
 | Addressing comments but not resolving threads on GitHub | Always resolve threads for fixed/declined items via `gh api graphql` |

--- a/skills/pr-resolve/SKILL.md
+++ b/skills/pr-resolve/SKILL.md
@@ -43,8 +43,7 @@ gh api repos/{owner}/{repo}/issues/<number>/comments --paginate --jq '.[] | {id,
 
 | Category | Criteria | Action |
 |----------|----------|--------|
-| **Actionable** | Requests code change | Verify correctness, then make the change |
-| **Suggestion** | Proposes improvement or alternative approach | Verify it's sound, then implement it. If the reviewer took time to suggest it, it's worth doing now |
+| **Actionable** | Requests code change or suggests an improvement | Verify correctness, then make the change. If the reviewer took time to suggest it, it's worth doing now |
 | **Question** | Asks for clarification | Draft response AND make any code change implied by the question (add comment, rename, clarify logic) |
 | **Discussion** | Debate about approach | Pick the best option and implement it. If genuinely ambiguous, ask the user — do NOT defer to a follow-up PR |
 | **Resolved** | Already addressed | Skip |

--- a/skills/pr-resolve/SKILL.md
+++ b/skills/pr-resolve/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: pr-resolve
+description: Use when PR has unaddressed comments, when review feedback needs action, or when asked to handle PR feedback
+---
+
+> Generated from Claude plugin command: plugins/pr/commands/resolve.md
+> Claude alias: /pr:resolve
+
+# Resolve PR Comments
+
+Analyzes outstanding PR comments and determines actions to address them.
+
+## Usage
+
+```
+pr-resolve              # Resolve comments on current branch's PR
+pr-resolve 123          # Resolve comments on PR #123
+pr-resolve --dry-run    # Show plan without making changes
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+### 1. Fetch PR and Comments
+
+```bash
+gh pr view --json number,url
+```
+
+Fetch comments in parallel using `--jq` with **single-quoted** filters (prevents zsh `!` expansion errors):
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/comments --paginate --jq '.[] | {id, path, line, body, user: .user.login}'
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --paginate --jq '[.[] | select(.body != "") | {id, state, body, user: .user.login}]'
+gh api repos/{owner}/{repo}/issues/<number>/comments --paginate --jq '.[] | {id, body, user: .user.login}'
+```
+
+### 2. Categorize Comments
+
+| Category | Criteria | Action |
+|----------|----------|--------|
+| **Actionable** | Requests code change | Make the change |
+| **Question** | Asks for clarification | Draft response |
+| **Discussion** | Debate about approach | Summarize options |
+| **Resolved** | Already addressed | Skip |
+
+### 3. Present Action Plan
+
+```markdown
+## PR Comments Analysis
+
+### Actionable (N items)
+| # | File:Line | Request | Proposed Fix |
+|---|-----------|---------|--------------|
+
+### Questions (N items)
+| # | From | Question | Draft Response |
+|---|------|----------|----------------|
+
+### Ready to resolve actionable items? (y/n)
+```
+
+### 4. Execute Fixes (if approved and not --dry-run)
+
+For each actionable item: read file, make change, verify tests pass.
+
+After all changes: run project tests, commit with message summarizing fixes, push.
+
+### 5. Reply and Resolve Comments on GitHub
+
+After pushing fixes, **you MUST resolve comment threads on GitHub** using the GraphQL API. Do not skip this step.
+
+#### Resolution rules
+
+| Category | GitHub Action |
+|----------|--------------|
+| **Actionable — fixed** | Reply with what you changed, then **resolve the thread** |
+| **Actionable — declined with rationale** | Reply explaining why with clear reasoning, then **resolve the thread** |
+| **Question / Discussion** | Reply if you have useful context, but **leave the thread open** |
+
+#### How to resolve a thread
+
+First, get the thread ID for each review comment. Review comment IDs from the REST API (`/pulls/<number>/comments`) are **not** GraphQL node IDs — you must convert them:
+
+```bash
+# Get the GraphQL node_id for a review comment (REST comment id -> node_id)
+gh api repos/{owner}/{repo}/pulls/comments/<comment_id> --jq '.node_id'
+```
+
+Then resolve the thread using GraphQL:
+
+```bash
+gh api graphql -f query='
+  mutation {
+    resolveReviewThread(input: {threadId: "<NODE_ID>"}) {
+      thread { isResolved }
+    }
+  }
+'
+```
+
+**Important:** The `threadId` must be a GraphQL node ID (starts with `PRRT_` or similar), not a REST integer ID. If you have the REST comment ID, fetch the `node_id` field first as shown above.
+
+#### Reply to individual comments
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/comments/<comment_id>/replies -f body='<your reply>'
+```
+
+Reply **before** resolving so the reviewer sees what was done.
+
+### 6. Report Completion
+
+Report files modified, commit SHA, and which comments were resolved vs left open. Suggest `pr-update` to sync PR description.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Blindly implementing all feedback | Evaluate each comment critically |
+| Not testing after changes | Always verify before pushing |
+| Not replying to reviewers | Always communicate what was addressed |
+| Addressing comments but not resolving threads on GitHub | Always resolve threads for fixed/declined items via `gh api graphql` |
+| Resolving question/discussion threads | Only resolve threads where you made a fix or gave a definitive decline with rationale |
+| Using REST comment ID as GraphQL threadId | Fetch `node_id` from REST API first, then pass that to the GraphQL mutation |
+| jq filters with `!=` in double quotes | Always use **single quotes** around jq expressions, or use `gh api --jq` flag |

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: pr-review
+description: Use when reviewing a PR, when helping evaluate someone else's changes, or when asked to review code on a branch
+---
+
+> Generated from Claude plugin command: plugins/pr/commands/review.md
+> Claude alias: /pr:review
+
+# Review PR
+
+Runs a comprehensive multi-perspective review of a PR using specialized agents.
+
+## Usage
+
+```
+pr-review              # Review PR for current branch
+pr-review 123          # Review PR #123
+```
+
+## Prerequisites
+
+This command requires the **pr-review-toolkit** plugin. Optional: **adr** plugin for architecture compliance.
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+### 1. Check Prerequisites
+
+Verify the `pr-review-toolkit` plugin is installed by checking if its agents are available.
+
+**If not installed, STOP and print:**
+```
+ERROR: Missing required plugin: pr-review-toolkit
+
+Install it:
+  /plugins add pr-review-toolkit
+```
+
+### 2. Find the PR
+
+If PR number provided as argument, include it in the command. Otherwise detect from current branch:
+```bash
+# With PR number argument:
+gh pr view <number> --json number,title,url,headRefName,baseRefName
+
+# Without (uses current branch):
+gh pr view --json number,title,url,headRefName,baseRefName
+```
+
+Extract and assign the target branch for use in all subsequent diffs:
+```bash
+BASE="$(gh pr view <number> --json baseRefName -q .baseRefName)"
+```
+
+If no PR exists for current branch, inform user and stop.
+
+### 3. Run All Review Agents
+
+Get the diff against the PR's actual target branch:
+```bash
+git diff "$BASE"...HEAD
+```
+
+Spawn **all 6 pr-review-toolkit agents in parallel** using the Agent tool with `subagent_type` set to the fully qualified agent name. Each agent covers a distinct review dimension:
+
+| Agent (`subagent_type`) | Focus |
+|-------|-------|
+| `pr-review-toolkit:code-reviewer` | Code quality, bugs, logic errors, CLAUDE.md/style guide adherence |
+| `pr-review-toolkit:silent-failure-hunter` | Silent failures, inadequate error handling, inappropriate fallbacks |
+| `pr-review-toolkit:pr-test-analyzer` | Test coverage completeness, missing edge cases |
+| `pr-review-toolkit:type-design-analyzer` | Type design quality, encapsulation, invariant expression |
+| `pr-review-toolkit:comment-analyzer` | Comment accuracy, staleness, long-term maintainability |
+| `pr-review-toolkit:code-simplifier` | Unnecessary complexity, DRY violations, code smells |
+
+<MANDATORY>
+You MUST use the `subagent_type` parameter when spawning each agent. Example:
+```
+Agent(subagent_type="pr-review-toolkit:code-reviewer", prompt="Review PR #N...", run_in_background=true)
+```
+Do NOT spawn generic agents with descriptions like "Code reviewer agent". The `subagent_type` parameter loads the agent's specialized system prompt — without it, the agent runs as a generic model with no review methodology.
+</MANDATORY>
+
+**All 6 agents run concurrently.** Wait for all to complete before proceeding.
+
+### 4. Aggregate and Post Results
+
+Collect findings from all agents. For each finding, post an **inline review comment on the specific file and line** using a single GitHub pull request review.
+
+Build the review payload as a JSON file to avoid shell escaping issues and ensure correct API format:
+```bash
+cat > /tmp/review.json << 'TEMPLATE'
+{
+  "event": "COMMENT",
+  "commit_id": "<HEAD commit SHA>",
+  "body": "## PR Review Summary\n\n**Agents run:** code-reviewer, silent-failure-hunter, pr-test-analyzer, type-design-analyzer, comment-analyzer, code-simplifier\n\n<high-level summary>",
+  "comments": [
+    {
+      "path": "<file>",
+      "line": <line number>,
+      "side": "RIGHT",
+      "body": "**[agent-name]** <finding>"
+    }
+  ]
+}
+TEMPLATE
+
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --input /tmp/review.json
+```
+
+**Required fields per inline comment:** `path`, `line`, `side` ("RIGHT" for new code), and `body`. The top-level `commit_id` must be the PR's HEAD SHA (`gh pr view <number> --json headRefOid -q .headRefOid`).
+
+Prefix each inline comment body with the agent name in bold (e.g., **[silent-failure-hunter]**) so the reviewer knows which perspective the finding came from.
+
+If an agent found no issues, note it in the summary body as passing.
+
+### 5. ADR Compliance Check
+
+Check if `docs/ARCHITECTURE.md` exists in the project.
+
+**If it exists:**
+- Get the PR diff using the saved `baseRefName`: `git diff "$BASE"...HEAD`
+- Run `/adr:review` against that diff
+- Report any CRITICAL or WARNING violations alongside the review results
+- If violations found, note them clearly:
+  ```
+  ## ADR Compliance
+
+  {N} architecture rule violations found in this PR:
+  {violation summary from /adr:review output}
+  ```
+
+**If it does not exist:** Skip silently — not every project uses ADRs.
+
+### 6. Report Completion
+
+Summarize:
+```
+## Review Complete
+
+**PR:** #<number> - <title>
+**Agents:** 6/6 completed
+**Findings:** N total across all agents
+**ADR:** {N violations | compliant | skipped}
+
+Review comments posted inline on the PR.
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Running without pr-review-toolkit | Install: `/plugins add pr-review-toolkit` |
+| Diffing against repo default branch | Always use the PR's `baseRefName` — the PR may target `develop`, `release/*`, etc. |
+| Posting a single summary comment | Use inline review comments on specific lines so feedback is actionable |
+| Running agents sequentially | All 6 agents are independent — run them in parallel |

--- a/skills/pr-update/SKILL.md
+++ b/skills/pr-update/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: pr-update
+description: Use when PR description is stale, after resolving comments, or when PR content has changed since creation
+---
+
+> Generated from Claude plugin command: plugins/pr/commands/update.md
+> Claude alias: /pr:update
+
+# Update PR Description
+
+Syncs PR description with current state of changes.
+
+## Usage
+
+```
+pr-update              # Update current branch's PR
+pr-update 123          # Update PR #123
+pr-update --preview    # Show changes without applying
+```
+
+## Invocation
+
+**IMMEDIATELY execute this workflow:**
+
+### 1. Get Current State
+
+If PR number provided as argument, include it in the commands. Otherwise detect from current branch:
+```bash
+# Current PR description and target branch
+gh pr view <number> --json number,title,body,commits,reviews,baseRefName
+
+# Extract target branch for diffs
+BASE="$(gh pr view <number> --json baseRefName -q .baseRefName)"
+
+# All commits since the PR's actual target branch (NOT the repo default)
+git log "$BASE"..HEAD --oneline
+
+# Current diff
+gh pr diff <number>
+```
+
+### 2. Analyze Changes Since PR Creation
+
+Compare:
+- Original PR description (what it claims)
+- Current commits (what actually changed)
+- Review comments resolved (what was addressed)
+
+Identify:
+- New commits added after PR creation
+- Sections of description now outdated
+- Review feedback that was addressed
+
+### 3. Generate Updated Description
+
+Preserve:
+- Linked issues (`Fixes #123`)
+- Screenshots or images
+- Manual notes from author
+- Testing instructions if still valid
+
+Update:
+- Summary to reflect current state
+- Changes list to include new commits
+- Testing section if approach changed
+
+Add (if applicable):
+- "Updated after review" note
+- Summary of resolved feedback
+
+### 4. Preview Changes
+
+Show diff of old vs new description:
+
+```markdown
+## PR Description Update Preview
+
+### Changes detected:
+- 2 new commits since original PR
+- 3 review comments resolved
+- Error handling added to auth module
+
+### Description diff:
+
+@@ Summary @@
+- Adds user authentication
++ Adds user authentication with improved error handling
+
+@@ Changes @@
++ - Auth: Add null checks per review feedback
++ - API: Switch to const declarations
+
+### Apply this update? (y/n)
+```
+
+### 5. Apply Update (if approved and not --preview)
+
+```bash
+gh pr edit <number> --body "$(cat <<'EOF'
+<updated description content>
+EOF
+)"
+```
+
+### 6. Report Completion
+
+```markdown
+## PR Updated
+
+**PR:** #<number>
+**Changes:** Summary updated, N new items in changes list
+
+View: <pr-url>
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Overwriting manual notes | Preserve user-added sections |
+| Losing linked issues | Keep Fixes/Closes references |
+| Updating without preview | Always show diff first |

--- a/skills/strangler-fig/SKILL.md
+++ b/skills/strangler-fig/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: strangler-fig
+description: Use when breaking up a god class, extracting responsibilities from an oversized module, incrementally replacing legacy code, or when old and new must coexist during a refactor — symptoms include classes over 500 lines, modules with mixed concerns, or "we can't rewrite this all at once"
+---
+
+# Strangler Fig Refactoring
+
+Decompose an incremental refactoring into production-safe goals using the Strangler Fig pattern — build new alongside old, redirect traffic, then remove legacy. Informed by Martin Fowler's StranglerFigApplication and Shopify's incremental migration approach.
+
+## When to Use
+
+- Extracting responsibilities from a God Object or oversized module
+- Replacing a legacy component without big-bang rewrite
+- Any refactor where old and new must coexist during transition
+- Classes over 500 lines with multiple distinct responsibilities
+- "We can't rewrite this all at once" situations
+
+## Workflow
+
+Execute three phases interactively with the user:
+
+### Phase 1: Identify Extraction Target
+
+1. Ask what code to refactor — the oversized class, tangled module, or legacy component
+2. Read the target code and map its responsibilities (list each distinct responsibility)
+3. Classify the refactor type:
+   - **Backend service extraction** — persistent state involved, data migration likely needed
+   - **Frontend component extraction** — UI/state extraction, typically no database migration
+   - **Pure code extraction** — logic extraction only, no persistent state changes
+   - **Mixed** — evaluate based on which responsibilities involve persistent state
+4. Ask which responsibilities to extract, or recommend based on cohesion analysis
+
+### Phase 2: Dependency & Seam Analysis
+
+1. Trace consumers — who calls, imports, or depends on the extraction target
+2. Trace dependencies — what the target depends on (other modules, DB, external services)
+3. Identify seams — natural boundaries where old and new systems can coexist
+4. Assess risk:
+   - Blast radius — how many callers/modules are affected
+   - Data consistency risk — are there shared mutable state or transactions
+   - Rollback complexity — how easy is it to undo each step
+5. Determine if persistent state is involved (indicates data migration goals will be needed)
+
+### Phase 3: Decompose into Production-Safe Goals
+
+Use strangler fig thinking and the dependency analysis from Phase 2 to identify natural goal boundaries. Each goal must be safe to merge to production independently.
+
+**Grouping heuristic**: combine steps that cannot be independently verified or deployed into a single goal. A goal is the smallest unit of work that is safe to ship alone.
+
+**Production-safety criteria** — a goal is production-safe if it meets at least one:
+- Protected by a feature flag (default off)
+- Unconsumed scaffolding (new code exists but nothing calls it yet)
+- Additive-only change (no existing behavior is altered or removed)
+- Safe deletion (removing code with verified zero consumers)
+
+For each goal, provide:
+- **Concrete mapping**: specific files, classes, tables, or components involved
+- **Rollback note**: how to reverse this goal if problems arise
+- **Merge criteria**: what must be true before this goal's PR is considered ready (advisory, for human reviewers)
+
+**Output format:**
+
+Goals table:
+
+| # | Goal | Description | Depends On | Production Safety |
+|---|------|-------------|------------|-------------------|
+| 1 | `kebab-goal-name` | What this goal accomplishes | — | Additive-only / Feature flag / etc. |
+| 2 | `kebab-goal-name` | What this goal accomplishes | Goal 1 | Unconsumed scaffolding |
+| … | … | … | … | … |
+
+**Execution Order**: Describe which goals are sequential and which can be parallelized. Goals with no shared dependency can be worked in parallel by separate engineers or teams.
+
+**Merge Criteria**: For each goal, document what reviewers should verify before merging. This is advisory guidance for human reviewers — not an automated gate.
+
+## Reference Framework
+
+The 7 strangler fig steps are a reference framework for analysis during Phases 2-3. They help identify what work needs to happen but do not dictate goal boundaries. The agent groups these into production-safe goals based on the project's actual needs.
+
+| Step | What | Applies When |
+|------|------|-------------|
+| 1. Define new interface | Create the new module/class/component with extracted responsibilities | Always |
+| 2. Redirect consumers | Update callers/importers to use the new interface | Always |
+| 3. Establish new data source | Create new storage (DB table, state store, context, cache) | Persistent state involved |
+| 4. Dual writes | Write to both old and new sources simultaneously for consistency | Persistent state involved |
+| 5. Backfill | Migrate existing data from old source to new | Historical data exists |
+| 6. Switch reads | Move read operations from old source to new | Persistent state involved |
+| 7. Remove legacy | Delete old code, old storage, old dependencies | Always |
+
+For detailed examples per refactor type, read the reference file at:
+`references/steps-by-context.md`
+
+For common merge criteria patterns and observation strategies, read:
+`references/gate-patterns.md`
+
+## Output
+
+Produce a goal dependency graph and per-goal summaries as structured content. Do NOT save files — the invoking command (`harness-refactor`) handles document creation.
+
+## Key Principles
+
+- **Reversibility is the core value** — every goal (except final deletion goals) should be reversible
+- **Transitional architecture is acceptable** — temporary code enabling coexistence is not waste, it's risk reduction
+- **Goals have explicit dependencies** — each goal declares what must be merged before it begins
+- **Merge criteria document deployment readiness** — they are advisory checkpoints, not automated gates
+- **Goal count and scope varies by refactor** — a simple extraction might be 2 goals; a complex service split might be 8
+
+## Common Mistakes
+
+| Mistake | Why It's Dangerous | Fix |
+|---------|-------------------|-----|
+| Scoping a goal that isn't production-safe to merge independently | If the PR breaks prod when merged alone, it's not a valid goal boundary | Restructure: add a feature flag, split further, or make the change additive-only |
+| Making goals too granular (15 PRs for a simple extraction) | Review fatigue, coordination overhead, unclear progress | Combine steps that can't be independently verified into a single goal |
+| Making goals too coarse (one mega-PR) | Defeats the purpose of incremental safety; hard to review and impossible to roll back cleanly | Split at seams where production safety is naturally maintained |
+| Not documenting rollback for each goal | You won't remember how to undo under incident pressure | Every goal needs a rollback note written before implementation |
+| Not identifying which goals can parallelize | Missed opportunity to reduce calendar time | Explicitly map which goals have no shared dependency and can run in parallel |
+
+## Red Flags — STOP and Reassess
+
+- "This goal's PR would break prod if merged alone" — the goal scope is wrong; restructure it
+- "We need all goals merged simultaneously" — goals aren't independent enough; find a way to sequence them safely
+- "Skip the merge criteria, it obviously works" — verify anyway; obvious things fail silently in production
+- "Let's just do it all in one PR" — defeats the purpose of incremental safety and eliminates the ability to roll back individual changes
+
+**All of these mean: revisit goal boundaries, restore production safety, then proceed.**

--- a/skills/strangler-fig/references/gate-patterns.md
+++ b/skills/strangler-fig/references/gate-patterns.md
@@ -1,0 +1,189 @@
+# Merge Criteria Patterns
+
+These are criteria for human reviewers deciding when to merge a goal's PR, not conditions that block the agent from coding. The agent writes all code upfront; these criteria inform when each PR is safe to merge to production.
+
+---
+
+## Criteria Types
+
+### Synchronous Criteria
+
+Things CI can check automatically — tests, lint, build. These can be encoded as required CI checks before a PR is approved.
+
+| Criteria | How to Verify |
+|------|--------------|
+| Tests pass | `./gradlew test` / `npm test` / `pytest` — all green |
+| Code compiles | Build succeeds with no type errors |
+| Linter clean | No new lint warnings introduced |
+| Integration tests pass | API contract tests, component tests, end-to-end smoke tests |
+| Code review approved | PR reviewed and approved by at least one peer |
+| No runtime exceptions in staging | Deploy to staging, run manual smoke test, check error logs |
+
+Synchronous criteria can be encoded as CI checks that block merge.
+
+### Async Criteria
+
+Things that need time or observation — they require elapsed time, external events, or collected evidence. These create natural pause points in the migration — do not rush them.
+
+| Criteria | How to Verify | Typical Duration |
+|------|--------------|-----------------|
+| Observation period clean | Zero new errors/regressions in monitoring for N hours | 24–72 hours |
+| Backfill complete | Row counts match between old and new storage | Depends on data volume |
+| Dual writes consistent | Spot checks show no divergence between old/new storage | 24–48 hours |
+| Feature flag at target % | Flag management system shows rollout at intended percentage | Minutes to hours |
+| Metrics stable | Error rate, latency, throughput within baseline bounds | 1–7 days |
+| On-call team sign-off | Team confirms no incidents attributable to the migration goal | After observation |
+
+Async criteria typically require a human decision about when to merge. Document the verification result in the PR before approving.
+
+---
+
+## Goal Transition Criteria
+
+### Before merging Goal: New Interface
+
+**Merge criteria:**
+- New class/component/module has unit tests written (not just code)
+- All new unit tests pass
+- New code compiles and linter is clean
+- Code review of new interface approved
+- Interface design confirmed (method signatures won't need to change during redirection)
+
+**Why this matters:** Redirecting consumers to a broken or unstable interface is worse than keeping everything in the monolith. Verify the new home is solid before moving callers.
+
+### Before merging Goal: Consumer Redirection
+
+**Merge criteria:**
+- Zero remaining direct calls to old interface (verified via grep/search)
+- Integration tests pass with consumers using new interface
+- Staging deployment shows no regressions
+- Old interface methods are still present but no longer called (do not delete yet)
+
+**Why this matters:** If your refactor includes data migration goals downstream, any consumer still reading/writing via the old path will cause divergence once dual writes begin. Even without data migration, stale callers defeat the purpose of the extraction.
+
+### Before merging Goal: New Data Source
+
+**Merge criteria:**
+- New table/slice/context created and migration applied (for DB: migration ran successfully in staging)
+- New storage is empty (expected — no data yet)
+- Read and write connectivity confirmed (e.g., test writes to new table succeed)
+- No schema errors or constraint violations on empty inserts
+
+**Why this matters:** Dual writes in the next goal require the destination to exist and be writable. Validate the target before starting to write to it.
+
+### Before merging Goal: Dual Writes (async criteria)
+
+**Merge criteria (async):**
+- Dual writes have been active in production for at least 24 hours
+- Spot check: sample N rows from old storage, verify corresponding rows exist in new storage with matching values
+- No dual-write errors in logs (both writes must succeed; a failed new-write should not silently continue)
+- On-call team has reviewed and signed off
+
+**Why this matters:** Backfill relies on new writes being consistent. If dual writes have bugs (e.g., type coercion errors, missing fields), backfilled data will be wrong. Catch this early.
+
+### Before merging Goal: Backfill
+
+**Merge criteria:**
+- Row counts match: `SELECT COUNT(*) FROM old_table` equals `SELECT COUNT(*) FROM new_table`
+- Spot check: sample 100–1000 rows, verify field-by-field consistency
+- Backfill job has run to completion with no errors
+- Backfill is idempotent (re-running produces no changes)
+- For frontend: old state keys have corresponding new state entries for all active sessions
+
+**Why this matters:** Switching reads before backfill is complete means users with pre-existing data will see missing or stale data. Do not skip this merge criteria check.
+
+### Before merging Goal: New Source Authoritative (async criteria)
+
+**Merge criteria (async):**
+- Feature flag (if used) at 100% for at least the observation period
+- No errors or regressions in monitoring for the observation period (typically 24–72 hours minimum; 1 week for high-risk systems)
+- All reads confirmed going to new source (verify via logging/tracing)
+- Old source writes are no longer necessary (dual writes can be removed safely)
+- Rollback plan documented and stakeholders aware that the cleanup goal is irreversible
+
+**Why this matters:** The cleanup goal is the point of no return. Deleting old code and old storage cannot be undone without a full revert. Invest in thorough observation before merging.
+
+---
+
+## Observation Strategies
+
+Observation periods are how you build confidence during async criteria. Use a layered approach:
+
+### Logging
+
+Add structured logs at key transition points:
+
+```kotlin
+// Log which path was taken (old vs. new)
+logger.info("settings_read", mapOf("source" to "new_table", "shopId" to shopId))
+
+// Log dual write results
+logger.info("settings_dual_write", mapOf(
+    "old_success" to oldWriteResult.isSuccess,
+    "new_success" to newWriteResult.isSuccess,
+    "shop_id" to shopId
+))
+```
+
+Query logs for error rates: `source=new_table AND level=ERROR` should be zero.
+
+### Metrics Dashboards
+
+Track these metrics during observation:
+
+| Metric | What to Watch |
+|--------|--------------|
+| Error rate | Should not increase vs. baseline |
+| P50/P95/P99 latency | New storage reads should not be slower |
+| Throughput | Requests per second should not change |
+| Cache hit rate | If caching involved, should remain stable |
+| DB connection pool | New table reads should not exhaust connections |
+
+Set up alerts if any metric exceeds baseline by more than 5–10%.
+
+### Feature Flag Rollout
+
+For frontend extractions or gradual backend rollouts:
+
+1. **1% canary** — Monitor for 1–4 hours. Any errors? Stop and investigate.
+2. **10% rollout** — Monitor for 4–24 hours. Compare error rates between old and new cohorts.
+3. **50% rollout** — Monitor for 24 hours. At this point both paths have similar traffic.
+4. **100% rollout** — Begin formal observation period.
+5. **Observation period** — Hold at 100% for agreed duration before merging the cleanup goal.
+
+Flag targeting: Use user ID or shop ID for consistent assignment (not random per request).
+
+### Alerting
+
+Set up dedicated alerts for the migration:
+
+```yaml
+# Example alert (DataDog/Grafana/PagerDuty)
+name: "SettingsService migration regression"
+condition: error_rate{service=settings-service} > 0.1%
+duration: 5 minutes
+severity: critical
+runbook: "Check dual writes and new table reads"
+```
+
+Alerts should fire on both new errors (from new code path) and missing events (if old path is still being called unexpectedly after switch reads).
+
+### Spot Check Queries
+
+Run manually during observation:
+
+```sql
+-- Verify row counts match after backfill
+SELECT
+    (SELECT COUNT(*) FROM shops WHERE settings_migrated = true) AS old_count,
+    (SELECT COUNT(*) FROM shop_settings) AS new_count;
+
+-- Verify no divergence in critical fields (sample 1000 rows)
+SELECT s.id, s.theme AS old_theme, ss.theme AS new_theme
+FROM shops s
+JOIN shop_settings ss ON ss.shop_id = s.id
+WHERE s.theme != ss.theme
+LIMIT 100;
+```
+
+Zero rows in the divergence query is the merge criteria for the backfill goal.

--- a/skills/strangler-fig/references/steps-by-context.md
+++ b/skills/strangler-fig/references/steps-by-context.md
@@ -1,0 +1,353 @@
+# Steps by Context
+
+Detailed step mappings for each refactor context type. Use these as concrete examples when identifying what work each stage of a strangler fig refactor involves.
+
+> **Note:** These steps are reference examples illustrating the *kind of work* each stage requires. They do not prescribe a 1:1 mapping between steps and goals/PRs. The agent groups these into production-safe goals based on the project's actual needs — see the strangler-fig skill's Phase 3 for goal decomposition guidance.
+
+---
+
+## Backend Service Extraction
+
+### When This Applies
+- Extracting a domain concept into its own service class or module
+- The target has database persistence (reads/writes its own rows)
+- Other services or controllers call into the target
+- The extracted concept will own its own data lifecycle
+
+### Example: Extracting SettingsService from a Shop God Object
+
+A `Shop` class handles payment processing, user management, inventory, and shop settings. We extract settings into `SettingsService`.
+
+#### Step 1: Define New Interface
+
+Create `SettingsService` with the extracted responsibilities:
+
+```kotlin
+// NEW: src/main/kotlin/com/example/settings/SettingsService.kt
+class SettingsService(private val settingsRepository: SettingsRepository) {
+    fun getSettings(shopId: String): Settings
+    fun updateSettings(shopId: String, update: SettingsUpdate): Settings
+    fun resetToDefaults(shopId: String): Settings
+}
+```
+
+Also create `SettingsRepository` interface and its implementation. The service reads from `shop_settings` table (created in step 3). For now, it can delegate to `Shop` internals as a thin wrapper.
+
+**Rollback**: Delete the new files. No callers redirected yet.
+
+#### Step 2: Redirect Consumers
+
+Update all callers to use `SettingsService` instead of calling `Shop` settings methods directly:
+
+```kotlin
+// BEFORE: ShopController.kt
+val theme = shop.getTheme(shopId)
+
+// AFTER: ShopController.kt
+val theme = settingsService.getSettings(shopId).theme
+```
+
+Identify callers via `grep -r "shop\.getTheme\|shop\.updateTheme\|shop\.getSettings"`.
+
+**Rollback**: Revert caller changes. `SettingsService` can still delegate to `Shop` internals.
+
+#### Step 3: Establish New Data Source
+
+Create a dedicated `shop_settings` table:
+
+```sql
+-- V20240101__create_shop_settings.sql
+CREATE TABLE shop_settings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    shop_id UUID NOT NULL REFERENCES shops(id),
+    theme VARCHAR(50) NOT NULL DEFAULT 'default',
+    timezone VARCHAR(100) NOT NULL DEFAULT 'UTC',
+    currency VARCHAR(10) NOT NULL DEFAULT 'USD',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX idx_shop_settings_shop_id ON shop_settings(shop_id);
+```
+
+Apply migration. New table starts empty — existing data still lives in the `shops` table.
+
+**Rollback**: Roll back migration. `SettingsService` still reads from `shops` table.
+
+#### Step 4: Dual Writes
+
+Write settings changes to both `shops` table (old) and `shop_settings` table (new):
+
+```kotlin
+fun updateSettings(shopId: String, update: SettingsUpdate): Settings {
+    // Write to new source
+    val settings = settingsRepository.save(shopId, update)
+    // Write to old source (keep in sync during transition)
+    shopRepository.updateSettingsColumns(shopId, update)
+    return settings
+}
+```
+
+All writes go to both tables. Reads still come from old table until step 6.
+
+**Rollback**: Remove dual write from `SettingsService`. Reads continue from old table.
+
+#### Step 5: Backfill
+
+Migrate existing settings data from `shops` table to `shop_settings`:
+
+```kotlin
+// BackfillShopSettingsJob.kt
+fun run() {
+    shopRepository.findAllInBatches(batchSize = 500) { shops ->
+        shops.forEach { shop ->
+            if (!settingsRepository.existsByShopId(shop.id)) {
+                settingsRepository.insert(SettingsRecord.fromShop(shop))
+            }
+        }
+    }
+}
+```
+
+Run as a background job or one-time migration script. Verify row counts match: `SELECT COUNT(*) FROM shops` vs `SELECT COUNT(*) FROM shop_settings`.
+
+**Rollback**: Truncate `shop_settings`. Dual writes from step 4 remain active.
+
+#### Step 6: Switch Reads
+
+Move all reads to `shop_settings`:
+
+```kotlin
+fun getSettings(shopId: String): Settings {
+    // NOW reads from new table
+    return settingsRepository.findByShopId(shopId)
+        ?: throw SettingsNotFoundException(shopId)
+}
+```
+
+Remove the old-table read path. Keep dual writes active during observation period.
+
+**Rollback**: Revert read path back to `shops` table.
+
+#### Step 7: Remove Legacy
+
+After observation confirms new table is authoritative:
+
+1. Remove dual writes from `SettingsService`
+2. Remove settings columns from `shops` table (migration)
+3. Remove settings methods from `Shop` class
+4. Remove any remaining references to old columns
+
+```sql
+-- V20240115__remove_settings_from_shops.sql
+ALTER TABLE shops DROP COLUMN theme;
+ALTER TABLE shops DROP COLUMN timezone;
+ALTER TABLE shops DROP COLUMN currency;
+```
+
+**Rollback**: Not applicable — this is the point of no return.
+
+---
+
+## Frontend Component Extraction
+
+### When This Applies
+- Extracting UI and state from a monolithic component into a focused one
+- The extracted component has its own state (Redux slice, React context, local state)
+- No server-side database changes required
+- Feature flag can gate the new vs. old component
+
+### Example: Extracting UserSettings from a Monolithic Dashboard
+
+A `Dashboard` component renders the entire app: nav, widgets, user settings panel, and notifications. We extract user settings into a dedicated `UserSettings` component.
+
+#### Step 1: Define New Interface
+
+Create `UserSettings` component with extracted props and state:
+
+```tsx
+// NEW: src/components/UserSettings/UserSettings.tsx
+interface UserSettingsProps {
+  userId: string;
+}
+
+export const UserSettings: React.FC<UserSettingsProps> = ({ userId }) => {
+  const settings = useUserSettings(userId);
+  // Renders theme, timezone, notification preferences
+};
+```
+
+Also create `useUserSettings` hook and `userSettingsSlice` (Redux) or `UserSettingsContext`.
+
+**Rollback**: Delete the new files.
+
+#### Step 2: Redirect Consumers
+
+Replace the inline settings panel in `Dashboard` with the new component:
+
+```tsx
+// BEFORE: Dashboard.tsx — inline settings JSX
+<div className="settings-panel">
+  <ThemeSelector value={userTheme} onChange={setUserTheme} />
+  ...
+</div>
+
+// AFTER: Dashboard.tsx — delegating to extracted component
+<UserSettings userId={currentUser.id} />
+```
+
+Gate this behind a feature flag during transition.
+
+**Rollback**: Revert `Dashboard.tsx`. New component still exists but unused.
+
+#### Step 3: Establish New Data Source
+
+**Adapts for frontend**: Instead of a DB table, create a dedicated Redux slice or React context:
+
+```ts
+// NEW: src/store/userSettingsSlice.ts
+const userSettingsSlice = createSlice({
+  name: 'userSettings',
+  initialState: { theme: 'light', timezone: 'UTC' },
+  reducers: {
+    setTheme: (state, action) => { state.theme = action.payload; },
+    setTimezone: (state, action) => { state.timezone = action.payload; }
+  }
+});
+```
+
+Register slice in Redux store. Old state still lives in general `userSlice`.
+
+**Rollback**: Remove slice from store.
+
+#### Step 4: Dual Writes
+
+**Adapts for frontend**: Use a feature flag to toggle which state store is the write target, or write to both slices temporarily:
+
+```ts
+// Middleware or action creator
+function updateTheme(theme: string) {
+  return (dispatch: AppDispatch) => {
+    dispatch(userSettingsSlice.actions.setTheme(theme)); // new
+    dispatch(userSlice.actions.setTheme(theme));         // old (keep in sync)
+  };
+}
+```
+
+**Rollback**: Remove dual dispatch, revert to single dispatch to old slice.
+
+#### Step 5: Backfill
+
+**Adapts for frontend**: Migrate existing state from old slice to new slice on app init:
+
+```ts
+// In store setup or app initialization
+const existingTheme = store.getState().user.theme;
+if (existingTheme && !store.getState().userSettings.theme) {
+  store.dispatch(userSettingsSlice.actions.setTheme(existingTheme));
+}
+```
+
+For persisted state (localStorage, sessionStorage), migrate keys:
+
+```ts
+const legacySettings = localStorage.getItem('user_settings');
+if (legacySettings) {
+  localStorage.setItem('userSettings', legacySettings);
+  // Keep old key during observation
+}
+```
+
+**Rollback**: Remove migration logic.
+
+#### Step 6: Switch Reads
+
+Update `useUserSettings` to read exclusively from new slice:
+
+```ts
+// BEFORE: reads from userSlice
+const theme = useSelector(state => state.user.theme);
+
+// AFTER: reads from userSettingsSlice
+const theme = useSelector(state => state.userSettings.theme);
+```
+
+Roll out via feature flag — 10% → 50% → 100%.
+
+**Rollback**: Revert selector, keep both slices active.
+
+#### Step 7: Remove Legacy
+
+After observation at 100% feature flag:
+
+1. Remove settings state from `userSlice`
+2. Remove dual writes
+3. Remove old selectors
+4. Remove feature flag
+5. Remove old inline settings JSX from `Dashboard`
+6. Clean up legacy localStorage keys
+
+---
+
+## Pure Code Extraction
+
+### When This Applies
+- Extracting logic into a new class, module, or utility — no persistent state involved
+- The target is a function, validation logic, calculation engine, or transformer
+- No database tables, no state stores, no external services
+- Only steps 1, 2, and 7 apply
+
+### Example: Extracting a Validation Module from a Controller
+
+An `OrderController` has grown to 800 lines, with 300 lines of inline validation logic mixed with HTTP handling. We extract validation into `OrderValidationService`.
+
+#### Step 1: Define New Interface
+
+Create `OrderValidationService` with all extracted validation methods:
+
+```kotlin
+// NEW: src/main/kotlin/com/example/orders/OrderValidationService.kt
+class OrderValidationService {
+    fun validateCreateOrder(request: CreateOrderRequest): ValidationResult
+    fun validateUpdateOrder(orderId: String, request: UpdateOrderRequest): ValidationResult
+    fun validateLineItems(items: List<LineItem>): ValidationResult
+}
+```
+
+Initially, move the validation logic verbatim. Do not change the logic during extraction — that comes after.
+
+**Rollback**: Delete the new file.
+
+#### Step 2: Redirect Consumers
+
+Update `OrderController` (and any other callers) to delegate to `OrderValidationService`:
+
+```kotlin
+// BEFORE: OrderController.kt — inline validation
+if (request.items.isEmpty()) {
+    throw BadRequestException("Order must have at least one item")
+}
+if (request.items.any { it.quantity <= 0 }) {
+    throw BadRequestException("Item quantity must be positive")
+}
+
+// AFTER: OrderController.kt — delegated
+val validation = orderValidationService.validateCreateOrder(request)
+if (!validation.isValid) throw BadRequestException(validation.errorMessage)
+```
+
+**Rollback**: Inline the validation back into the controller.
+
+#### Steps 3-6: N/A
+
+No persistent state involved. No database, no state store, no dual writes, no backfill, no read switching.
+
+#### Step 7: Remove Legacy
+
+Remove the old inline validation code from `OrderController`:
+
+1. Delete the inlined validation blocks from controller methods
+2. Remove any validation helper methods that were on the controller
+3. Run tests to confirm nothing broken
+4. If any other classes had similar inline validation, update them too
+
+After step 7, the controller is significantly smaller and `OrderValidationService` owns all order validation logic.


### PR DESCRIPTION
## Summary
- add a repo-tracked native Codex `skills/` pack generated from the existing plugin source
- add `cmd/gencodexskills` plus a snapshot drift test so Claude and Codex workflows stay in sync
- document Codex support, install, update, and single-source authoring rules in the README and plugin docs

## Testing
- `go test . -run 'TestCodexSkillFiles|TestTrackedCodexSkillsSnapshot|TestPluginVersion'`
- `go build -o /tmp/belayer-pr-author ./cmd/belayer`
- `go test ./...` ❌ fails in `internal/cli` at `TestRootCommandIncludesExplorer` with `unknown command "explorer" for "belayer"`
