### PR TITLE
docs: sync documentation for v5 direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,11 @@ Neither changes how work happens inside a repo.
 
 ## Frameworks
 
-A framework is a directory with `pipeline.yaml` + scripts. Belayer ships `claude-tmux` as the first built-in:
+A framework is a directory with `pipeline.yaml` + scripts. Belayer ships two built-in frameworks:
 
 ```bash
-belayer setup --framework claude-tmux        # built-in
+belayer setup --framework claude-tmux        # interactive tmux sessions
+belayer setup --framework gstack             # headless: claude implements, codex reviews
 belayer setup --framework ./my-framework     # custom
 ```
 
@@ -163,19 +164,10 @@ go test ./...
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the code map and [docs/DESIGN.md](docs/DESIGN.md) for design patterns.
 
-## Claude Code Plugins
+## Companion Tools
 
-This repo ships three Claude Code plugins:
-
-- **harness** — 3-tier documentation system with living execution plans
-- **pr** — Pull request lifecycle management
-- **explorer** — Submit specs into the belayer pipeline
-
-Install in other projects:
-```bash
-claude plugin add donovan-yohan/belayer --path plugins/harness
-claude plugin add donovan-yohan/belayer --path plugins/pr
-```
+- **[carabiner](https://github.com/donovan-yohan/carabiner)** — Agent-agnostic harness for quality patterns and domain knowledge
+- **gstack** — vendored in `.claude/skills/gstack/`, provides /review, /ship, /office-hours, and 25+ other skills
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,6 +84,7 @@ Belayer uses climbing metaphors and a three-phase model:
 | Temporal | `internal/temporal/` | ClimbWorkflow, NodeActivity (spawn + heartbeat + poll completion + node-context.json) |
 | Intake | `internal/intake/` | Intake adapter interface, SubmitSpec, bridge function, Jira adapter, schedule reconciliation |
 | Plugins | `internal/plugins/` | Claude Code marketplace registration: writes to `~/.claude/plugins/` registry files during `belayer init`, Codex skill generation |
+| Vendor | `internal/vendor/` | Agent CLI resolution: vendor registry, command builder, %{VAR} interpolation, gate schema generation |
 | Frameworks | `frameworks/` | Built-in framework templates (embed.FS), Install/List/EnsureInternalDir |
 
 ## Data Flow
@@ -126,6 +127,9 @@ Belayer uses an Activity-per-Node model. Each pipeline node is a Temporal Activi
 ### Key Concepts
 
 - **Two pipeline primitives**: Nodes (constructive — produce artifacts) and Gates (adversarial — evaluate artifacts with multi-dimensional scoring)
+- **Agent nodes**: Pipeline nodes with `type: agent` + `vendor` + `prompt`. Belayer resolves the vendor to a CLI command (claude -p, codex exec) with structured output schema for gate nodes. No shell scripts needed.
+- **Vendor resolution**: `internal/vendor/` maps vendor names to CLI invocations. Claude uses `--json-schema` (inline), Codex uses `--output-schema` (temp file). Gate nodes auto-generate JSON Schema from YAML dimensions.
+- **%{VAR} interpolation**: Belayer variables use `%{INPUT}`, `%{WORK_DIR}` syntax to avoid clashing with shell `$VAR` and agent skill invocations like `$review`.
 - **Activity Per Node**: Each pipeline node/gate = one Temporal Activity. Simplest model.
 - **File-based completion**: Node commands write `.belayer/.internal/completion/<id>-<node>-attempt-<N>.json` when done (via `belayer node-complete` or directly)
 - **Node protocol**: `NodeActivity` writes `.belayer/.internal/input/node-context.json` before spawning. The framework command reads it for context.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -26,6 +26,27 @@ Core writes `.belayer/.internal/input/node-context.json` before spawning. Framew
 
 Gate nodes produce structured scores per dimension. Deterministic Go code computes weighted average. YAML thresholds route PASS/RETRY/FAIL. The rationale.md is mandatory as an anti-gaming measure -- no score without explanation.
 
+## Agent Nodes
+
+Agent nodes (`type: agent`) replace shell scripts with vendor + prompt in YAML. Belayer resolves the vendor to the right CLI command. `command:` still works for custom scripts.
+
+```yaml
+- name: implement
+  type: agent
+  vendor: claude
+  prompt: "Implement the design specification at %{INPUT}"
+```
+
+Vendor map: `claude` → `claude -p --dangerously-skip-permissions --output-format stream-json`, `codex` → `codex exec -s read-only --json`. Gate nodes auto-append `--json-schema` (claude) or `--output-schema` (codex) with dimensions from the YAML.
+
+## Two Contracts
+
+Belayer's only opinions about workflow:
+- **Trigger contract** (Intake → Implementation): framework script validates "is this artifact ready to build?"
+- **Ready-to-ship contract** (Implementation → Output): implementation declares "ready to ship"
+
+Both are shell scripts returning exit 0 (ready) or exit 1 (not ready). What "ready" means is the framework's decision.
+
 ## Validation Pipeline
 
 Validation flows through four layers. See [review-loops-test-infra-design](design-docs/2026-03-16-review-loops-test-infra-design.md) for full design.

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -2,6 +2,7 @@
 
 ## Current Designs
 
+- [2026-03-29-quality-learning-loop-claude-codex-design](2026-03-29-quality-learning-loop-claude-codex-design.md) — Quality learning loop + claude-codex framework: carabiner quality patterns, agent nodes, gate-failure flywheel (2026-03-29)
 - [2026-03-25-three-phase-architecture-design](2026-03-25-three-phase-architecture-design.md) — Three-phase architecture: Explore/Climb/Summit, multi-repo setter/spotter, config hierarchy (2026-03-25)
 
 ## Archived
@@ -33,6 +34,7 @@
 
 ### Superseded
 
+- [2026-03-29-adversarial-review-system-design](2026-03-29-adversarial-review-system-design.md) — Validate/Review split + blinded protocol for harness plugin (2026-03-29, superseded by carabiner separation)
 - [2026-03-09-manage-session-context](2026-03-09-manage-session-context.md) — Manage session context design (historical draft) (2026-03-09)
 - [2026-03-09-mail-system-design](2026-03-09-mail-system-design.md) — Beads-backed inter-agent mail system with tmux send-keys delivery (2026-03-09)
 - [2026-03-07-belayer-manage-design](2026-03-07-belayer-manage-design.md) — Goal 5: Belayer manage — interactive agent session for task creation (2026-03-07)


### PR DESCRIPTION
## Summary

Sync project documentation to reflect the v5 architectural direction from the Slate analysis session (2026-03-29/30).

- **ARCHITECTURE.md**: Added `internal/vendor/` to code map. Added agent nodes, vendor resolution, and `%{VAR}` interpolation to pipeline engine key concepts.
- **DESIGN.md**: Added Agent Nodes section (vendor + prompt in YAML, vendor map) and Two Contracts section (trigger + ready-to-ship).
- **README.md**: Added gstack framework to setup options. Replaced "Claude Code Plugins" with "Companion Tools" listing carabiner and gstack.
- **design-docs/index.md**: Added quality learning loop and adversarial review system design docs.

## Context

This is doc cleanup following the v5 direction changes that landed on master:
- Agent node type with vendor resolution (`internal/vendor/`)
- gstack framework (`frameworks/gstack/`)
- PR review trimmed to 3 agents
- Philosophy doc with three-role separation
- Carabiner split as separate harness repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)