### PR TITLE
feat: intake DX — Pipeline: ready signal, Temporal auto-start, belayer submit CLI

### DIFF
--- a/frameworks/gstack/README.md
+++ b/frameworks/gstack/README.md
@@ -113,3 +113,16 @@ Any agent with gstack skills can fill any role.
 ```bash
 belayer setup --framework gstack
 ```
+
+## Intake
+
+The intake trigger (`check-ready.sh`) looks for design docs with **both** fields:
+
+```
+Status: APPROVED
+Pipeline: ready
+```
+
+`Status: APPROVED` means "I like this design." `Pipeline: ready` means "build it now." The poller requires both. Old approved docs without `Pipeline: ready` are ignored.
+
+To submit manually without the poller: `belayer submit --file <design-doc>`

--- a/frameworks/gstack/scripts/check-ready.sh
+++ b/frameworks/gstack/scripts/check-ready.sh
@@ -20,7 +20,7 @@ CONSUMED_FILE="$PROJECTS_DIR/.consumed"
 
 # Find most recent APPROVED design doc not yet consumed
 for doc in $(ls -t "$PROJECTS_DIR"/*-design-*.md 2>/dev/null); do
-  if grep -q "^Status: APPROVED" "$doc" 2>/dev/null; then
+  if grep -q "^Status: APPROVED" "$doc" 2>/dev/null && grep -q "^Pipeline: ready" "$doc" 2>/dev/null; then
     BASENAME=$(basename "$doc")
     if ! grep -qF "$BASENAME" "$CONSUMED_FILE" 2>/dev/null; then
       # Output the artifact path. Consumption is owned by the caller (belayer poller).

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -28,6 +28,7 @@ Getting started:
 		newWorkerCmd(),
 		newStartCmd(),
 		newSetupCmd(),
+		newSubmitCmd(),
 	)
 
 	return cmd

--- a/internal/cli/submit.go
+++ b/internal/cli/submit.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func newSubmitCmd() *cobra.Command {
+	var fileFlag, promptFlag string
+
+	cmd := &cobra.Command{
+		Use:   "submit [description]",
+		Short: "Submit a design doc or prompt to the pipeline",
+		Long: `Submit work to the belayer pipeline for autonomous execution.
+
+The worker must be running (belayer worker). This command sends the
+spec to the worker's HTTP API which starts a Climb workflow.
+
+Examples:
+  belayer submit --file design.md          # submit a design doc
+  belayer submit --prompt "Add auth"       # submit a text prompt
+  belayer submit "Implement feature X"     # positional args`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var spec string
+			var designFile string
+
+			if fileFlag != "" {
+				data, err := os.ReadFile(fileFlag)
+				if err != nil {
+					return fmt.Errorf("read file %q: %w", fileFlag, err)
+				}
+				spec = strings.TrimSpace(string(data))
+				designFile = fileFlag
+			} else if promptFlag != "" {
+				spec = promptFlag
+			} else if len(args) > 0 {
+				spec = strings.Join(args, " ")
+			} else {
+				return fmt.Errorf("provide --file, --prompt, or positional args")
+			}
+
+			if spec == "" {
+				return fmt.Errorf("spec is empty")
+			}
+
+			payload := map[string]interface{}{
+				"spec":   spec,
+				"source": "submit",
+			}
+			if designFile != "" {
+				payload["metadata"] = map[string]string{"design_file": designFile}
+			}
+			body, err := json.Marshal(payload)
+			if err != nil {
+				return fmt.Errorf("marshal request: %w", err)
+			}
+
+			httpClient := &http.Client{Timeout: 5 * time.Second}
+			resp, err := httpClient.Post(
+				fmt.Sprintf("http://127.0.0.1:%d/start", workerHTTPPort),
+				"application/json",
+				bytes.NewReader(body),
+			)
+			if err != nil {
+				return fmt.Errorf("belayer worker is not running. Start it with: belayer worker")
+			}
+			defer resp.Body.Close()
+
+			respBody, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("worker error (%d): %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+			}
+
+			var result map[string]string
+			if err := json.Unmarshal(respBody, &result); err != nil {
+				fmt.Printf("Pipeline started. Response: %s\n", respBody)
+				return nil
+			}
+
+			fmt.Printf("Pipeline started: workflow=%s\n", result["workflow_id"])
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fileFlag, "file", "", "Design doc file path")
+	cmd.Flags().StringVar(&promptFlag, "prompt", "", "Text prompt as pipeline input")
+
+	return cmd
+}

--- a/internal/cli/submit.go
+++ b/internal/cli/submit.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/donovan-yohan/belayer/internal/intake"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -51,12 +53,12 @@ Examples:
 				return fmt.Errorf("spec is empty")
 			}
 
-			payload := map[string]interface{}{
-				"spec":   spec,
-				"source": "submit",
+			payload := intake.SubmitSpec{
+				Spec:   spec,
+				Source: "submit",
 			}
 			if designFile != "" {
-				payload["metadata"] = map[string]string{"design_file": designFile}
+				payload.Metadata = map[string]string{"design_file": designFile}
 			}
 			body, err := json.Marshal(payload)
 			if err != nil {
@@ -70,7 +72,7 @@ Examples:
 				bytes.NewReader(body),
 			)
 			if err != nil {
-				return fmt.Errorf("belayer worker is not running. Start it with: belayer worker")
+				return fmt.Errorf("belayer worker is not running. Start it with: belayer worker\n  (cause: %w)", err)
 			}
 			defer resp.Body.Close()
 

--- a/internal/cli/submit.go
+++ b/internal/cli/submit.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -53,9 +55,15 @@ Examples:
 				return fmt.Errorf("spec is empty")
 			}
 
+			// Generate a stable ExternalID from spec content hash so retries
+			// produce the same workflow ID (Temporal deduplicates).
+			hash := sha256.Sum256([]byte(spec))
+			externalID := "submit-" + hex.EncodeToString(hash[:8])
+
 			payload := intake.SubmitSpec{
-				Spec:   spec,
-				Source: "submit",
+				Spec:       spec,
+				Source:     "submit",
+				ExternalID: externalID,
 			}
 			if designFile != "" {
 				payload.Metadata = map[string]string{"design_file": designFile}

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -127,10 +127,37 @@ func cleanupWorktree(ctx context.Context, repoDir, worktreeDir, branch string) {
 	}
 }
 
+// temporalProcess bundles the child process and its log file for coordinated cleanup.
+type temporalProcess struct {
+	cmd     *exec.Cmd
+	logFile *os.File
+}
+
+// shutdown gracefully stops the Temporal dev server: SIGINT, wait with timeout, kill if needed.
+func (tp *temporalProcess) shutdown() {
+	if tp == nil || tp.cmd == nil || tp.cmd.Process == nil {
+		return
+	}
+	_ = tp.cmd.Process.Signal(os.Interrupt)
+	done := make(chan error, 1)
+	go func() { done <- tp.cmd.Wait() }()
+	select {
+	case <-time.After(5 * time.Second):
+		_ = tp.cmd.Process.Kill()
+		<-done // reap after kill
+	case <-done:
+	}
+	if tp.logFile != nil {
+		tp.logFile.Close()
+	}
+}
+
 // ensureTemporal checks if Temporal is running and starts it if not.
-// Returns the child process (for cleanup) or nil if Temporal was already running.
-func ensureTemporal(workDir string) (*exec.Cmd, error) {
-	conn, err := net.DialTimeout("tcp", "127.0.0.1:7233", 2*time.Second)
+// Returns a temporalProcess for cleanup, or nil if Temporal was already running.
+func ensureTemporal(workDir string) (*temporalProcess, error) {
+	// Probe localhost (not 127.0.0.1) to match the SDK's default dial target,
+	// which may resolve to IPv6 ::1 on some systems.
+	conn, err := net.DialTimeout("tcp", "localhost:7233", 2*time.Second)
 	if err == nil {
 		conn.Close()
 		return nil, nil // already running
@@ -158,12 +185,15 @@ func ensureTemporal(workDir string) (*exec.Cmd, error) {
 
 	for i := 0; i < 30; i++ {
 		time.Sleep(500 * time.Millisecond)
-		if conn, err := net.DialTimeout("tcp", "127.0.0.1:7233", 500*time.Millisecond); err == nil {
+		if conn, err := net.DialTimeout("tcp", "localhost:7233", 500*time.Millisecond); err == nil {
 			conn.Close()
-			return cmd, nil
+			return &temporalProcess{cmd: cmd, logFile: logFile}, nil
 		}
 	}
-	cmd.Process.Kill()
+	// Timeout: kill, reap, close log.
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+	logFile.Close()
 	return nil, fmt.Errorf("Temporal failed to start within 15s. Check %s/temporal.log", logDir)
 }
 
@@ -177,12 +207,12 @@ func runWorker(workDir string) error {
 	}
 
 	// Auto-start Temporal if not running.
-	temporalCmd, err := ensureTemporal(workDir)
+	tp, err := ensureTemporal(workDir)
 	if err != nil {
 		return err
 	}
-	if temporalCmd != nil {
-		defer temporalCmd.Process.Signal(os.Interrupt)
+	if tp != nil {
+		defer tp.shutdown()
 		fmt.Println("Started Temporal dev server (auto)")
 	}
 

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -13,6 +14,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"
@@ -124,6 +127,46 @@ func cleanupWorktree(ctx context.Context, repoDir, worktreeDir, branch string) {
 	}
 }
 
+// ensureTemporal checks if Temporal is running and starts it if not.
+// Returns the child process (for cleanup) or nil if Temporal was already running.
+func ensureTemporal(workDir string) (*exec.Cmd, error) {
+	conn, err := net.DialTimeout("tcp", "127.0.0.1:7233", 2*time.Second)
+	if err == nil {
+		conn.Close()
+		return nil, nil // already running
+	}
+
+	temporalPath, err := exec.LookPath("temporal")
+	if err != nil {
+		return nil, fmt.Errorf("Temporal CLI not found.\n  Install: brew install temporal\n  Or: https://docs.temporal.io/cli")
+	}
+
+	logDir := filepath.Join(workDir, ".belayer", ".internal")
+	os.MkdirAll(logDir, 0o755)
+	logFile, err := os.Create(filepath.Join(logDir, "temporal.log"))
+	if err != nil {
+		return nil, fmt.Errorf("create temporal log: %w", err)
+	}
+
+	cmd := exec.Command(temporalPath, "server", "start-dev")
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		return nil, fmt.Errorf("start Temporal: %w", err)
+	}
+
+	for i := 0; i < 30; i++ {
+		time.Sleep(500 * time.Millisecond)
+		if conn, err := net.DialTimeout("tcp", "127.0.0.1:7233", 500*time.Millisecond); err == nil {
+			conn.Close()
+			return cmd, nil
+		}
+	}
+	cmd.Process.Kill()
+	return nil, fmt.Errorf("Temporal failed to start within 15s. Check %s/temporal.log", logDir)
+}
+
 func runWorker(workDir string) error {
 	if workDir == "" {
 		var err error
@@ -133,11 +176,24 @@ func runWorker(workDir string) error {
 		}
 	}
 
+	// Auto-start Temporal if not running.
+	temporalCmd, err := ensureTemporal(workDir)
+	if err != nil {
+		return err
+	}
+	if temporalCmd != nil {
+		defer temporalCmd.Process.Signal(os.Interrupt)
+		fmt.Println("Started Temporal dev server (auto)")
+	}
+
 	c, err := client.Dial(client.Options{})
 	if err != nil {
-		return fmt.Errorf("cannot connect to Temporal. Run 'belayer temporal start' first.\n\nError: %w", err)
+		return fmt.Errorf("cannot connect to Temporal: %w", err)
 	}
 	defer c.Close()
+
+	// Register search attributes for Temporal Web UI observability (best-effort).
+	registerSearchAttributes(c)
 
 	// Wire real providers into the activities.
 	spawner := &session.ExecSpawner{}
@@ -387,4 +443,23 @@ func markConsumed(artifactPath string) {
 	}
 	defer f.Close()
 	fmt.Fprintln(f, basename)
+}
+
+// registerSearchAttributes registers custom search attributes with the Temporal
+// dev server for Web UI observability. Best-effort: silently skips on error
+// (attribute may already exist, or server doesn't support the operator API).
+func registerSearchAttributes(c client.Client) {
+	// Skip for non-localhost Temporal (Cloud requires UI-based registration).
+	addr := os.Getenv("TEMPORAL_ADDRESS")
+	if addr != "" && !strings.Contains(addr, "localhost") && !strings.Contains(addr, "127.0.0.1") {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _ = c.OperatorService().AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
+		Namespace: "default",
+		SearchAttributes: map[string]enumspb.IndexedValueType{
+			"CurrentNode": enumspb.INDEXED_VALUE_TYPE_TEXT,
+		},
+	})
 }

--- a/internal/intake/bridge.go
+++ b/internal/intake/bridge.go
@@ -1,14 +1,12 @@
 package intake
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
-	"time"
-	"unicode"
 
 	"github.com/donovan-yohan/belayer/internal/pipeline"
 )
@@ -60,51 +58,29 @@ func CreateGitWorktree(repoDir, worktreeDir, branch string) error {
 	return nil
 }
 
-// GenerateBranchSlug uses claude -p haiku to create a short branch-friendly slug
-// from the description. Falls back to "impl" if claude is unavailable or slow.
+// slugPattern splits on non-alphanumeric characters for branch slug generation.
+var slugPattern = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// GenerateBranchSlug creates a short branch-friendly slug from the description.
+// Uses first 4 meaningful words (3+ chars), kebab-case, max 40 chars.
 func GenerateBranchSlug(description string) string {
-	// Truncate input to keep the prompt small.
-	input := description
-	if len(input) > 500 {
-		input = input[:500]
-	}
-
-	prompt := fmt.Sprintf(`Generate a short git branch name slug (2-4 words, kebab-case, lowercase, no special characters) that summarizes this work. Output ONLY the slug, nothing else.
-
-%s`, input)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "claude", "-p", "--model", "haiku", prompt)
-	out, err := cmd.Output()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: branch slug generation failed (falling back to \"impl\"): %v\n", err)
-		return "impl"
-	}
-
-	slug := strings.TrimSpace(string(out))
-	// Sanitize: only allow lowercase alphanumeric and hyphens.
-	var sanitized strings.Builder
-	for _, r := range slug {
-		switch {
-		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-':
-			sanitized.WriteRune(r)
-		case unicode.IsUpper(r):
-			sanitized.WriteRune(unicode.ToLower(r))
-		case r == ' ' || r == '_':
-			sanitized.WriteRune('-')
+	words := slugPattern.Split(strings.ToLower(description), -1)
+	var meaningful []string
+	for _, w := range words {
+		if len(w) >= 3 {
+			meaningful = append(meaningful, w)
+		}
+		if len(meaningful) == 4 {
+			break
 		}
 	}
-	result := sanitized.String()
-	result = strings.Trim(result, "-")
-	if result == "" {
+	if len(meaningful) == 0 {
 		return "impl"
 	}
-	// Cap length.
-	if len(result) > 40 {
-		result = result[:40]
-		result = strings.TrimRight(result, "-")
+	slug := strings.Join(meaningful, "-")
+	if len(slug) > 40 {
+		slug = slug[:40]
+		slug = strings.TrimRight(slug, "-")
 	}
-	return result
+	return slug
 }

--- a/internal/intake/bridge_test.go
+++ b/internal/intake/bridge_test.go
@@ -24,6 +24,44 @@ func TestGenerateWorkflowID_DifferentInputs(t *testing.T) {
 	}
 }
 
+func TestGenerateBranchSlug_Normal(t *testing.T) {
+	got := intake.GenerateBranchSlug("Implement user authentication system")
+	if got != "implement-user-authentication-system" {
+		t.Errorf("got %q, want 'implement-user-authentication-system'", got)
+	}
+}
+
+func TestGenerateBranchSlug_Short(t *testing.T) {
+	got := intake.GenerateBranchSlug("Fix bug")
+	if got != "fix-bug" {
+		t.Errorf("got %q, want 'fix-bug'", got)
+	}
+}
+
+func TestGenerateBranchSlug_Empty(t *testing.T) {
+	got := intake.GenerateBranchSlug("")
+	if got != "impl" {
+		t.Errorf("got %q, want 'impl'", got)
+	}
+}
+
+func TestGenerateBranchSlug_SpecialChars(t *testing.T) {
+	got := intake.GenerateBranchSlug("Add $review + %{INPUT} support!")
+	if got != "add-review-input-support" {
+		t.Errorf("got %q, want 'add-review-input-support'", got)
+	}
+}
+
+func TestGenerateBranchSlug_Long(t *testing.T) {
+	got := intake.GenerateBranchSlug("implement the extremely long feature description that goes on and on")
+	if len(got) > 40 {
+		t.Errorf("slug too long: %d chars, max 40", len(got))
+	}
+	if got[len(got)-1] == '-' {
+		t.Error("slug should not end with a hyphen")
+	}
+}
+
 func TestResolvePipelineYAML_NoPipeline(t *testing.T) {
 	// Use a temp directory with no pipeline YAML files — should return an error.
 	dir, err := os.MkdirTemp("", "belayer-intake-test-*")

--- a/internal/temporal/workflow.go
+++ b/internal/temporal/workflow.go
@@ -83,13 +83,6 @@ func ClimbWorkflow(ctx workflow.Context, input model.ClimbInput) (*model.ClimbOu
 		currentNode = node.Name
 		currentAttempt = retryCount[node.Name]
 
-		// Set search attributes for Temporal Web UI visibility.
-		if err := workflow.UpsertSearchAttributes(ctx, map[string]interface{}{
-			"CurrentNode": node.Name,
-		}); err != nil {
-			workflow.GetLogger(ctx).Warn("search attributes not registered (non-fatal)", "error", err)
-		}
-
 		actInput := NodeActivityInput{
 			Node:      node,
 			TaskID:    workflow.GetInfo(ctx).WorkflowExecution.ID,


### PR DESCRIPTION
## Summary

Fixes three DX problems discovered during the first real pipeline test, plus adds DX improvements for seamless setup.

**Bug Fixes**
- Removed `UpsertSearchAttributes` from workflow.go — was crashing workflows when the search attribute wasn't registered on the Temporal server. Query handler and structured heartbeats provide sufficient observability.
- Replaced LLM-based branch slug generation (`claude -p --model haiku`, 10s timeout, `signal: killed` on every trigger) with a local regex-based slugifier. Instant, no external dependencies.

**Intake DX**
- `check-ready.sh` now requires both `Status: APPROVED` AND `Pipeline: ready` fields. Separates "I like this design" from "build it automatically." Old approved docs without `Pipeline: ready` are ignored by the poller.
- New `belayer submit` CLI command for manual pipeline intake. POSTs to the worker HTTP API. Clear error if worker isn't running.

**Temporal DX**
- `belayer worker` auto-starts the Temporal dev server if nothing is listening on port 7233. Finds `temporal` CLI via `LookPath`, starts as child process with log capture to `.belayer/.internal/temporal.log`. Cleans up on Ctrl+C.
- Registers `CurrentNode` search attribute via Temporal `OperatorService` on startup (best-effort, skips for non-localhost Temporal).

## Pre-Landing Review
No issues found.

## Test plan
- [x] All Go tests pass (15 packages, 0 failures)
- [x] Build clean (`go build ./...`)
- [x] 5 new tests for GenerateBranchSlug (normal, short, empty, special chars, long)

🤖 Generated with [Claude Code](https://claude.com/claude-code)