### PR TITLE
feat: agentic route nodes with subpipeline isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Standalone Go CLI that orchestrates autonomous coding agents through declarative
 | Learnings | `docs/LEARNINGS.md` | Past learnings, corrections, patterns discovered across sessions |
 | Design Docs | `docs/design-docs/` | Feature brainstorm outputs and design decisions |
 | ADRs | `docs/adrs/` | Architecture decision records |
+| Pipeline Reference | `docs/PIPELINE_REFERENCE.md` | Full YAML schema, node types, gate/router config, validation rules |
 | TODOs | `docs/TODOS.md` | Deferred items, P2/P3 backlog, tech debt tracker |
 | Review Guidance | `docs/REVIEW_GUIDANCE.md` | Adversarial review config, deployment context, question bank |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Standalone Go CLI that orchestrates autonomous coding agents through declarative
 - **Node protocol**: Core writes `node-context.json` before spawning. Framework commands read it for context. Commands write completion files when done.
 - **ExecSpawner**: Core spawner execs `command:` from YAML via `sh -c`. Returns exit channel for fast-fail. Context-aware (kills process on cancellation).
 - **Score-then-route**: Gate nodes produce structured scores; Go code computes weighted average; YAML thresholds route PASS/RETRY/FAIL. Anti-gaming by design.
+- **Route nodes**: Nodes with `routes:` declare N-way agentic branching. LLM picks from enum of declared route names. Each route runs as Temporal child workflow. Decision artifact captures choice, confidence, reasoning, rejected alternatives.
 - **Three-phase model**: Explore (intake — idea to spec) → Climb (implementation — agent does the work) → Summit (output — review, gates, PR). Belayer is orchestration-only.
 - **New output types**: Adding a pipeline output type requires updates in: `validate.go` (validOutputTypes map), `model.go` (OutputConfig comment), and `outcome/detect.go` (typeDefault switch). Missing `detect.go` causes silent false-positive outcomes.
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,15 @@ belayer climb "add auth"
     │   ├── Writes .belayer/.internal/input/node-context.json
     │   ├── Execs the node's command (from pipeline YAML)
     │   ├── Polls for .belayer/.internal/completion/<id>.json
-    │   └── Routes to next node (on_pass / on_retry / on_fail)
+    │   ├── Routes to next node (on_pass / on_retry / on_fail)
+    │   └── Router nodes → dispatch chosen route as child workflow
     │
     └── Pipeline complete → branch with commits ready for PR
 ```
 
 ## Pipeline YAML
 
-Pipelines define nodes (constructive steps) and gates (adversarial quality checks):
+Pipelines define nodes (constructive steps), gates (adversarial quality checks), and routers (agentic N-way branching):
 
 ```yaml
 name: my-pipeline
@@ -138,6 +139,7 @@ The `claude-tmux` framework handles this via a Claude Code Stop hook that calls 
 | **You own your nodes** — bring your own implementations | Platform owns your agents |
 | **Multi-repo as additive layer** — same per-repo pipeline | Multi-repo as an agent feature |
 | **Score-then-route gates** — deterministic quality scoring | Trust the agent's self-assessment |
+| **Route nodes** — LLM-driven N-way branching with subpipeline isolation | Static workflow paths |
 
 ## CLI
 
@@ -162,7 +164,7 @@ go build -o belayer ./cmd/belayer
 go test ./...
 ```
 
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the code map and [docs/DESIGN.md](docs/DESIGN.md) for design patterns.
+See [docs/PIPELINE_REFERENCE.md](docs/PIPELINE_REFERENCE.md) for the full YAML schema, [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the code map, and [docs/DESIGN.md](docs/DESIGN.md) for design patterns.
 
 ## Companion Tools
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,6 +78,7 @@ Belayer uses climbing metaphors and a three-phase model:
 | Model | `internal/model/` | Domain types: NodeOutcome, CompletionResult, ClimbInput/Output |
 | Pipeline | `internal/pipeline/` | YAML parser, validator, visualizer, pipeline config model |
 | Gate | `internal/gate/` | Gate result parsing, weighted scoring, threshold routing, prompt builder |
+| Route | `internal/route/` | Route result parsing/validation, route prompt builder for N-way agentic branching |
 | Events | `internal/events/` | JSONL event logger for pipeline observability (node + gate events) |
 | Outcome | `internal/outcome/` | Outcome detection: verdict.txt > output file first line > type default |
 | Session | `internal/session/` | ExecSpawner (generic command exec), path helpers for `.belayer/.internal/`, SpawnOpts |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,9 +126,10 @@ Belayer uses an Activity-per-Node model. Each pipeline node is a Temporal Activi
 
 ### Key Concepts
 
-- **Two pipeline primitives**: Nodes (constructive — produce artifacts) and Gates (adversarial — evaluate artifacts with multi-dimensional scoring)
+- **Three pipeline primitives**: Nodes (constructive — produce artifacts), Gates (adversarial — evaluate artifacts with multi-dimensional scoring), and Routers (agentic N-way branching — LLM picks one of N declared paths, each running as an isolated Temporal child workflow)
 - **Agent nodes**: Pipeline nodes with `type: agent` + `vendor` + `prompt`. Belayer resolves the vendor to a CLI command (claude -p, codex exec) with structured output schema for gate nodes. No shell scripts needed.
-- **Vendor resolution**: `internal/vendor/` maps vendor names to CLI invocations. Claude uses `--json-schema` (inline), Codex uses `--output-schema` (temp file). Gate nodes auto-generate JSON Schema from YAML dimensions.
+- **Vendor resolution**: `internal/vendor/` maps vendor names to CLI invocations. Claude uses `--json-schema` (inline), Codex uses `--output-schema` (temp file). Gate nodes auto-generate JSON Schema from YAML dimensions. Router nodes auto-generate JSON Schema with enum constraint on route names.
+- **Route nodes**: Nodes with a `routes:` field declare N-way agentic routing. The LLM picks from an enum of declared route names. Each route points to a subpipeline YAML in `.belayer/pipelines/`. The chosen route runs as a Temporal child workflow with its own retry counters and completion semantics. Route decisions produce a structured artifact (`route-result.json`) with choice, confidence, reasoning, and rejected alternatives.
 - **%{VAR} interpolation**: Belayer variables use `%{INPUT}`, `%{WORK_DIR}` syntax to avoid clashing with shell `$VAR` and agent skill invocations like `$review`.
 - **Activity Per Node**: Each pipeline node/gate = one Temporal Activity. Simplest model.
 - **File-based completion**: Node commands write `.belayer/.internal/completion/<id>-<node>-attempt-<N>.json` when done (via `belayer node-complete` or directly)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -6,9 +6,10 @@ Patterns and conventions for the belayer codebase.
 
 Nodes define `command:` (what to exec), `description:` (what to do), routing (`on_pass`/`on_retry`/`on_fail`). Belayer execs the command via ExecSpawner, polls for completion, and routes to the next node based on outcome.
 
-Two pipeline primitives:
+Three pipeline primitives:
 - **Nodes** (constructive): Produce artifacts (code, specs, PRs)
 - **Gates** (adversarial): Evaluate artifacts with multi-dimensional scoring. Produce `gate-result.json` + `rationale.md`
+- **Routers** (agentic branching): LLM picks one of N declared paths, each running as an isolated Temporal child workflow. Produce `route-result.json`
 
 ## Framework Model
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -37,7 +37,31 @@ Agent nodes (`type: agent`) replace shell scripts with vendor + prompt in YAML. 
   prompt: "Implement the design specification at %{INPUT}"
 ```
 
-Vendor map: `claude` → `claude -p --dangerously-skip-permissions --output-format stream-json`, `codex` → `codex exec -s read-only --json`. Gate nodes auto-append `--json-schema` (claude) or `--output-schema` (codex) with dimensions from the YAML.
+Vendor map: `claude` → `claude -p --dangerously-skip-permissions --output-format stream-json`, `codex` → `codex exec -s read-only --json`. Gate nodes auto-append `--json-schema` (claude) or `--output-schema` (codex) with dimensions from the YAML. Router nodes auto-append JSON Schema with enum constraint on route names.
+
+## Route Nodes
+
+Route nodes (`type: agent` + `routes:`) enable N-way agentic branching. The LLM classifies input and picks one of N declared paths. Each path runs as an isolated Temporal child workflow.
+
+```yaml
+- name: review-router
+  type: agent
+  vendor: claude
+  prompt: "Classify this change and choose the review depth"
+  input: { type: commit }
+  output: { type: route_result }
+  routes:
+    mode: choose_one
+    options:
+      full-feature-review:
+        pipeline: .belayer/pipelines/full-feature-review.yaml
+        description: Broad change, needs full review
+      quick-bugfix-review:
+        pipeline: .belayer/pipelines/quick-bugfix-review.yaml
+        description: Small fix, lightweight review
+```
+
+Route decisions produce `route-result.json` with choice, confidence, reasoning, and rejected alternatives. The `enum` constraint in the JSON Schema prevents the LLM from hallucinating routes. Malformed results trigger OutcomeRetry (same as gates). Subpipeline YAMLs are pre-resolved at startup for reproducibility.
 
 ## Two Contracts
 

--- a/docs/PIPELINE_REFERENCE.md
+++ b/docs/PIPELINE_REFERENCE.md
@@ -1,0 +1,380 @@
+# Pipeline YAML Reference
+
+Complete guide to writing belayer pipeline YAML files. Use this when constructing or modifying `.belayer/pipeline.yaml` and subpipeline files.
+
+## Top-Level Structure
+
+```yaml
+name: my-pipeline                    # required: pipeline identifier
+
+intake:                              # optional: how work enters the pipeline
+  - name: design-doc
+    type: trigger
+    check: .belayer/scripts/check-ready.sh
+
+nodes:                               # required: at least one node
+  - name: implement
+    # ... node config
+
+safety:                              # optional: pipeline-wide limits
+  max_concurrent_runs: 3
+```
+
+## Node Types
+
+Every node has a `type` field. Three types exist:
+
+| Type | Purpose | Key Fields |
+|------|---------|------------|
+| `node` | Constructive step — produces artifacts | `command`, `output` |
+| `gate` | Adversarial quality check — scores and routes | `dimensions`, `thresholds`, `output: { type: gate_result }` |
+| `agent` | Vendor-driven node — belayer builds the CLI command | `vendor`, `prompt`, `output` |
+
+Agent nodes with `dimensions` are treated as gates (agent does the scoring). Agent nodes with `routes` are routers (agent picks a path).
+
+## Common Fields (All Node Types)
+
+```yaml
+- name: my-node                      # required: unique within pipeline
+  type: node                         # node | gate | agent (default: node)
+  description: |                     # optional: human-readable purpose
+    What this node does.
+
+  # Input: what the node receives
+  input:
+    type: description                # description | file | commit
+    key: previous_node               # optional: artifact key from a prior node
+
+  # Output: what the node produces
+  output:
+    type: file                       # required: file | commit | gate_result | pr | route_result
+    path: output/result.txt          # optional: expected output file path
+    key: my_output                   # optional: artifact key (default: node name)
+
+  # Routing: where to go after this node
+  on_pass: next-node                 # node name | "next" | "stop" (default: next sequential)
+  on_retry: self                     # node name | "self" (default: self)
+  on_fail: stop                      # node name | "stop" (default: stop)
+  max_retries: 3                     # max retry attempts (default: 0 = no retries)
+```
+
+## Script Nodes (`type: node`)
+
+Execute a shell command. Belayer runs the command via `sh -c`, polls for a completion file, and routes based on outcome.
+
+```yaml
+- name: implement
+  type: node
+  command: .belayer/scripts/run.sh
+  description: |
+    Implement the feature described in the design doc.
+  input: { type: file, key: design_doc }
+  output: { type: commit }
+  on_pass: review
+  on_retry: self
+  max_retries: 3
+```
+
+**Environment variables** set before command execution:
+- `BELAYER_TASK_ID` — workflow ID
+- `BELAYER_NODE` — node name
+- `BELAYER_ATTEMPT` — attempt number (0-based)
+- `BELAYER_WORK_DIR` — worktree directory
+
+**Context file**: `.belayer/.internal/input/node-context.json` is written before the command runs. Contains task details, node config, and artifacts from prior nodes.
+
+**Completion**: The command (or a hook) writes `.belayer/.internal/completion/<task-id>-<node>-attempt-<N>.json` when done.
+
+## Agent Nodes (`type: agent`)
+
+Belayer resolves the vendor to a CLI command. No shell script needed.
+
+```yaml
+- name: implement
+  type: agent
+  vendor: claude                     # required: claude | codex
+  prompt: |                          # required: what to tell the agent
+    Implement the design specification at %{INPUT}.
+    Write tests. Commit when done.
+  input: { type: file, key: design_doc }
+  output: { type: commit }
+  on_pass: review
+  max_retries: 3
+```
+
+**Supported vendors:**
+
+| Vendor | CLI Command | Schema Flag |
+|--------|-------------|-------------|
+| `claude` | `claude -p --output-format stream-json` | `--json-schema` (inline JSON) |
+| `codex` | `codex exec -s read-only --json` | `--output-schema` (temp file) |
+
+**Variable interpolation** in prompts: Use `%{VAR}` syntax (not `$VAR`, which clashes with shell and agent skills).
+
+| Variable | Resolves To |
+|----------|-------------|
+| `%{INPUT}` | Input artifact path or description |
+| `%{WORK_DIR}` | Worktree directory |
+
+## Gate Nodes (Adversarial Quality Checks)
+
+Gates evaluate artifacts and produce structured scores. Belayer computes a weighted average and routes based on YAML thresholds. The gate session never decides its own outcome (score-then-route anti-gaming).
+
+Gates can be `type: gate` with a `command`, or `type: agent` with `dimensions`:
+
+```yaml
+# Option A: gate with shell command
+- name: review
+  type: gate
+  command: .belayer/scripts/run.sh
+  description: |
+    Review the code for spec compliance and test coverage.
+  input: { type: commit }
+  dimensions:
+    - { name: spec_compliance, weight: 0.35, description: "Changes match spec?" }
+    - { name: test_coverage, weight: 0.30, description: "Tests are meaningful?" }
+    - { name: correctness, weight: 0.35, description: "Works in production?" }
+  thresholds:
+    pass: 7.0                        # weighted score >= 7.0 → PASS
+    retry: 4.0                       # weighted score >= 4.0 → RETRY (else FAIL)
+  output: { type: gate_result }
+  on_pass: ship
+  on_retry: implement
+  max_retries: 2
+
+# Option B: agent gate (belayer builds the CLI command + schema)
+- name: review
+  type: agent
+  vendor: codex
+  prompt: |
+    Review the code changes. Score each dimension 0-10.
+  input: { type: commit }
+  dimensions:
+    - { name: spec_compliance, weight: 0.35, description: "Changes match spec?" }
+    - { name: test_coverage, weight: 0.30, description: "Tests are meaningful?" }
+    - { name: correctness, weight: 0.35, description: "Works in production?" }
+  thresholds:
+    pass: 7.0
+    retry: 4.0
+  output: { type: gate_result }
+  on_pass: ship
+  on_retry: implement
+  max_retries: 2
+```
+
+**Gate rules:**
+- At least one dimension required
+- Dimension weights must sum to 1.0
+- `thresholds.pass` must be in (0, 10]
+- `thresholds.retry` must be non-negative and less than `thresholds.pass`
+- Output type must be `gate_result`
+- Gate prompts should include `%{INPUT}` so the rubric is injected
+
+**Gate output**: Produces `gate-result.json` (structured scores) + `rationale.md` (human-readable explanation). The rationale is mandatory as an anti-gaming measure.
+
+## Router Nodes (Agentic N-Way Branching)
+
+Routers let an LLM choose one of N declared paths. Each path runs as an isolated Temporal child workflow with its own nodes, retry counters, and completion semantics.
+
+```yaml
+- name: review-router
+  type: agent                        # must be agent
+  vendor: claude
+  prompt: |
+    Read the PR diff at %{INPUT}. Classify this change and choose
+    the appropriate review depth. Consider: scope, risk areas,
+    public API changes, file count, and test coverage impact.
+  input: { type: commit, key: implement }
+  output: { type: route_result, path: .belayer/.internal/output/route-result.json }
+  routes:
+    mode: choose_one                 # required: only mode currently supported
+    options:                         # required: at least 2 options
+      full-feature-review:
+        pipeline: .belayer/pipelines/full-feature-review.yaml   # required: subpipeline path
+        description: >                                          # optional but recommended
+          Broad or risky change. Needs thorough code review.
+      quick-bugfix-review:
+        pipeline: .belayer/pipelines/quick-bugfix-review.yaml
+        description: >
+          Small localized fix. Lightweight review only.
+      refactor-review:
+        pipeline: .belayer/pipelines/refactor-review.yaml
+        description: >
+          Structural change. Focus on behavioral preservation.
+  on_pass: stop
+  on_retry: self
+  on_fail: stop
+  max_retries: 2
+```
+
+**Router rules:**
+- Must be `type: agent` with a `vendor` and `prompt`
+- `routes.mode` must be `choose_one`
+- At least 2 route options required
+- Option names must match `^[a-zA-Z0-9][a-zA-Z0-9-]*$`
+- Each option must have a non-empty `pipeline` path
+- Output type must be `route_result`
+- Cannot have `dimensions` (routes and gates are mutually exclusive)
+- `on_retry` must be `self` or empty
+
+**How it works:**
+1. Belayer injects a route selection prompt with the option names, descriptions, and a JSON Schema with an `enum` constraint (prevents hallucinated routes)
+2. The agent writes `route-result.json` with `route`, `confidence`, `reasoning`, and `rejected` alternatives
+3. Belayer validates the result, then spawns the chosen subpipeline as a Temporal child workflow
+4. The child runs in the same worktree with its own retry budget
+5. Child outputs merge back into the parent pipeline (namespaced as `router-name/child-node`)
+
+**Subpipeline files** are standalone pipeline YAMLs (same schema as the top-level). They live in `.belayer/pipelines/` by convention. Example:
+
+```yaml
+# .belayer/pipelines/quick-bugfix-review.yaml
+name: quick-bugfix-review
+
+nodes:
+  - name: code-review
+    type: agent
+    vendor: codex
+    prompt: |
+      Lightweight review: check correctness and regression risk.
+    input: { type: commit }
+    dimensions:
+      - { name: correctness, weight: 0.4, description: "Does the fix work?" }
+      - { name: regression_risk, weight: 0.35, description: "Could this break something?" }
+      - { name: test_coverage, weight: 0.25, description: "Is the fix tested?" }
+    thresholds: { pass: 6.5, retry: 3.0 }
+    output: { type: gate_result }
+    on_pass: ship
+    on_retry: fix
+    max_retries: 1
+
+  - name: fix
+    type: agent
+    vendor: claude
+    prompt: "Address the review feedback at %{INPUT}"
+    input: { type: file, key: feedback }
+    output: { type: commit }
+    on_pass: code-review
+
+  - name: ship
+    type: agent
+    vendor: claude
+    prompt: "Create a PR for the changes"
+    input: { type: commit }
+    output: { type: pr }
+    on_pass: stop
+```
+
+**Subpipeline YAMLs are pre-resolved** at startup (worker boot or `belayer climb`). The raw YAML is snapshotted and passed into the Temporal workflow for deterministic replay. No file I/O happens during workflow execution.
+
+## Output Types
+
+| Type | Produced By | Description |
+|------|-------------|-------------|
+| `file` | Nodes | Generic file output (default for script nodes) |
+| `commit` | Nodes, agents | Git commit in the worktree |
+| `gate_result` | Gates | Structured scores + rationale |
+| `pr` | Nodes, agents | Pull request creation |
+| `route_result` | Routers | Route decision with confidence and reasoning |
+
+**Adding a new output type** requires updates in three places:
+1. `internal/pipeline/validate.go` — `validOutputTypes` map
+2. `internal/pipeline/model.go` — `OutputConfig` type comment
+3. `internal/outcome/detect.go` — `typeDefault` switch
+
+Missing `detect.go` causes silent false-positive outcomes.
+
+## Intake Configuration
+
+Intake defines how work enters the pipeline.
+
+```yaml
+intake:
+  - name: design-doc
+    type: trigger                    # trigger | interactive | jira
+    check: .belayer/scripts/check-ready.sh
+
+  - name: interactive
+    type: interactive                # at most one interactive intake
+```
+
+| Type | Description |
+|------|-------------|
+| `trigger` | Script-based polling. `check` script returns artifact path on stdout (exit 0) or nothing (exit 1) |
+| `interactive` | `belayer start` session. At most one per pipeline |
+| `jira` | Jira issue intake (requires config) |
+
+## Safety Configuration
+
+```yaml
+safety:
+  max_concurrent_runs: 3             # max parallel workflows (default: 3)
+```
+
+## Validation Rules Summary
+
+Belayer validates pipelines at parse time. Common validation errors:
+
+| Rule | Error |
+|------|-------|
+| Pipeline must have a `name` | `pipeline name is required` |
+| At least one node | `pipeline must have at least one node` |
+| No duplicate node names | `duplicate node name: "X"` |
+| `on_pass`/`on_retry`/`on_fail` must reference a known node or keyword | `references unknown node or keyword` |
+| Gate dimensions must sum to 1.0 | `dimension weights sum to X, must sum to 1.0` |
+| Agent nodes require `vendor` + `prompt` | `vendor is required`, `prompt is required` |
+| `command` and `vendor` are mutually exclusive | `command and vendor are mutually exclusive` |
+| Router + gate is not allowed | `routes and dimensions are mutually exclusive` |
+
+## Complete Example
+
+A full pipeline with implementation, routing, and subpipelines:
+
+```yaml
+name: full-pipeline
+
+intake:
+  - name: design-doc
+    type: trigger
+    check: .belayer/scripts/check-ready.sh
+
+nodes:
+  - name: implement
+    type: agent
+    vendor: claude
+    prompt: "Implement the design specification at %{INPUT}"
+    input: { type: file, key: design_doc }
+    output: { type: commit }
+    on_pass: review-router
+    on_fail: stop
+
+  - name: review-router
+    type: agent
+    vendor: claude
+    prompt: |
+      Classify this change and choose the review depth.
+      Consider scope, risk, API changes, and test coverage.
+    input: { type: commit, key: implement }
+    output: { type: route_result }
+    routes:
+      mode: choose_one
+      options:
+        thorough-review:
+          pipeline: .belayer/pipelines/thorough-review.yaml
+          description: Large or risky change. Full 5-dimension review.
+        quick-review:
+          pipeline: .belayer/pipelines/quick-review.yaml
+          description: Small fix. 3-dimension lightweight review.
+    on_pass: stop
+    on_retry: self
+    on_fail: stop
+    max_retries: 2
+
+safety:
+  max_concurrent_runs: 3
+```
+
+## See Also
+
+- [Design](DESIGN.md) — patterns and conventions
+- [Architecture](ARCHITECTURE.md) — module boundaries and data flow
+- [Quality](QUALITY.md) — testing strategy

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -14,7 +14,7 @@ Execution plans for active and completed work.
 |-------|----------|-------|
 | Schedule reconciliation is a stub | Medium | `internal/intake/schedule.go` logs intent but does not create Temporal schedules |
 | Worker `/status` endpoint is a stub | Low | Returns health only — full workflow listing deferred to Phase 2 |
-| `StartSHA` in `NodeActivityInput` never populated | Low | Code-output commit verification guard never fires |
+| ~~`StartSHA` in `NodeActivityInput` never populated~~ | ~~Low~~ | Resolved: `startSHA` captured locally in `NodeActivity` before spawn (2026-03-30) |
 
 
 ## Completed Plans

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -24,6 +24,8 @@ Go's built-in `go test` with `testing` package. No external test framework.
 | `internal/temporal/workflow_test.go` | ClimbWorkflow orchestration |
 | `internal/temporal/activity_test.go` | NodeActivity: spawn, heartbeat, poll completion |
 | `internal/temporal/integration_test.go` | End-to-end pipeline integration |
+| `internal/route/result_test.go` | Route result parsing, validation, prompt builder |
+| `internal/vendor/vendor_test.go` | Vendor resolution, command builder, router schema generation |
 | `internal/intake/bridge_test.go` | Intake bridge: SubmitSpec to workflow |
 | `internal/intake/jira_test.go` | Jira intake adapter |
 | `internal/intake/schedule_test.go` | Schedule reconciliation |

--- a/frameworks/gstack/pipeline.yaml
+++ b/frameworks/gstack/pipeline.yaml
@@ -10,41 +10,53 @@ intake:
 
 nodes:
   # Implementation phase: self-resolving loop
-  # implement ↔ review is the build loop. Gates are implementation primitives.
+  # implement ↔ review-router is the build loop.
   - name: implement
     type: agent
     vendor: claude
     prompt: "Implement the design specification at %{INPUT}"
     input: { type: file, key: design_doc }
     output: { type: commit }
-    on_pass: review
+    on_pass: review-router
     on_fail: stop
 
-  - name: review
-    type: gate
-    vendor: codex
-    prompt: "$review"
-    input: { type: commit }
-    output: { type: gate_result }
-    dimensions:
-      - { name: code_quality, weight: 0.35 }
-      - { name: scope_compliance, weight: 0.30 }
-      - { name: production_readiness, weight: 0.35 }
-    thresholds: { pass: 7.0, retry: 4.0 }
-    on_pass: ship
-    on_retry: implement
-    on_fail: stop
-    max_retries: 2
-
-  # Output phase: shipping
-  - name: ship
+  # Route: classify the change and pick the appropriate review depth.
+  # Each route leads to an isolated subpipeline with its own review
+  # dimensions, retry budget, and shipping step.
+  - name: review-router
     type: agent
     vendor: claude
-    prompt: "Create a pull request for the changes on this branch. Include a summary of what was implemented, run any tests, and push to remote. Write the PR URL to .belayer/.internal/output/pr.json as {\"url\": \"...\", \"number\": N}."
-    input: { type: commit }
-    output: { type: pr, path: .belayer/.internal/output/pr.json }
+    prompt: |
+      Read the PR diff at %{INPUT}. Classify this change and choose
+      the appropriate review depth. Consider: scope of change, risk
+      areas touched, whether it modifies public APIs or schemas,
+      number of files changed, and test coverage impact.
+    input: { type: commit, key: implement }
+    output: { type: route_result, path: .belayer/.internal/output/route-result.json }
+    routes:
+      mode: choose_one
+      options:
+        full-feature-review:
+          pipeline: .belayer/pipelines/full-feature-review.yaml
+          description: >
+            Broad or risky change. Needs thorough code review with
+            5 dimensions (quality, scope, production, tests, architecture)
+            and full gate scoring.
+        quick-bugfix-review:
+          pipeline: .belayer/pipelines/quick-bugfix-review.yaml
+          description: >
+            Small localized fix. Lightweight code review with 3 dimensions
+            (correctness, regression risk, tests) and 1 retry max.
+        refactor-review:
+          pipeline: .belayer/pipelines/refactor-review.yaml
+          description: >
+            Structural change with no new behavior. Review focuses on
+            behavioral preservation, architecture improvement, and
+            migration safety. Higher pass threshold (7.5).
     on_pass: stop
+    on_retry: self
     on_fail: stop
+    max_retries: 2
 
 safety:
   max_concurrent_runs: 3

--- a/frameworks/gstack/pipelines/full-feature-review.yaml
+++ b/frameworks/gstack/pipelines/full-feature-review.yaml
@@ -1,0 +1,29 @@
+name: full-feature-review
+
+nodes:
+  - name: code-review
+    type: agent
+    vendor: codex
+    prompt: "$review"
+    input: { type: commit }
+    output: { type: gate_result }
+    dimensions:
+      - { name: code_quality, weight: 0.25, description: "Code organization, readability, and adherence to project patterns" }
+      - { name: scope_compliance, weight: 0.20, description: "Does the implementation match the spec without scope creep?" }
+      - { name: production_readiness, weight: 0.20, description: "Error handling, logging, security, and deployment readiness" }
+      - { name: test_coverage, weight: 0.20, description: "Unit tests, edge cases, and integration test coverage" }
+      - { name: architecture, weight: 0.15, description: "Component boundaries, dependency management, and extensibility" }
+    thresholds: { pass: 7.0, retry: 4.0 }
+    on_pass: ship
+    on_retry: self
+    on_fail: stop
+    max_retries: 2
+
+  - name: ship
+    type: agent
+    vendor: claude
+    prompt: "Create a pull request for the completed feature. Include a detailed summary of what was implemented, run all tests, and push to remote. Write the PR URL to .belayer/.internal/output/pr.json as {\"url\": \"...\", \"number\": N}."
+    input: { type: gate_result, key: code-review }
+    output: { type: pr, path: .belayer/.internal/output/pr.json }
+    on_pass: stop
+    on_fail: stop

--- a/frameworks/gstack/pipelines/quick-bugfix-review.yaml
+++ b/frameworks/gstack/pipelines/quick-bugfix-review.yaml
@@ -1,0 +1,27 @@
+name: quick-bugfix-review
+
+nodes:
+  - name: code-review
+    type: agent
+    vendor: codex
+    prompt: "$review"
+    input: { type: commit }
+    output: { type: gate_result }
+    dimensions:
+      - { name: correctness, weight: 0.5, description: "Does the fix address the bug without introducing new issues?" }
+      - { name: regression_risk, weight: 0.3, description: "Could this change break existing functionality?" }
+      - { name: test_coverage, weight: 0.2, description: "Are tests adequate for the fix?" }
+    thresholds: { pass: 7.0, retry: 4.0 }
+    on_pass: ship
+    on_retry: self
+    on_fail: stop
+    max_retries: 1
+
+  - name: ship
+    type: agent
+    vendor: claude
+    prompt: "Create a pull request for the completed bug fix. Include a summary of what was fixed, run any tests, and push to remote. Write the PR URL to .belayer/.internal/output/pr.json as {\"url\": \"...\", \"number\": N}."
+    input: { type: gate_result, key: code-review }
+    output: { type: pr, path: .belayer/.internal/output/pr.json }
+    on_pass: stop
+    on_fail: stop

--- a/frameworks/gstack/pipelines/refactor-review.yaml
+++ b/frameworks/gstack/pipelines/refactor-review.yaml
@@ -1,0 +1,28 @@
+name: refactor-review
+
+nodes:
+  - name: code-review
+    type: agent
+    vendor: codex
+    prompt: "$review"
+    input: { type: commit }
+    output: { type: gate_result }
+    dimensions:
+      - { name: behavioral_preservation, weight: 0.35, description: "Does the refactor preserve all existing behavior? No functional changes." }
+      - { name: architecture_improvement, weight: 0.30, description: "Does the new structure actually improve modularity, readability, or maintainability?" }
+      - { name: test_coverage, weight: 0.20, description: "Are existing tests still passing? Were new tests added for restructured code?" }
+      - { name: migration_safety, weight: 0.15, description: "Can this be deployed incrementally? Are there backwards-compatibility concerns?" }
+    thresholds: { pass: 7.5, retry: 5.0 }
+    on_pass: ship
+    on_retry: self
+    on_fail: stop
+    max_retries: 2
+
+  - name: ship
+    type: agent
+    vendor: claude
+    prompt: "Create a pull request for the completed refactor. Emphasize that this is a structural change with no new behavior. Include before/after architecture notes. Run all tests and push to remote. Write the PR URL to .belayer/.internal/output/pr.json as {\"url\": \"...\", \"number\": N}."
+    input: { type: gate_result, key: code-review }
+    output: { type: pr, path: .belayer/.internal/output/pr.json }
+    on_pass: stop
+    on_fail: stop

--- a/internal/cli/climb.go
+++ b/internal/cli/climb.go
@@ -15,6 +15,7 @@ import (
 	"github.com/donovan-yohan/belayer/internal/events"
 	"github.com/donovan-yohan/belayer/internal/intake"
 	"github.com/donovan-yohan/belayer/internal/model"
+	"github.com/donovan-yohan/belayer/internal/pipeline"
 	"github.com/donovan-yohan/belayer/internal/session"
 	beltemporal "github.com/donovan-yohan/belayer/internal/temporal"
 )
@@ -43,6 +44,18 @@ func NewClimbCmd() *cobra.Command {
 			pipelineYAML, pipelineName, err := intake.ResolvePipelineYAML(cwd)
 			if err != nil {
 				return fmt.Errorf("resolve pipeline: %w", err)
+			}
+
+			// 2b. Validate and pre-resolve subpipelines for router nodes.
+			var subpipelineYAMLs map[string][]byte
+			if cfg, err := pipeline.ParsePipeline(pipelineYAML); err == nil {
+				if err := pipeline.Validate(cfg); err != nil {
+					return fmt.Errorf("validate pipeline: %w", err)
+				}
+				subpipelineYAMLs, err = pipeline.ResolveSubpipelineYAMLs(cfg, cwd)
+				if err != nil {
+					return fmt.Errorf("validate route subpipelines: %w", err)
+				}
 			}
 
 			// 3. Connect to Temporal.
@@ -97,13 +110,14 @@ func NewClimbCmd() *cobra.Command {
 			// 7. Build and start workflow.
 			// Sessions run in the worktree (isolated), not the main repo.
 			climbInput := model.ClimbInput{
-				Description:  description,
-				DesignFile:   designFile,
-				PipelineYAML: pipelineYAML,
-				FromNode:     nodeFlag,
-				InputPath:    inputFlag,
-				WorkDir:      worktreeDir,
-				Branch:       branch,
+				Description:      description,
+				DesignFile:       designFile,
+				PipelineYAML:     pipelineYAML,
+				SubpipelineYAMLs: subpipelineYAMLs,
+				FromNode:         nodeFlag,
+				InputPath:        inputFlag,
+				WorkDir:          worktreeDir,
+				Branch:           branch,
 			}
 
 			run, err := tc.ExecuteWorkflow(

--- a/internal/cli/climb.go
+++ b/internal/cli/climb.go
@@ -28,6 +28,19 @@ func NewClimbCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "climb [description]",
 		Short: "Start a pipeline climb (pipeline entry point)",
+		Long: `Start a pipeline run in a fresh git worktree.
+
+Resolves .belayer/pipeline.yaml, validates nodes (including router
+subpipelines), creates a worktree, and starts a Temporal workflow.
+
+Input priority: --file > --prompt > positional args > stdin.
+
+Examples:
+  belayer climb "add user authentication"
+  belayer climb --file design.md
+  belayer climb --file design.md --detach
+  belayer climb --node review-gate --input path/to/commit
+  echo "fix the login bug" | belayer climb`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,15 +8,24 @@ func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "belayer",
 		Short: "Pipeline orchestrator for autonomous coding agents",
-		Long: `Belayer orchestrates autonomous coding agents through a declarative pipeline.
+		Long: `Belayer orchestrates autonomous coding agents through declarative YAML pipelines.
+
+Three pipeline primitives:
+  Nodes     Constructive steps that produce artifacts (code, specs, PRs)
+  Gates     Adversarial quality checks with multi-dimensional scoring
+  Routers   Agentic N-way branching — LLM picks a path, runs as child workflow
 
 Define your pipeline in YAML, install a framework (belayer setup --framework),
-and belayer handles execution via Temporal workflows.
+and belayer handles execution, scoring, routing, and retries via Temporal.
 
 Getting started:
   belayer setup --framework gstack        Install a framework
   belayer climb "description"             Start a pipeline run
-  belayer status                          Check pipeline progress`,
+  belayer worker                          Start the worker daemon
+  belayer submit "description"            Submit to a running worker
+  belayer status                          Check pipeline progress
+
+See docs/PIPELINE_REFERENCE.md for the full YAML schema.`,
 	}
 
 	cmd.Version = version

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -18,12 +18,16 @@ func newSetupCmd() *cobra.Command {
 		Short: "Scaffold a belayer framework into the current repo",
 		Long: `Install a belayer framework into .belayer/ of the current repository.
 
-Frameworks provide pipeline.yaml and node runner scripts that define
-how belayer executes pipeline nodes.
+Frameworks provide pipeline.yaml, node runner scripts, and optional
+subpipeline YAMLs (in .belayer/pipelines/) that define how belayer
+executes pipeline nodes, gates, and routers.
 
 Examples:
   belayer setup --framework gstack                # built-in framework
-  belayer setup --framework ./my-custom-framework # local path`,
+  belayer setup --framework ./my-custom-framework # local path
+
+After setup, customize .belayer/pipeline.yaml. See docs/PIPELINE_REFERENCE.md
+for the full YAML schema.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if frameworkFlag == "" {
 				return fmt.Errorf("--framework is required")

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -53,14 +53,15 @@ Start this BEFORE running 'belayer start' or 'belayer climb'.`,
 
 // startWorkflowInput holds the parameters for starting a pipeline workflow.
 type startWorkflowInput struct {
-	Spec         string
-	Source       string
-	ExternalID   string
-	DesignFile   string
-	PipelineName string
-	PipelineYAML []byte
-	WorkDir      string
-	Repos        []string
+	Spec             string
+	Source           string
+	ExternalID       string
+	DesignFile       string
+	PipelineName     string
+	PipelineYAML     []byte
+	SubpipelineYAMLs map[string][]byte
+	WorkDir          string
+	Repos            []string
 }
 
 // startWorkflowOutput holds the result of starting a workflow.
@@ -90,12 +91,13 @@ func startWorkflow(ctx context.Context, tc client.Client, input startWorkflowInp
 	}
 	workflowID := intake.GenerateWorkflowID(input.PipelineName, input.Source, externalID)
 	climbInput := model.ClimbInput{
-		Description:  input.Spec,
-		DesignFile:   input.DesignFile,
-		PipelineYAML: input.PipelineYAML,
-		WorkDir:      worktreeDir,
-		Branch:       branch,
-		Repos:        input.Repos,
+		Description:      input.Spec,
+		DesignFile:       input.DesignFile,
+		PipelineYAML:     input.PipelineYAML,
+		SubpipelineYAMLs: input.SubpipelineYAMLs,
+		WorkDir:          worktreeDir,
+		Branch:           branch,
+		Repos:            input.Repos,
 	}
 
 	opts := client.StartWorkflowOptions{
@@ -240,6 +242,7 @@ func runWorker(workDir string) error {
 	}
 	var intakeChecks []string
 	var maxConcurrent int
+	var subpipelineYAMLs map[string][]byte
 	if len(pipelineYAML) > 0 {
 		if cfg, err := pipeline.ParsePipeline(pipelineYAML); err == nil {
 			for _, ic := range cfg.Intake {
@@ -251,6 +254,8 @@ func runWorker(workDir string) error {
 			if maxConcurrent == 0 {
 				maxConcurrent = 3
 			}
+			// Pre-resolve subpipeline YAMLs for router nodes (reproducibility).
+			subpipelineYAMLs, _ = pipeline.ResolveSubpipelineYAMLs(cfg, workDir)
 		}
 	}
 
@@ -258,13 +263,13 @@ func runWorker(workDir string) error {
 	if len(intakeChecks) > 0 {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		go startIntakePoller(ctx, c, workDir, intakeChecks, maxConcurrent, pipelineYAML, pipelineName)
+		go startIntakePoller(ctx, c, workDir, intakeChecks, maxConcurrent, pipelineYAML, pipelineName, subpipelineYAMLs)
 	}
 
 	// Start HTTP API server for submit/status tools.
 	httpErrCh := make(chan error, 1)
 	go func() {
-		httpErrCh <- startHTTPAPI(c, workDir, pipelineYAML, pipelineName)
+		httpErrCh <- startHTTPAPI(c, workDir, pipelineYAML, pipelineName, subpipelineYAMLs)
 	}()
 
 	// Fail fast if the HTTP API can't bind (e.g., port already in use).
@@ -288,7 +293,7 @@ func runWorker(workDir string) error {
 }
 
 // startHTTPAPI runs the HTTP API server for submit/status tool calls.
-func startHTTPAPI(temporalClient client.Client, workDir string, pipelineYAML []byte, pipelineName string) error {
+func startHTTPAPI(temporalClient client.Client, workDir string, pipelineYAML []byte, pipelineName string, subpipelineYAMLs map[string][]byte) error {
 	mux := http.NewServeMux()
 
 	// POST /start — accepts SubmitSpec JSON, starts a ClimbWorkflow, returns workflow ID.
@@ -326,14 +331,15 @@ func startHTTPAPI(temporalClient client.Client, workDir string, pipelineYAML []b
 		}
 
 		out, err := startWorkflow(r.Context(), temporalClient, startWorkflowInput{
-			Spec:         spec.Spec,
-			Source:       spec.Source,
-			ExternalID:   spec.ExternalID,
-			DesignFile:   spec.Metadata["design_file"],
-			PipelineName: spec.PipelineName,
-			PipelineYAML: resolvedYAML,
-			WorkDir:      workDir,
-			Repos:        spec.Repos,
+			Spec:             spec.Spec,
+			Source:           spec.Source,
+			ExternalID:       spec.ExternalID,
+			DesignFile:       spec.Metadata["design_file"],
+			PipelineName:     spec.PipelineName,
+			PipelineYAML:     resolvedYAML,
+			SubpipelineYAMLs: subpipelineYAMLs,
+			WorkDir:          workDir,
+			Repos:            spec.Repos,
 		})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -366,7 +372,7 @@ func startHTTPAPI(temporalClient client.Client, workDir string, pipelineYAML []b
 // startIntakePoller polls intake trigger scripts and starts workflows when
 // APPROVED design docs are found. Consume-after-confirm: the doc is only
 // marked consumed after the workflow starts successfully.
-func startIntakePoller(ctx context.Context, tc client.Client, workDir string, checks []string, maxConcurrent int, pipelineYAML []byte, pipelineName string) {
+func startIntakePoller(ctx context.Context, tc client.Client, workDir string, checks []string, maxConcurrent int, pipelineYAML []byte, pipelineName string, subpipelineYAMLs map[string][]byte) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 	failures := make(map[int]int)  // consecutive failure count per check
@@ -420,13 +426,14 @@ func startIntakePoller(ctx context.Context, tc client.Client, workDir string, ch
 				// If the same doc triggers twice (crash between start and consume),
 				// Temporal rejects the duplicate workflow ID.
 				out, err := startWorkflow(ctx, tc, startWorkflowInput{
-					Spec:         string(specData),
-					Source:       "trigger",
-					ExternalID:   filepath.Base(artifactPath),
-					DesignFile:   artifactPath,
-					PipelineName: pipelineName,
-					PipelineYAML: pipelineYAML,
-					WorkDir:      workDir,
+					Spec:             string(specData),
+					Source:           "trigger",
+					ExternalID:       filepath.Base(artifactPath),
+					DesignFile:       artifactPath,
+					PipelineName:     pipelineName,
+					PipelineYAML:     pipelineYAML,
+					SubpipelineYAMLs: subpipelineYAMLs,
+					WorkDir:          workDir,
 				})
 				if err != nil {
 					log.Printf("intake poller: start workflow failed: %v", err)

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -255,7 +255,11 @@ func runWorker(workDir string) error {
 				maxConcurrent = 3
 			}
 			// Pre-resolve subpipeline YAMLs for router nodes (reproducibility).
-			subpipelineYAMLs, _ = pipeline.ResolveSubpipelineYAMLs(cfg, workDir)
+			if resolved, err := pipeline.ResolveSubpipelineYAMLs(cfg, workDir); err != nil {
+				log.Fatalf("failed to resolve router subpipelines: %v", err)
+			} else {
+				subpipelineYAMLs = resolved
+			}
 		}
 	}
 
@@ -318,12 +322,22 @@ func startHTTPAPI(temporalClient client.Client, workDir string, pipelineYAML []b
 
 		resolvedYAML := pipelineYAML
 		resolvedName := pipelineName
+		resolvedSubYAMLs := subpipelineYAMLs
 		if len(resolvedYAML) == 0 {
 			var err error
 			resolvedYAML, resolvedName, err = intake.ResolvePipelineYAML(workDir)
 			if err != nil {
 				http.Error(w, "Pipeline error: "+err.Error(), http.StatusBadRequest)
 				return
+			}
+			// Re-resolve subpipeline YAMLs from the freshly parsed pipeline.
+			if cfg, err := pipeline.ParsePipeline(resolvedYAML); err == nil {
+				if subs, err := pipeline.ResolveSubpipelineYAMLs(cfg, workDir); err != nil {
+					http.Error(w, "Subpipeline error: "+err.Error(), http.StatusBadRequest)
+					return
+				} else {
+					resolvedSubYAMLs = subs
+				}
 			}
 		}
 		if spec.PipelineName == "" {
@@ -337,7 +351,7 @@ func startHTTPAPI(temporalClient client.Client, workDir string, pipelineYAML []b
 			DesignFile:       spec.Metadata["design_file"],
 			PipelineName:     spec.PipelineName,
 			PipelineYAML:     resolvedYAML,
-			SubpipelineYAMLs: subpipelineYAMLs,
+			SubpipelineYAMLs: resolvedSubYAMLs,
 			WorkDir:          workDir,
 			Repos:            spec.Repos,
 		})

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -47,16 +47,17 @@ func (s ClimbStatus) IsValid() bool {
 
 // ClimbInput is the input to the Climb workflow.
 type ClimbInput struct {
-	Description  string   `json:"description"`
-	DesignFile   string   `json:"design_file,omitempty"`
-	PipelineFile string   `json:"pipeline_file,omitempty"`
-	PipelineYAML []byte   `json:"pipeline_yaml,omitempty"`
-	FromNode     string   `json:"from_node,omitempty"`
-	InputPath    string   `json:"input_path,omitempty"`
-	WorkDir      string   `json:"work_dir"`
-	Branch       string   `json:"branch"`
-	Repos        []string `json:"repos,omitempty"`
-	BaseRef      string   `json:"base_ref,omitempty"`
+	Description      string              `json:"description"`
+	DesignFile       string              `json:"design_file,omitempty"`
+	PipelineFile     string              `json:"pipeline_file,omitempty"`
+	PipelineYAML     []byte              `json:"pipeline_yaml,omitempty"`
+	SubpipelineYAMLs map[string][]byte   `json:"subpipeline_yamls,omitempty"`
+	FromNode         string              `json:"from_node,omitempty"`
+	InputPath        string              `json:"input_path,omitempty"`
+	WorkDir          string              `json:"work_dir"`
+	Branch           string              `json:"branch"`
+	Repos            []string            `json:"repos,omitempty"`
+	BaseRef          string              `json:"base_ref,omitempty"`
 }
 
 // ClimbOutput is the output of a completed Climb workflow.

--- a/internal/outcome/detect.go
+++ b/internal/outcome/detect.go
@@ -101,6 +101,11 @@ func typeDefault(node *pipeline.NodeConfig, workDir string, attempt int) model.C
 		// which is called directly — Detect() is not invoked for gates in current code.
 		// If this path ever becomes reachable, PASS is a safe no-op since the activity will override.
 		return model.CompletionResult{Outcome: model.OutcomePass, Attempt: attempt}
+	case "route_result":
+		// Defensive default: route outcome is determined by materializeRouteFromStdout() in the activity,
+		// which is called directly — Detect() is not invoked for router nodes in current code.
+		// If this path ever becomes reachable, PASS is a safe no-op since the activity will override.
+		return model.CompletionResult{Outcome: model.OutcomePass, Attempt: attempt}
 	default:
 		// commit types default to PASS (caller checks commits via hasNewCommits)
 		return model.CompletionResult{Outcome: model.OutcomePass, Attempt: attempt}

--- a/internal/pipeline/model.go
+++ b/internal/pipeline/model.go
@@ -9,6 +9,18 @@ const (
 	NodeTypeAgent NodeType = "agent"
 )
 
+// RouteOption defines a single route in a router node.
+type RouteOption struct {
+	Pipeline    string `yaml:"pipeline" json:"pipeline"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+}
+
+// RouteConfig defines the routing behaviour for a router node.
+type RouteConfig struct {
+	Mode    string                 `yaml:"mode" json:"mode"`
+	Options map[string]RouteOption `yaml:"options" json:"options"`
+}
+
 // DimensionConfig defines a scoring dimension for a gate node.
 type DimensionConfig struct {
 	Name        string  `yaml:"name" json:"name"`
@@ -56,6 +68,7 @@ type NodeConfig struct {
 	Output      OutputConfig      `yaml:"output" json:"output"`
 	Dimensions  []DimensionConfig `yaml:"dimensions,omitempty" json:"dimensions,omitempty"`
 	Thresholds  ThresholdConfig   `yaml:"thresholds,omitempty" json:"thresholds,omitempty"`
+	Routes      *RouteConfig      `yaml:"routes,omitempty" json:"routes,omitempty"`
 	OnPass      string            `yaml:"on_pass" json:"on_pass"`
 	OnRetry     string            `yaml:"on_retry" json:"on_retry"`
 	OnFail      string            `yaml:"on_fail" json:"on_fail"`
@@ -69,7 +82,7 @@ type InputConfig struct {
 }
 
 // OutputConfig specifies what a node produces.
-// Type is one of: file | commit | gate_result | pr
+// Type is one of: file | commit | gate_result | pr | route_result
 type OutputConfig struct {
 	Type          string `yaml:"type" json:"type"`
 	Path          string `yaml:"path,omitempty" json:"path,omitempty"`
@@ -81,6 +94,11 @@ type OutputConfig struct {
 // Agent nodes with dimensions are also treated as gates for scoring purposes.
 func (n *NodeConfig) IsGate() bool {
 	return n.Type == NodeTypeGate || (n.Type == NodeTypeAgent && len(n.Dimensions) > 0)
+}
+
+// IsRouter returns true if this node is a router (has routes with at least one option).
+func (n *NodeConfig) IsRouter() bool {
+	return n.Routes != nil && len(n.Routes.Options) > 0
 }
 
 // IsAgent returns true if this node uses a vendor agent.

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -92,6 +92,10 @@ func Validate(cfg *PipelineConfig) error {
 			sort.Strings(valid)
 			return fmt.Errorf("node %q: output.type must be one of [%s], got %q", n.Name, strings.Join(valid, ", "), n.Output.Type)
 		}
+		// Mutual exclusion: routes and dimensions cannot coexist on the same node.
+		if n.IsRouter() && len(n.Dimensions) > 0 {
+			return fmt.Errorf("router %q: routes and dimensions are mutually exclusive — use one or the other", n.Name)
+		}
 		// Enforce consistency between node type and output type.
 		// Gate nodes and agent nodes with dimensions both produce gate_result.
 		if n.IsGate() && n.Output.Type != "gate_result" {
@@ -169,9 +173,6 @@ func Validate(cfg *PipelineConfig) error {
 			if n.Output.Type != "route_result" {
 				return fmt.Errorf("router %q: output.type must be \"route_result\" when routes are present, got %q", n.Name, n.Output.Type)
 			}
-			if n.IsGate() {
-				return fmt.Errorf("router %q: routes and dimensions are mutually exclusive — use one or the other", n.Name)
-			}
 			if n.Type != NodeTypeAgent {
 				return fmt.Errorf("router %q: router nodes must have type \"agent\" (got %q)", n.Name, n.Type)
 			}
@@ -209,13 +210,6 @@ func Validate(cfg *PipelineConfig) error {
 		}
 	}
 	return nil
-}
-
-// ValidateRoutes parses and validates every subpipeline referenced by router nodes.
-// It must be called at all entrypoints (climb, worker) after Validate() succeeds.
-func ValidateRoutes(cfg *PipelineConfig, workDir string) error {
-	_, err := ResolveSubpipelineYAMLs(cfg, workDir)
-	return err
 }
 
 // ResolveSubpipelineYAMLs validates and pre-reads all subpipeline YAML files for router nodes.

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 )
 
+// routeNameRe validates route option names (alphanumeric with hyphens).
+var routeNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*$`)
+
 // Validate checks a PipelineConfig for structural correctness.
 func Validate(cfg *PipelineConfig) error {
 	if cfg.Name == "" {
@@ -155,7 +158,6 @@ func Validate(cfg *PipelineConfig) error {
 			if len(n.Routes.Options) < 2 {
 				return fmt.Errorf("router %q: must have at least 2 route options, got %d", n.Name, len(n.Routes.Options))
 			}
-			routeNameRe := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*$`)
 			for optName, opt := range n.Routes.Options {
 				if !routeNameRe.MatchString(optName) {
 					return fmt.Errorf("router %q: option name %q must match pattern ^[a-zA-Z0-9][a-zA-Z0-9-]*$", n.Name, optName)

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -34,10 +36,11 @@ func Validate(cfg *PipelineConfig) error {
 		"self": true,
 	}
 	validOutputTypes := map[string]bool{
-		"file":        true,
-		"gate_result": true,
-		"commit":      true,
-		"pr":          true,
+		"file":         true,
+		"gate_result":  true,
+		"commit":       true,
+		"pr":           true,
+		"route_result": true,
 	}
 	validNodeTypes := map[NodeType]bool{
 		"":            true,
@@ -47,7 +50,7 @@ func Validate(cfg *PipelineConfig) error {
 	}
 	for _, n := range cfg.Nodes {
 		if !validNodeTypes[n.Type] {
-			return fmt.Errorf("node %q: unknown type %q (must be \"node\" or \"gate\")", n.Name, n.Type)
+			return fmt.Errorf("node %q: unknown type %q (must be \"node\", \"gate\", or \"agent\")", n.Name, n.Type)
 		}
 		// Agent node validation: vendor and prompt required, command mutually exclusive.
 		if n.Type == NodeTypeAgent {
@@ -144,8 +147,40 @@ func Validate(cfg *PipelineConfig) error {
 		} else if len(n.Dimensions) > 0 && n.Type != NodeTypeAgent {
 			return fmt.Errorf("node %q: dimensions are only valid on gate or agent nodes", n.Name)
 		}
+		// Router-specific validation
+		if n.IsRouter() {
+			if n.Routes.Mode != "choose_one" {
+				return fmt.Errorf("router %q: routes.mode must be \"choose_one\", got %q", n.Name, n.Routes.Mode)
+			}
+			if len(n.Routes.Options) < 2 {
+				return fmt.Errorf("router %q: must have at least 2 route options, got %d", n.Name, len(n.Routes.Options))
+			}
+			routeNameRe := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*$`)
+			for optName, opt := range n.Routes.Options {
+				if !routeNameRe.MatchString(optName) {
+					return fmt.Errorf("router %q: option name %q must match pattern ^[a-zA-Z0-9][a-zA-Z0-9-]*$", n.Name, optName)
+				}
+				if opt.Pipeline == "" {
+					return fmt.Errorf("router %q: option %q must have a non-empty pipeline path", n.Name, optName)
+				}
+			}
+			if n.Output.Type != "route_result" {
+				return fmt.Errorf("router %q: output.type must be \"route_result\" when routes are present, got %q", n.Name, n.Output.Type)
+			}
+			if n.IsGate() {
+				return fmt.Errorf("router %q: routes and dimensions are mutually exclusive — use one or the other", n.Name)
+			}
+			if n.Type != NodeTypeAgent {
+				return fmt.Errorf("router %q: router nodes must have type \"agent\" (got %q)", n.Name, n.Type)
+			}
+			if n.OnRetry != "" && n.OnRetry != "self" {
+				return fmt.Errorf("router %q: on_retry must be \"self\" or empty, got %q", n.Name, n.OnRetry)
+			}
+		} else if n.Output.Type == "route_result" {
+			return fmt.Errorf("node %q: output.type \"route_result\" is only valid on router nodes (add routes: with options)", n.Name)
+		}
 	}
-	// Validate intake configs.
+	// Validate intake configs (must be after node loop — uses `seen` for node name lookup).
 	validIntakeTypes := map[string]bool{
 		"jira":        true,
 		"interactive": true,
@@ -172,4 +207,40 @@ func Validate(cfg *PipelineConfig) error {
 		}
 	}
 	return nil
+}
+
+// ValidateRoutes parses and validates every subpipeline referenced by router nodes.
+// It must be called at all entrypoints (climb, worker) after Validate() succeeds.
+func ValidateRoutes(cfg *PipelineConfig, workDir string) error {
+	_, err := ResolveSubpipelineYAMLs(cfg, workDir)
+	return err
+}
+
+// ResolveSubpipelineYAMLs validates and pre-reads all subpipeline YAML files for router nodes.
+// Returns a map from route option name to raw YAML bytes. This snapshot is passed into
+// ClimbInput.SubpipelineYAMLs so the Temporal workflow can resolve subpipelines
+// deterministically without file I/O.
+func ResolveSubpipelineYAMLs(cfg *PipelineConfig, workDir string) (map[string][]byte, error) {
+	result := make(map[string][]byte)
+	for _, n := range cfg.Nodes {
+		if !n.IsRouter() {
+			continue
+		}
+		for optName, opt := range n.Routes.Options {
+			subPath := filepath.Join(workDir, opt.Pipeline)
+			data, err := os.ReadFile(subPath)
+			if err != nil {
+				return nil, fmt.Errorf("router %q option %q: cannot read subpipeline %q: %w", n.Name, optName, opt.Pipeline, err)
+			}
+			subCfg, err := ParsePipeline(data)
+			if err != nil {
+				return nil, fmt.Errorf("router %q option %q: failed to parse subpipeline %q: %w", n.Name, optName, opt.Pipeline, err)
+			}
+			if err := Validate(subCfg); err != nil {
+				return nil, fmt.Errorf("router %q option %q: subpipeline %q is invalid: %w", n.Name, optName, opt.Pipeline, err)
+			}
+			result[optName] = data
+		}
+	}
+	return result, nil
 }

--- a/internal/pipeline/validate_test.go
+++ b/internal/pipeline/validate_test.go
@@ -338,3 +338,159 @@ func TestValidate_GateWithVendorNoPrompt(t *testing.T) {
 		t.Errorf("error should mention missing prompt, got: %v", err)
 	}
 }
+
+// --- Router validation tests ---
+
+func validRouterPipeline() *PipelineConfig {
+	return &PipelineConfig{
+		Name: "router-pipeline",
+		Nodes: []NodeConfig{
+			{
+				Name:   "lead",
+				Type:   NodeTypeNode,
+				Output: OutputConfig{Type: "commit"},
+				OnPass: "router",
+				OnFail: "stop",
+			},
+			{
+				Name:   "router",
+				Type:   NodeTypeAgent,
+				Vendor: "claude",
+				Prompt: "Classify this change",
+				Output: OutputConfig{Type: "route_result"},
+				Routes: &RouteConfig{
+					Mode: "choose_one",
+					Options: map[string]RouteOption{
+						"full-review":  {Pipeline: ".belayer/pipelines/full.yaml", Description: "Full"},
+						"quick-review": {Pipeline: ".belayer/pipelines/quick.yaml", Description: "Quick"},
+					},
+				},
+				OnPass:     "stop",
+				OnRetry:    "self",
+				OnFail:     "stop",
+				MaxRetries: 2,
+			},
+		},
+	}
+}
+
+func TestValidate_RouterValid(t *testing.T) {
+	if err := Validate(validRouterPipeline()); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidate_RouterInvalidMode(t *testing.T) {
+	cfg := validRouterPipeline()
+	cfg.Nodes[1].Routes.Mode = "fan_out"
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid route mode")
+	}
+	if !strings.Contains(err.Error(), "choose_one") {
+		t.Errorf("error should mention choose_one, got: %v", err)
+	}
+}
+
+func TestValidate_RouterSingleOption(t *testing.T) {
+	cfg := validRouterPipeline()
+	cfg.Nodes[1].Routes.Options = map[string]RouteOption{
+		"only-option": {Pipeline: ".belayer/pipelines/only.yaml"},
+	}
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for single route option")
+	}
+	if !strings.Contains(err.Error(), "at least 2") {
+		t.Errorf("error should mention at least 2, got: %v", err)
+	}
+}
+
+func TestValidate_RouterInvalidOptionName(t *testing.T) {
+	cfg := validRouterPipeline()
+	cfg.Nodes[1].Routes.Options["bad name spaces"] = RouteOption{Pipeline: "p.yaml"}
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid option name")
+	}
+	if !strings.Contains(err.Error(), "must match pattern") {
+		t.Errorf("error should mention pattern, got: %v", err)
+	}
+}
+
+func TestValidate_RouterEmptyPipeline(t *testing.T) {
+	cfg := validRouterPipeline()
+	cfg.Nodes[1].Routes.Options["full-review"] = RouteOption{Pipeline: "", Description: "Full"}
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for empty pipeline path")
+	}
+	if !strings.Contains(err.Error(), "non-empty pipeline") {
+		t.Errorf("error should mention non-empty pipeline, got: %v", err)
+	}
+}
+
+func TestValidate_RouterWrongOutputType(t *testing.T) {
+	cfg := validRouterPipeline()
+	cfg.Nodes[1].Output.Type = "file"
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for wrong output type on router")
+	}
+	if !strings.Contains(err.Error(), "route_result") {
+		t.Errorf("error should mention route_result, got: %v", err)
+	}
+}
+
+func TestValidate_RouterWithDimensions(t *testing.T) {
+	cfg := validRouterPipeline()
+	cfg.Nodes[1].Dimensions = []DimensionConfig{
+		{Name: "quality", Weight: 1.0},
+	}
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for router with dimensions")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutually exclusive, got: %v", err)
+	}
+}
+
+func TestValidate_RouterNonAgentType(t *testing.T) {
+	cfg := validRouterPipeline()
+	cfg.Nodes[1].Type = NodeTypeNode
+	cfg.Nodes[1].Command = "echo test"
+	cfg.Nodes[1].Vendor = ""
+	cfg.Nodes[1].Prompt = ""
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for non-agent router")
+	}
+	if !strings.Contains(err.Error(), "agent") {
+		t.Errorf("error should mention agent, got: %v", err)
+	}
+}
+
+func TestValidate_RouterInvalidOnRetry(t *testing.T) {
+	cfg := validRouterPipeline()
+	cfg.Nodes[1].OnRetry = "lead"
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for router on_retry pointing to another node")
+	}
+	if !strings.Contains(err.Error(), "on_retry") {
+		t.Errorf("error should mention on_retry, got: %v", err)
+	}
+}
+
+func TestValidate_RouteResultOnNonRouter(t *testing.T) {
+	cfg := validPipeline()
+	cfg.Nodes[0].Output.Type = "route_result"
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for route_result on non-router")
+	}
+	if !strings.Contains(err.Error(), "route_result") {
+		t.Errorf("error should mention route_result, got: %v", err)
+	}
+}

--- a/internal/route/prompt.go
+++ b/internal/route/prompt.go
@@ -1,0 +1,38 @@
+package route
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/donovan-yohan/belayer/internal/pipeline"
+)
+
+// BuildRoutePrompt generates a structured route description block for injection
+// into the LLM prompt. Same pattern as gate.BuildGatePrompt().
+func BuildRoutePrompt(node pipeline.NodeConfig) string {
+	if node.Routes == nil || len(node.Routes.Options) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("\nChoose one of the following routes:\n")
+
+	// Sort option names for deterministic prompt output
+	names := make([]string, 0, len(node.Routes.Options))
+	for name := range node.Routes.Options {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		opt := node.Routes.Options[name]
+		desc := strings.TrimSpace(opt.Description)
+		if desc != "" {
+			fmt.Fprintf(&sb, "- %s: %s\n", name, desc)
+		} else {
+			fmt.Fprintf(&sb, "- %s\n", name)
+		}
+	}
+	sb.WriteString("\nYou MUST choose exactly one route. Output your choice as structured JSON.\n")
+	return sb.String()
+}

--- a/internal/route/result.go
+++ b/internal/route/result.go
@@ -41,7 +41,8 @@ func ParseBytes(data []byte, validRoutes []string) (*RouteResult, error) {
 	return &result, nil
 }
 
-// Validate checks that the chosen route is in the valid set.
+// Validate checks that the route result is well-formed: route is in the valid set,
+// confidence is in [0, 1], and reasoning is non-empty.
 func (r *RouteResult) Validate(validRoutes []string) error {
 	if r.Route == "" {
 		return fmt.Errorf("route result: route field is empty")
@@ -52,6 +53,12 @@ func (r *RouteResult) Validate(validRoutes []string) error {
 	}
 	if !valid[r.Route] {
 		return fmt.Errorf("route result: chosen route %q is not in valid set %v", r.Route, validRoutes)
+	}
+	if r.Confidence < 0 || r.Confidence > 1 {
+		return fmt.Errorf("route result: confidence must be in [0, 1], got %f", r.Confidence)
+	}
+	if r.Reasoning == "" {
+		return fmt.Errorf("route result: reasoning field is required")
 	}
 	return nil
 }

--- a/internal/route/result.go
+++ b/internal/route/result.go
@@ -1,0 +1,57 @@
+package route
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// RouteResult is the structured output from a routing decision.
+type RouteResult struct {
+	Route      string          `json:"route"`
+	Confidence float64         `json:"confidence"`
+	Reasoning  string          `json:"reasoning"`
+	Rejected   []RejectedRoute `json:"rejected"`
+}
+
+// RejectedRoute describes a route that was not chosen.
+type RejectedRoute struct {
+	Route  string `json:"route"`
+	Reason string `json:"reason"`
+}
+
+// Parse reads and validates a route-result.json file against valid route names.
+func Parse(path string, validRoutes []string) (*RouteResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read route result: %w", err)
+	}
+	return ParseBytes(data, validRoutes)
+}
+
+// ParseBytes parses route result JSON bytes and validates against valid route names.
+func ParseBytes(data []byte, validRoutes []string) (*RouteResult, error) {
+	var result RouteResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("parse route result: %w", err)
+	}
+	if err := result.Validate(validRoutes); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// Validate checks that the chosen route is in the valid set.
+func (r *RouteResult) Validate(validRoutes []string) error {
+	if r.Route == "" {
+		return fmt.Errorf("route result: route field is empty")
+	}
+	valid := make(map[string]bool, len(validRoutes))
+	for _, v := range validRoutes {
+		valid[v] = true
+	}
+	if !valid[r.Route] {
+		return fmt.Errorf("route result: chosen route %q is not in valid set %v", r.Route, validRoutes)
+	}
+	return nil
+}

--- a/internal/route/result_test.go
+++ b/internal/route/result_test.go
@@ -85,7 +85,7 @@ func TestParseBytes_ValidWithZeroConfidence(t *testing.T) {
 // --- Validate tests ---
 
 func TestValidate_ChosenInSet(t *testing.T) {
-	r := &RouteResult{Route: "full-feature-review"}
+	r := &RouteResult{Route: "full-feature-review", Confidence: 0.9, Reasoning: "broad change"}
 	err := r.Validate([]string{"quick-bugfix-review", "full-feature-review", "refactor-review"})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/internal/route/result_test.go
+++ b/internal/route/result_test.go
@@ -1,0 +1,191 @@
+package route
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/donovan-yohan/belayer/internal/pipeline"
+)
+
+// --- ParseBytes tests ---
+
+func TestParseBytes_Valid(t *testing.T) {
+	data := []byte(`{
+		"route": "quick-bugfix-review",
+		"confidence": 0.92,
+		"reasoning": "Small localized fix with no behavioral changes.",
+		"rejected": [
+			{"route": "full-feature-review", "reason": "too broad for this change"},
+			{"route": "refactor-review", "reason": "no structural changes"}
+		]
+	}`)
+	validRoutes := []string{"quick-bugfix-review", "full-feature-review", "refactor-review"}
+
+	result, err := ParseBytes(data, validRoutes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Route != "quick-bugfix-review" {
+		t.Errorf("Route: got %q, want %q", result.Route, "quick-bugfix-review")
+	}
+	if result.Confidence != 0.92 {
+		t.Errorf("Confidence: got %f, want 0.92", result.Confidence)
+	}
+	if result.Reasoning == "" {
+		t.Error("Reasoning should not be empty")
+	}
+	if len(result.Rejected) != 2 {
+		t.Errorf("Rejected: got %d entries, want 2", len(result.Rejected))
+	}
+}
+
+func TestParseBytes_InvalidJSON(t *testing.T) {
+	_, err := ParseBytes([]byte("not json"), []string{"route-a"})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "parse route result") {
+		t.Errorf("error should mention parse context, got: %v", err)
+	}
+}
+
+func TestParseBytes_EmptyRoute(t *testing.T) {
+	data := []byte(`{"route": "", "confidence": 0.8, "reasoning": "ok", "rejected": []}`)
+	_, err := ParseBytes(data, []string{"route-a", "route-b"})
+	if err == nil {
+		t.Fatal("expected error for empty route field")
+	}
+	if !strings.Contains(err.Error(), "route field is empty") {
+		t.Errorf("error should mention empty route field, got: %v", err)
+	}
+}
+
+func TestParseBytes_InvalidRoute(t *testing.T) {
+	data := []byte(`{"route": "unknown-route", "confidence": 0.5, "reasoning": "picked something", "rejected": []}`)
+	_, err := ParseBytes(data, []string{"route-a", "route-b"})
+	if err == nil {
+		t.Fatal("expected error for route not in valid set")
+	}
+	if !strings.Contains(err.Error(), "not in valid set") {
+		t.Errorf("error should mention valid set, got: %v", err)
+	}
+}
+
+func TestParseBytes_ValidWithZeroConfidence(t *testing.T) {
+	data := []byte(`{"route": "route-a", "confidence": 0, "reasoning": "uncertain", "rejected": []}`)
+	result, err := ParseBytes(data, []string{"route-a", "route-b"})
+	if err != nil {
+		t.Fatalf("unexpected error for zero confidence: %v", err)
+	}
+	if result.Confidence != 0 {
+		t.Errorf("Confidence: got %f, want 0", result.Confidence)
+	}
+}
+
+// --- Validate tests ---
+
+func TestValidate_ChosenInSet(t *testing.T) {
+	r := &RouteResult{Route: "full-feature-review"}
+	err := r.Validate([]string{"quick-bugfix-review", "full-feature-review", "refactor-review"})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ChosenNotInSet(t *testing.T) {
+	r := &RouteResult{Route: "nonexistent-route"}
+	err := r.Validate([]string{"route-a", "route-b"})
+	if err == nil {
+		t.Fatal("expected error for route not in valid set")
+	}
+	if !strings.Contains(err.Error(), "not in valid set") {
+		t.Errorf("error should mention valid set, got: %v", err)
+	}
+}
+
+// --- BuildRoutePrompt tests ---
+
+func TestBuildRoutePrompt_WithDescriptions(t *testing.T) {
+	node := pipeline.NodeConfig{
+		Name: "review-router",
+		Routes: &pipeline.RouteConfig{
+			Mode: "choose_one",
+			Options: map[string]pipeline.RouteOption{
+				"full-feature-review": {
+					Pipeline:    "pipelines/full-feature-review.yaml",
+					Description: "Broad or risky change. Needs browser QA, design review.",
+				},
+				"quick-bugfix-review": {
+					Pipeline:    "pipelines/quick-bugfix-review.yaml",
+					Description: "Small localized fix. Code review gate only.",
+				},
+			},
+		},
+	}
+
+	prompt := BuildRoutePrompt(node)
+
+	if !strings.Contains(prompt, "Choose one of the following routes:") {
+		t.Error("prompt should contain route header")
+	}
+	if !strings.Contains(prompt, "full-feature-review") {
+		t.Error("prompt should contain route name 'full-feature-review'")
+	}
+	if !strings.Contains(prompt, "Broad or risky change") {
+		t.Error("prompt should contain route description")
+	}
+	if !strings.Contains(prompt, "quick-bugfix-review") {
+		t.Error("prompt should contain route name 'quick-bugfix-review'")
+	}
+	if !strings.Contains(prompt, "Small localized fix") {
+		t.Error("prompt should contain route description")
+	}
+	if !strings.Contains(prompt, "You MUST choose exactly one route") {
+		t.Error("prompt should contain instruction to choose exactly one route")
+	}
+	if !strings.Contains(prompt, "structured JSON") {
+		t.Error("prompt should mention structured JSON output")
+	}
+}
+
+func TestBuildRoutePrompt_NoRoutes(t *testing.T) {
+	nodeNilRoutes := pipeline.NodeConfig{Name: "plain-node"}
+	if got := BuildRoutePrompt(nodeNilRoutes); got != "" {
+		t.Errorf("expected empty string for nil Routes, got %q", got)
+	}
+
+	nodeEmptyOptions := pipeline.NodeConfig{
+		Name:   "router-no-options",
+		Routes: &pipeline.RouteConfig{Mode: "choose_one", Options: map[string]pipeline.RouteOption{}},
+	}
+	if got := BuildRoutePrompt(nodeEmptyOptions); got != "" {
+		t.Errorf("expected empty string for empty Options, got %q", got)
+	}
+}
+
+func TestBuildRoutePrompt_SortedOutput(t *testing.T) {
+	node := pipeline.NodeConfig{
+		Name: "review-router",
+		Routes: &pipeline.RouteConfig{
+			Mode: "choose_one",
+			Options: map[string]pipeline.RouteOption{
+				"zebra-route":  {Pipeline: "pipelines/zebra.yaml", Description: "Last alphabetically"},
+				"alpha-route":  {Pipeline: "pipelines/alpha.yaml", Description: "First alphabetically"},
+				"middle-route": {Pipeline: "pipelines/middle.yaml", Description: "Middle alphabetically"},
+			},
+		},
+	}
+
+	prompt := BuildRoutePrompt(node)
+
+	alphaPos := strings.Index(prompt, "alpha-route")
+	middlePos := strings.Index(prompt, "middle-route")
+	zebraPos := strings.Index(prompt, "zebra-route")
+
+	if alphaPos == -1 || middlePos == -1 || zebraPos == -1 {
+		t.Fatal("prompt missing one or more route names")
+	}
+	if !(alphaPos < middlePos && middlePos < zebraPos) {
+		t.Errorf("routes not in alphabetical order: alpha=%d, middle=%d, zebra=%d", alphaPos, middlePos, zebraPos)
+	}
+}

--- a/internal/temporal/activity.go
+++ b/internal/temporal/activity.go
@@ -17,6 +17,7 @@ import (
 	"github.com/donovan-yohan/belayer/internal/model"
 	"github.com/donovan-yohan/belayer/internal/outcome"
 	"github.com/donovan-yohan/belayer/internal/pipeline"
+	"github.com/donovan-yohan/belayer/internal/route"
 	"github.com/donovan-yohan/belayer/internal/session"
 	"github.com/donovan-yohan/belayer/internal/vendor"
 )
@@ -53,8 +54,9 @@ type NodeContext struct {
 	Description string                     `json:"description"`
 	InputPrompt string                     `json:"input_prompt"`
 	Artifacts   map[string]string          `json:"artifacts"`
-	Dimensions  []pipeline.DimensionConfig `json:"dimensions,omitempty"`
-	Thresholds  *pipeline.ThresholdConfig  `json:"thresholds,omitempty"`
+	Dimensions   []pipeline.DimensionConfig `json:"dimensions,omitempty"`
+	Thresholds   *pipeline.ThresholdConfig  `json:"thresholds,omitempty"`
+	RouteOptions []string                   `json:"route_options,omitempty"`
 }
 
 // writeNodeContext writes node-context.json to the internal input directory.
@@ -117,18 +119,25 @@ func (a *Activities) NodeActivity(ctx context.Context, input NodeActivityInput) 
 	if input.Node.IsGate() {
 		thresholds = &input.Node.Thresholds
 	}
+	var routeOptions []string
+	if input.Node.IsRouter() {
+		for name := range input.Node.Routes.Options {
+			routeOptions = append(routeOptions, name)
+		}
+	}
 	nc := NodeContext{
 		SchemaVersion: 1,
-		TaskID:      input.TaskID,
-		NodeName:    input.Node.Name,
-		NodeType:    string(input.Node.EffectiveType()),
-		Attempt:     input.Attempt,
-		WorkDir:     input.WorkDir,
-		Description: input.Node.Description,
-		InputPrompt: inputPrompt,
-		Artifacts:   input.Artifacts,
-		Dimensions:  input.Node.Dimensions,
-		Thresholds:  thresholds,
+		TaskID:       input.TaskID,
+		NodeName:     input.Node.Name,
+		NodeType:     string(input.Node.EffectiveType()),
+		Attempt:      input.Attempt,
+		WorkDir:      input.WorkDir,
+		Description:  input.Node.Description,
+		InputPrompt:  inputPrompt,
+		Artifacts:    input.Artifacts,
+		Dimensions:   input.Node.Dimensions,
+		Thresholds:   thresholds,
+		RouteOptions: routeOptions,
 	}
 	if err := writeNodeContext(input.WorkDir, nc); err != nil {
 		return nil, fmt.Errorf("write node context: %w", err)
@@ -155,13 +164,24 @@ func (a *Activities) NodeActivity(ctx context.Context, input NodeActivityInput) 
 			activity.GetLogger(ctx).Warn("Prompt ref resolution partially failed, proceeding with best-effort prompt", "error", refErr, "node", input.Node.Name)
 		}
 		prompt := vendor.Interpolate(resolvedPrompt, vars)
+		schema := vendor.SchemaConfig{
+			IsGate:     input.Node.IsGate(),
+			Dimensions: input.Node.Dimensions,
+		}
+		if input.Node.IsRouter() {
+			schema.IsRouter = true
+			names := make([]string, 0, len(input.Node.Routes.Options))
+			for name := range input.Node.Routes.Options {
+				names = append(names, name)
+			}
+			schema.RouteNames = names
+		}
 		var err error
 		command, vendorCleanup, err = vendor.BuildCommand(
 			input.Node.Vendor,
 			prompt,
 			input.WorkDir,
-			input.Node.IsGate(),
-			input.Node.Dimensions,
+			schema,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("resolve vendor command for %q: %w", input.Node.Name, err)
@@ -176,7 +196,7 @@ func (a *Activities) NodeActivity(ctx context.Context, input NodeActivityInput) 
 		Description:   input.Node.Description,
 		Command:       command,
 		InputPrompt:   inputPrompt,
-		CaptureStdout: input.Node.IsGate() && input.Node.Vendor != "",
+		CaptureStdout: (input.Node.IsGate() || input.Node.IsRouter()) && input.Node.Vendor != "",
 	}
 	exitCh, err := a.Spawner.Spawn(ctx, opts)
 	if err != nil {
@@ -213,6 +233,18 @@ func (a *Activities) NodeActivity(ctx context.Context, input NodeActivityInput) 
 				}}, nil
 			}
 			return &NodeActivityOutput{Result: gateResult}, nil
+		}
+		// Router nodes with vendor: capture stdout and materialize route result.
+		if input.Node.IsRouter() && input.Node.Vendor != "" {
+			routeResult, routeErr := materializeRouteFromStdout(input, spawnResult)
+			if routeErr != nil {
+				return &NodeActivityOutput{Result: model.CompletionResult{
+					Outcome:  model.OutcomeRetry,
+					Feedback: fmt.Sprintf("route output error: %v", routeErr),
+					Attempt:  input.Attempt,
+				}}, nil
+			}
+			return &NodeActivityOutput{Result: routeResult}, nil
 		}
 		// Non-gate vendor nodes: auto-complete based on output type.
 		if input.Node.Vendor != "" {
@@ -305,6 +337,55 @@ func materializeGateFromStdout(input NodeActivityInput, spawnResult session.Spaw
 	}
 	result.Attempt = input.Attempt
 	return result, nil
+}
+
+// materializeRouteFromStdout writes route-result.json from captured stdout,
+// then parses and validates the route choice against declared options.
+func materializeRouteFromStdout(input NodeActivityInput, spawnResult session.SpawnResult) (model.CompletionResult, error) {
+	stdout := spawnResult.Stdout
+	if len(stdout) == 0 {
+		return model.CompletionResult{}, fmt.Errorf("router produced no output")
+	}
+
+	// For Claude stream-json, extract the result event.
+	if input.Node.Vendor == "claude" {
+		extracted, err := vendor.ExtractStreamResult(stdout)
+		if err != nil {
+			return model.CompletionResult{}, fmt.Errorf("extract stream result: %w", err)
+		}
+		stdout = extracted
+	}
+
+	// Resolve output path.
+	resultPath := input.Node.Output.Path
+	if resultPath == "" {
+		resultPath = ".belayer/.internal/output/route-result.json"
+	}
+	absPath := filepath.Join(input.WorkDir, resultPath)
+
+	// Write route-result.json.
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return model.CompletionResult{}, fmt.Errorf("create output dir: %w", err)
+	}
+	if err := os.WriteFile(absPath, stdout, 0o644); err != nil {
+		return model.CompletionResult{}, fmt.Errorf("write route result: %w", err)
+	}
+
+	// Parse and validate the route choice.
+	validRoutes := make([]string, 0, len(input.Node.Routes.Options))
+	for name := range input.Node.Routes.Options {
+		validRoutes = append(validRoutes, name)
+	}
+	_, err := route.ParseBytes(stdout, validRoutes)
+	if err != nil {
+		return model.CompletionResult{}, err
+	}
+
+	return model.CompletionResult{
+		Outcome:    model.OutcomePass,
+		OutputPath: resultPath,
+		Attempt:    input.Attempt,
+	}, nil
 }
 
 // processGateResult reads gate-result.json, validates, computes weighted score,
@@ -503,6 +584,17 @@ func buildInputPrompt(node pipeline.NodeConfig, artifacts map[string]string) str
 				fmt.Fprintf(&sb, "\nInput artifact at: %s\n", path)
 			}
 		}
+	} else if node.IsRouter() {
+		sb.WriteString(route.BuildRoutePrompt(node))
+		sb.WriteString("\n")
+		switch node.Input.Type {
+		case "code", "commit":
+			sb.WriteString("\nInput: Review the changes. Full diff at .belayer/.internal/input/diff.txt\n")
+		case "file":
+			if path, ok := artifacts[resolveInputKey(node)]; ok {
+				fmt.Fprintf(&sb, "\nInput artifact at: %s\n", path)
+			}
+		}
 	} else {
 		switch node.Input.Type {
 		case "file":
@@ -587,6 +679,26 @@ func GetHeadSHA(workDir string) (string, error) {
 		return "", fmt.Errorf("git rev-parse HEAD: %w", err)
 	}
 	return strings.TrimSpace(out), nil
+}
+
+// ReadFileInput is the input to ReadFileActivity.
+type ReadFileInput struct {
+	FilePath string
+	WorkDir  string
+}
+
+// ReadFileActivity reads a file from disk. Used by workflows to read route results
+// without violating Temporal determinism constraints.
+func (a *Activities) ReadFileActivity(ctx context.Context, input ReadFileInput) ([]byte, error) {
+	absPath := input.FilePath
+	if !filepath.IsAbs(absPath) {
+		absPath = filepath.Join(input.WorkDir, absPath)
+	}
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("read file %q: %w", input.FilePath, err)
+	}
+	return data, nil
 }
 
 // runGit runs a git command in workDir and returns combined output.

--- a/internal/temporal/activity.go
+++ b/internal/temporal/activity.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -124,6 +125,7 @@ func (a *Activities) NodeActivity(ctx context.Context, input NodeActivityInput) 
 		for name := range input.Node.Routes.Options {
 			routeOptions = append(routeOptions, name)
 		}
+		sort.Strings(routeOptions)
 	}
 	nc := NodeContext{
 		SchemaVersion: 1,
@@ -174,6 +176,7 @@ func (a *Activities) NodeActivity(ctx context.Context, input NodeActivityInput) 
 			for name := range input.Node.Routes.Options {
 				names = append(names, name)
 			}
+			sort.Strings(names)
 			schema.RouteNames = names
 		}
 		var err error

--- a/internal/temporal/activity_test.go
+++ b/internal/temporal/activity_test.go
@@ -510,3 +510,160 @@ func TestProcessGateResult_MissingGateResultJSON(t *testing.T) {
 		t.Fatal("expected error for missing gate-result.json")
 	}
 }
+
+// --- ReadFileActivity tests ---
+
+func TestReadFileActivity_Success(t *testing.T) {
+	workDir := t.TempDir()
+	filePath := filepath.Join(workDir, "test-file.json")
+	want := []byte(`{"route":"quick-review"}`)
+	if err := os.WriteFile(filePath, want, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	a := &Activities{}
+	got, err := a.ReadFileActivity(context.Background(), ReadFileInput{
+		FilePath: filePath,
+		WorkDir:  workDir,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadFileActivity_RelativePath(t *testing.T) {
+	workDir := t.TempDir()
+	subDir := filepath.Join(workDir, ".belayer", ".internal", "output")
+	os.MkdirAll(subDir, 0o755)
+	want := []byte(`{"route":"full-review"}`)
+	os.WriteFile(filepath.Join(subDir, "route-result.json"), want, 0o644)
+
+	a := &Activities{}
+	got, err := a.ReadFileActivity(context.Background(), ReadFileInput{
+		FilePath: ".belayer/.internal/output/route-result.json",
+		WorkDir:  workDir,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadFileActivity_Missing(t *testing.T) {
+	a := &Activities{}
+	_, err := a.ReadFileActivity(context.Background(), ReadFileInput{
+		FilePath: "/tmp/nonexistent-file-12345.json",
+		WorkDir:  "/tmp",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "read file") {
+		t.Errorf("error should mention read file, got: %v", err)
+	}
+}
+
+// --- materializeRouteFromStdout tests ---
+
+func TestMaterializeRouteFromStdout_Valid(t *testing.T) {
+	workDir := t.TempDir()
+	stdout := []byte(`{"route":"quick-review","confidence":0.9,"reasoning":"small fix","rejected":[{"route":"full-review","reason":"too broad"}]}`)
+
+	input := NodeActivityInput{
+		WorkDir: workDir,
+		Attempt: 0,
+		Node: pipeline.NodeConfig{
+			Name:   "review-router",
+			Type:   pipeline.NodeTypeAgent,
+			Vendor: "codex",
+			Output: pipeline.OutputConfig{
+				Type: "route_result",
+				Path: ".belayer/.internal/output/route-result.json",
+			},
+			Routes: &pipeline.RouteConfig{
+				Mode: "choose_one",
+				Options: map[string]pipeline.RouteOption{
+					"quick-review": {Pipeline: "pipelines/quick.yaml"},
+					"full-review":  {Pipeline: "pipelines/full.yaml"},
+				},
+			},
+		},
+	}
+	spawnResult := session.SpawnResult{Stdout: stdout}
+
+	result, err := materializeRouteFromStdout(input, spawnResult)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Outcome != model.OutcomePass {
+		t.Errorf("outcome: got %q, want PASS", result.Outcome)
+	}
+	if result.OutputPath == "" {
+		t.Error("expected OutputPath to be set")
+	}
+
+	// Verify file was written.
+	data, err := os.ReadFile(filepath.Join(workDir, result.OutputPath))
+	if err != nil {
+		t.Fatalf("route-result.json not written: %v", err)
+	}
+	if string(data) != string(stdout) {
+		t.Errorf("file content mismatch")
+	}
+}
+
+func TestMaterializeRouteFromStdout_EmptyStdout(t *testing.T) {
+	input := NodeActivityInput{
+		WorkDir: t.TempDir(),
+		Node: pipeline.NodeConfig{
+			Name:   "router",
+			Vendor: "codex",
+			Routes: &pipeline.RouteConfig{
+				Options: map[string]pipeline.RouteOption{
+					"a": {Pipeline: "a.yaml"},
+					"b": {Pipeline: "b.yaml"},
+				},
+			},
+		},
+	}
+	_, err := materializeRouteFromStdout(input, session.SpawnResult{Stdout: nil})
+	if err == nil {
+		t.Fatal("expected error for empty stdout")
+	}
+	if !strings.Contains(err.Error(), "no output") {
+		t.Errorf("error should mention no output, got: %v", err)
+	}
+}
+
+func TestMaterializeRouteFromStdout_InvalidRoute(t *testing.T) {
+	workDir := t.TempDir()
+	stdout := []byte(`{"route":"nonexistent","confidence":0.5,"reasoning":"oops","rejected":[]}`)
+
+	input := NodeActivityInput{
+		WorkDir: workDir,
+		Node: pipeline.NodeConfig{
+			Name:   "router",
+			Vendor: "codex",
+			Output: pipeline.OutputConfig{Type: "route_result"},
+			Routes: &pipeline.RouteConfig{
+				Options: map[string]pipeline.RouteOption{
+					"route-a": {Pipeline: "a.yaml"},
+					"route-b": {Pipeline: "b.yaml"},
+				},
+			},
+		},
+	}
+
+	_, err := materializeRouteFromStdout(input, session.SpawnResult{Stdout: stdout})
+	if err == nil {
+		t.Fatal("expected error for invalid route choice")
+	}
+	if !strings.Contains(err.Error(), "not in valid set") {
+		t.Errorf("error should mention valid set, got: %v", err)
+	}
+}

--- a/internal/temporal/workflow.go
+++ b/internal/temporal/workflow.go
@@ -313,19 +313,20 @@ func dispatchRoute(
 	}
 
 	chosenRoute := routeResult.Route
-	option, ok := node.Routes.Options[chosenRoute]
-	if !ok {
+	if _, ok := node.Routes.Options[chosenRoute]; !ok {
 		return nil, fmt.Errorf("route %q not found in declared options", chosenRoute)
 	}
 
 	// 3. Resolve subpipeline YAML from pre-loaded map (deterministic, no file I/O).
+	// Map is keyed by route option name (set by ResolveSubpipelineYAMLs at startup).
 	subYAML, ok := input.SubpipelineYAMLs[chosenRoute]
 	if !ok {
-		// Fallback: try the option pipeline path as key.
-		subYAML, ok = input.SubpipelineYAMLs[option.Pipeline]
-		if !ok {
-			return nil, fmt.Errorf("subpipeline YAML for route %q not pre-loaded (key: %q)", chosenRoute, option.Pipeline)
+		keys := make([]string, 0, len(input.SubpipelineYAMLs))
+		for k := range input.SubpipelineYAMLs {
+			keys = append(keys, k)
 		}
+		sort.Strings(keys)
+		return nil, fmt.Errorf("subpipeline YAML for route %q not pre-loaded (available keys: %v)", chosenRoute, keys)
 	}
 
 	// 4. Parse and validate subpipeline.

--- a/internal/temporal/workflow.go
+++ b/internal/temporal/workflow.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/donovan-yohan/belayer/internal/model"
 	"github.com/donovan-yohan/belayer/internal/pipeline"
+	"github.com/donovan-yohan/belayer/internal/route"
 )
 
 // findNodeIndex returns the index of the node with the given name, or -1 if not found.
@@ -110,6 +111,57 @@ func ClimbWorkflow(ctx workflow.Context, input model.ClimbInput) (*model.ClimbOu
 				artifacts[node.OutputKey()] = result.OutputPath
 			}
 			nodeOutputs[node.Name] = result.OutputPath
+
+			// Router dispatch: spawn child workflow for the chosen route.
+			if node.IsRouter() && result.OutputPath != "" {
+				childOut, routeErr := dispatchRoute(ctx, input, node, result, artifacts, nodeOutputs, ao)
+				if routeErr != nil {
+					return &model.ClimbOutput{
+						Status:      model.ClimbFailed,
+						NodeOutputs: nodeOutputs,
+						Message:     fmt.Sprintf("router %q dispatch failed: %v", node.Name, routeErr),
+						Branch:      input.Branch,
+					}, nil
+				}
+				if childOut.Status == model.ClimbFailed {
+					// Child failed — propagate as router node failure.
+					if node.OnFail != "" && node.OnFail != "stop" {
+						failJumps++
+						if failJumps > maxFailJumps {
+							return &model.ClimbOutput{
+								Status:      model.ClimbFailed,
+								NodeOutputs: nodeOutputs,
+								Message:     fmt.Sprintf("router %q: child failed, exceeded max fail jumps", node.Name),
+								Branch:      input.Branch,
+							}, nil
+						}
+						if i := findNodeIndex(cfg.Nodes, node.OnFail); i != -1 {
+							nodeIdx = i
+							continue
+						}
+					}
+					return &model.ClimbOutput{
+						Status:      model.ClimbFailed,
+						NodeOutputs: nodeOutputs,
+						Message:     fmt.Sprintf("router %q: child workflow failed: %s", node.Name, childOut.Message),
+						Branch:      input.Branch,
+					}, nil
+				}
+				// Merge child outputs: namespaced for auditability, plus un-namespaced alias.
+				var lastChildOutput string
+				for key, path := range childOut.NodeOutputs {
+					namespacedKey := fmt.Sprintf("%s/%s", node.Name, key)
+					artifacts[namespacedKey] = path
+					nodeOutputs[namespacedKey] = path
+					lastChildOutput = path
+				}
+				// Un-namespaced alias: router's output key = child's terminal output.
+				// Lets downstream parent nodes reference the router by name.
+				if lastChildOutput != "" {
+					artifacts[node.OutputKey()] = lastChildOutput
+					nodeOutputs[node.Name] = lastChildOutput
+				}
+			}
 
 			if node.OnPass == "stop" {
 				return &model.ClimbOutput{
@@ -217,3 +269,96 @@ func ClimbWorkflow(ctx workflow.Context, input model.ClimbInput) (*model.ClimbOu
 		Branch:      input.Branch,
 	}, nil
 }
+
+// dispatchRoute reads the route decision, resolves the subpipeline, spawns a child
+// workflow for the chosen route, and returns the child's output.
+func dispatchRoute(
+	ctx workflow.Context,
+	input model.ClimbInput,
+	node pipeline.NodeConfig,
+	result model.CompletionResult,
+	artifacts map[string]string,
+	nodeOutputs map[string]string,
+	ao workflow.ActivityOptions,
+) (*model.ClimbOutput, error) {
+	// 1. Read route-result.json content via a side-effect-free activity.
+	actx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Second,
+	})
+	a := &Activities{}
+	var routeResultBytes []byte
+	if err := workflow.ExecuteActivity(actx, a.ReadFileActivity, ReadFileInput{
+		FilePath: result.OutputPath,
+		WorkDir:  input.WorkDir,
+	}).Get(ctx, &routeResultBytes); err != nil {
+		return nil, fmt.Errorf("read route result: %w", err)
+	}
+
+	// 2. Parse and validate route choice.
+	validRoutes := make([]string, 0, len(node.Routes.Options))
+	for name := range node.Routes.Options {
+		validRoutes = append(validRoutes, name)
+	}
+	routeResult, err := route.ParseBytes(routeResultBytes, validRoutes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid route result: %w", err)
+	}
+
+	chosenRoute := routeResult.Route
+	option, ok := node.Routes.Options[chosenRoute]
+	if !ok {
+		return nil, fmt.Errorf("route %q not found in declared options", chosenRoute)
+	}
+
+	// 3. Resolve subpipeline YAML from pre-loaded map (deterministic, no file I/O).
+	subYAML, ok := input.SubpipelineYAMLs[chosenRoute]
+	if !ok {
+		// Fallback: try the option pipeline path as key.
+		subYAML, ok = input.SubpipelineYAMLs[option.Pipeline]
+		if !ok {
+			return nil, fmt.Errorf("subpipeline YAML for route %q not pre-loaded (key: %q)", chosenRoute, option.Pipeline)
+		}
+	}
+
+	// 4. Parse and validate subpipeline.
+	subCfg, err := pipeline.ParsePipeline(subYAML)
+	if err != nil {
+		return nil, fmt.Errorf("parse subpipeline for route %q: %w", chosenRoute, err)
+	}
+	if err := pipeline.Validate(subCfg); err != nil {
+		return nil, fmt.Errorf("validate subpipeline for route %q: %w", chosenRoute, err)
+	}
+
+	// 5. Spawn child workflow.
+	parentID := workflow.GetInfo(ctx).WorkflowExecution.ID
+	childID := fmt.Sprintf("%s/route/%s", parentID, chosenRoute)
+
+	childInput := model.ClimbInput{
+		Description:  fmt.Sprintf("Subpipeline: %s (routed from %s)", chosenRoute, node.Name),
+		PipelineYAML: subYAML,
+		WorkDir:      input.WorkDir,
+		Branch:       input.Branch,
+		BaseRef:      input.BaseRef,
+	}
+
+	cwo := workflow.ChildWorkflowOptions{
+		WorkflowID: childID,
+	}
+	childCtx := workflow.WithChildOptions(ctx, cwo)
+
+	var childOut model.ClimbOutput
+	if err := workflow.ExecuteChildWorkflow(childCtx, ClimbWorkflow, childInput).Get(ctx, &childOut); err != nil {
+		return nil, fmt.Errorf("child workflow for route %q failed: %w", chosenRoute, err)
+	}
+
+	// 6. Log route decision for observability.
+	workflow.GetLogger(ctx).Info("Route dispatched",
+		"router", node.Name,
+		"route", chosenRoute,
+		"confidence", routeResult.Confidence,
+		"child_status", childOut.Status,
+	)
+
+	return &childOut, nil
+}
+

--- a/internal/temporal/workflow.go
+++ b/internal/temporal/workflow.go
@@ -2,6 +2,7 @@ package temporal
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"go.temporal.io/sdk/workflow"
@@ -114,7 +115,7 @@ func ClimbWorkflow(ctx workflow.Context, input model.ClimbInput) (*model.ClimbOu
 
 			// Router dispatch: spawn child workflow for the chosen route.
 			if node.IsRouter() && result.OutputPath != "" {
-				childOut, routeErr := dispatchRoute(ctx, input, node, result, artifacts, nodeOutputs, ao)
+				childOut, routeErr := dispatchRoute(ctx, input, node, result, retryCount[node.Name])
 				if routeErr != nil {
 					return &model.ClimbOutput{
 						Status:      model.ClimbFailed,
@@ -148,8 +149,15 @@ func ClimbWorkflow(ctx workflow.Context, input model.ClimbInput) (*model.ClimbOu
 					}, nil
 				}
 				// Merge child outputs: namespaced for auditability, plus un-namespaced alias.
+				// Sort keys for deterministic iteration inside the Temporal workflow.
+				childKeys := make([]string, 0, len(childOut.NodeOutputs))
+				for key := range childOut.NodeOutputs {
+					childKeys = append(childKeys, key)
+				}
+				sort.Strings(childKeys)
 				var lastChildOutput string
-				for key, path := range childOut.NodeOutputs {
+				for _, key := range childKeys {
+					path := childOut.NodeOutputs[key]
 					namespacedKey := fmt.Sprintf("%s/%s", node.Name, key)
 					artifacts[namespacedKey] = path
 					nodeOutputs[namespacedKey] = path
@@ -277,9 +285,7 @@ func dispatchRoute(
 	input model.ClimbInput,
 	node pipeline.NodeConfig,
 	result model.CompletionResult,
-	artifacts map[string]string,
-	nodeOutputs map[string]string,
-	ao workflow.ActivityOptions,
+	attempt int,
 ) (*model.ClimbOutput, error) {
 	// 1. Read route-result.json content via a side-effect-free activity.
 	actx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
@@ -295,10 +301,12 @@ func dispatchRoute(
 	}
 
 	// 2. Parse and validate route choice.
+	// Collect and sort route names for deterministic validation inside the workflow.
 	validRoutes := make([]string, 0, len(node.Routes.Options))
 	for name := range node.Routes.Options {
 		validRoutes = append(validRoutes, name)
 	}
+	sort.Strings(validRoutes)
 	routeResult, err := route.ParseBytes(routeResultBytes, validRoutes)
 	if err != nil {
 		return nil, fmt.Errorf("invalid route result: %w", err)
@@ -330,15 +338,17 @@ func dispatchRoute(
 	}
 
 	// 5. Spawn child workflow.
+	// Include attempt counter for deterministic uniqueness across retries.
 	parentID := workflow.GetInfo(ctx).WorkflowExecution.ID
-	childID := fmt.Sprintf("%s/route/%s", parentID, chosenRoute)
+	childID := fmt.Sprintf("%s/route/%s/%d", parentID, chosenRoute, attempt)
 
 	childInput := model.ClimbInput{
-		Description:  fmt.Sprintf("Subpipeline: %s (routed from %s)", chosenRoute, node.Name),
-		PipelineYAML: subYAML,
-		WorkDir:      input.WorkDir,
-		Branch:       input.Branch,
-		BaseRef:      input.BaseRef,
+		Description:      fmt.Sprintf("Subpipeline: %s (routed from %s)", chosenRoute, node.Name),
+		PipelineYAML:     subYAML,
+		SubpipelineYAMLs: input.SubpipelineYAMLs,
+		WorkDir:          input.WorkDir,
+		Branch:           input.Branch,
+		BaseRef:          input.BaseRef,
 	}
 
 	cwo := workflow.ChildWorkflowOptions{

--- a/internal/temporal/workflow_test.go
+++ b/internal/temporal/workflow_test.go
@@ -361,3 +361,191 @@ func (s *ClimbWorkflowTestSuite) TestClimb_MaxRetriesExhausted() {
 	s.Equal(model.ClimbFailed, result.Status)
 	s.Contains(result.Message, "max retries")
 }
+
+// --- Router node tests ---
+
+func routerPipelineYAML() []byte {
+	return []byte(`
+name: router-test
+nodes:
+  - name: implement
+    type: node
+    command: echo test
+    description: Write code
+    output:
+      type: commit
+    on_pass: review-router
+    on_fail: stop
+  - name: review-router
+    type: agent
+    vendor: claude
+    prompt: "Classify this change"
+    input:
+      type: commit
+      key: implement
+    output:
+      type: route_result
+      path: .belayer/.internal/output/route-result.json
+    routes:
+      mode: choose_one
+      options:
+        full-review:
+          pipeline: .belayer/pipelines/full-review.yaml
+          description: Full review
+        quick-review:
+          pipeline: .belayer/pipelines/quick-review.yaml
+          description: Quick review
+    on_pass: stop
+    on_retry: self
+    on_fail: stop
+    max_retries: 2
+`)
+}
+
+var childSubpipelineYAML = []byte(`
+name: child-review
+nodes:
+  - name: code-review
+    type: node
+    command: echo review
+    description: Review code
+    output:
+      type: file
+    on_pass: stop
+    on_fail: stop
+`)
+
+func routerInput() model.ClimbInput {
+	return model.ClimbInput{
+		PipelineYAML: routerPipelineYAML(),
+		SubpipelineYAMLs: map[string][]byte{
+			"quick-review": childSubpipelineYAML,
+			"full-review":  childSubpipelineYAML,
+		},
+		WorkDir: "/tmp/test-router",
+		Branch:  "feature/router-test",
+	}
+}
+
+var validRouteResultJSON = []byte(`{"route":"quick-review","confidence":0.9,"reasoning":"small fix","rejected":[{"route":"full-review","reason":"too small"}]}`)
+
+// TestClimb_RouterDispatchesChild: implement PASS → router PASS → child executes inline → ClimbCompleted with namespaced outputs.
+func (s *ClimbWorkflowTestSuite) TestClimb_RouterDispatchesChild() {
+	a := &Activities{}
+
+	s.env.OnActivity(a.NodeActivity, mock.Anything, mock.MatchedBy(func(in NodeActivityInput) bool {
+		return in.Node.Name == "implement"
+	})).Return(passOutput("implement"), nil)
+
+	s.env.OnActivity(a.NodeActivity, mock.Anything, mock.MatchedBy(func(in NodeActivityInput) bool {
+		return in.Node.Name == "review-router"
+	})).Return(&NodeActivityOutput{
+		Result: model.CompletionResult{
+			Outcome:    model.OutcomePass,
+			OutputPath: ".belayer/.internal/output/route-result.json",
+		},
+	}, nil)
+
+	s.env.OnActivity(a.ReadFileActivity, mock.Anything, mock.Anything).Return(validRouteResultJSON, nil)
+
+	// Child subpipeline executes inline — mock its activity.
+	s.env.OnActivity(a.NodeActivity, mock.Anything, mock.MatchedBy(func(in NodeActivityInput) bool {
+		return in.Node.Name == "code-review"
+	})).Return(passOutput("code-review"), nil)
+
+	s.env.ExecuteWorkflow(ClimbWorkflow, routerInput())
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
+	var result model.ClimbOutput
+	s.NoError(s.env.GetWorkflowResult(&result))
+	s.Equal(model.ClimbCompleted, result.Status)
+	// Child outputs should be namespaced under the router node name.
+	s.Contains(result.NodeOutputs, "review-router/code-review")
+	// Un-namespaced alias should also exist.
+	s.Contains(result.NodeOutputs, "review-router")
+}
+
+// TestClimb_RouterChildFailure: child workflow's node fails → parent ClimbFailed.
+func (s *ClimbWorkflowTestSuite) TestClimb_RouterChildFailure() {
+	a := &Activities{}
+
+	s.env.OnActivity(a.NodeActivity, mock.Anything, mock.MatchedBy(func(in NodeActivityInput) bool {
+		return in.Node.Name == "implement"
+	})).Return(passOutput("implement"), nil)
+
+	s.env.OnActivity(a.NodeActivity, mock.Anything, mock.MatchedBy(func(in NodeActivityInput) bool {
+		return in.Node.Name == "review-router"
+	})).Return(&NodeActivityOutput{
+		Result: model.CompletionResult{
+			Outcome:    model.OutcomePass,
+			OutputPath: ".belayer/.internal/output/route-result.json",
+		},
+	}, nil)
+
+	s.env.OnActivity(a.ReadFileActivity, mock.Anything, mock.Anything).Return(validRouteResultJSON, nil)
+
+	// Child subpipeline's node fails.
+	s.env.OnActivity(a.NodeActivity, mock.Anything, mock.MatchedBy(func(in NodeActivityInput) bool {
+		return in.Node.Name == "code-review"
+	})).Return(&NodeActivityOutput{
+		Result: model.CompletionResult{
+			Outcome: model.OutcomeFail,
+		},
+	}, nil)
+
+	s.env.ExecuteWorkflow(ClimbWorkflow, routerInput())
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
+	var result model.ClimbOutput
+	s.NoError(s.env.GetWorkflowResult(&result))
+	s.Equal(model.ClimbFailed, result.Status)
+	s.Contains(result.Message, "review-router")
+}
+
+// TestClimb_RouterRetryThenPass: router first returns RETRY (malformed output), then PASS → child completes.
+func (s *ClimbWorkflowTestSuite) TestClimb_RouterRetryThenPass() {
+	a := &Activities{}
+
+	s.env.OnActivity(a.NodeActivity, mock.Anything, mock.MatchedBy(func(in NodeActivityInput) bool {
+		return in.Node.Name == "implement"
+	})).Return(passOutput("implement"), nil)
+
+	// First router attempt: malformed → RETRY.
+	s.env.OnActivity(a.NodeActivity, mock.Anything, mock.MatchedBy(func(in NodeActivityInput) bool {
+		return in.Node.Name == "review-router" && in.Attempt == 0
+	})).Return(&NodeActivityOutput{
+		Result: model.CompletionResult{
+			Outcome:  model.OutcomeRetry,
+			Feedback: "route output error: invalid JSON",
+			Attempt:  0,
+		},
+	}, nil).Once()
+
+	// Second router attempt: valid → PASS.
+	s.env.OnActivity(a.NodeActivity, mock.Anything, mock.MatchedBy(func(in NodeActivityInput) bool {
+		return in.Node.Name == "review-router" && in.Attempt == 1
+	})).Return(&NodeActivityOutput{
+		Result: model.CompletionResult{
+			Outcome:    model.OutcomePass,
+			OutputPath: ".belayer/.internal/output/route-result.json",
+			Attempt:    1,
+		},
+	}, nil).Once()
+
+	s.env.OnActivity(a.ReadFileActivity, mock.Anything, mock.Anything).Return(validRouteResultJSON, nil)
+
+	// Child subpipeline executes inline after successful retry.
+	s.env.OnActivity(a.NodeActivity, mock.Anything, mock.MatchedBy(func(in NodeActivityInput) bool {
+		return in.Node.Name == "code-review"
+	})).Return(passOutput("code-review"), nil)
+
+	s.env.ExecuteWorkflow(ClimbWorkflow, routerInput())
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+
+	var result model.ClimbOutput
+	s.NoError(s.env.GetWorkflowResult(&result))
+	s.Equal(model.ClimbCompleted, result.Status)
+}

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -14,6 +14,14 @@ import (
 	"github.com/donovan-yohan/belayer/internal/pipeline"
 )
 
+// SchemaConfig specifies structured output schema requirements for a vendor command.
+type SchemaConfig struct {
+	IsGate     bool
+	Dimensions []pipeline.DimensionConfig
+	IsRouter   bool
+	RouteNames []string // enum values for route constraint
+}
+
 // Config holds the resolved CLI command and args for a vendor.
 type Config struct {
 	Command string
@@ -108,10 +116,45 @@ func GateResultSchema(dimensions []pipeline.DimensionConfig) map[string]any {
 	}
 }
 
+// RouteResultSchema returns the JSON Schema for route result output.
+// RouteNames are embedded as an enum constraint so the model can only
+// choose from declared route options.
+func RouteResultSchema(routeNames []string) map[string]any {
+	return map[string]any{
+		"type":     "object",
+		"required": []string{"route", "confidence", "reasoning", "rejected"},
+		"properties": map[string]any{
+			"route": map[string]any{
+				"type": "string",
+				"enum": routeNames,
+			},
+			"confidence": map[string]any{
+				"type":    "number",
+				"minimum": 0,
+				"maximum": 1,
+			},
+			"reasoning": map[string]any{
+				"type": "string",
+			},
+			"rejected": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type":     "object",
+					"required": []string{"route", "reason"},
+					"properties": map[string]any{
+						"route":  map[string]any{"type": "string"},
+						"reason": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+}
+
 // BuildCommand constructs the full shell command for running an agent.
 // For gate nodes, it adds structured output schema handling based on the vendor's SchemaMode.
 // The returned command is meant to be run via sh -c.
-func BuildCommand(vendorName, prompt, workDir string, isGate bool, dimensions []pipeline.DimensionConfig) (string, func(), error) {
+func BuildCommand(vendorName, prompt, workDir string, schema SchemaConfig) (string, func(), error) {
 	cfg, err := Resolve(vendorName)
 	if err != nil {
 		return "", nil, err
@@ -122,19 +165,30 @@ func BuildCommand(vendorName, prompt, workDir string, isGate bool, dimensions []
 
 	var cleanup func()
 
-	// Add structured output schema for gate nodes.
-	if isGate && len(dimensions) > 0 {
-		schema := GateResultSchema(dimensions)
-		schemaJSON, err := json.Marshal(schema)
+	// Add structured output schema for gate or router nodes.
+	var schemaJSON []byte
+	if schema.IsRouter && len(schema.RouteNames) > 0 {
+		routeSchema := RouteResultSchema(schema.RouteNames)
+		var err error
+		schemaJSON, err = json.Marshal(routeSchema)
+		if err != nil {
+			return "", nil, fmt.Errorf("marshal route schema: %w", err)
+		}
+	} else if schema.IsGate && len(schema.Dimensions) > 0 {
+		gateSchema := GateResultSchema(schema.Dimensions)
+		var err error
+		schemaJSON, err = json.Marshal(gateSchema)
 		if err != nil {
 			return "", nil, fmt.Errorf("marshal gate schema: %w", err)
 		}
+	}
 
+	if len(schemaJSON) > 0 {
 		switch cfg.SchemaMode {
 		case "inline":
 			args = append(args, cfg.SchemaFlag, string(schemaJSON))
 		case "file":
-			tmpFile, err := os.CreateTemp("", "belayer-gate-schema-*.json")
+			tmpFile, err := os.CreateTemp("", "belayer-schema-*.json")
 			if err != nil {
 				return "", nil, fmt.Errorf("create schema temp file: %w", err)
 			}

--- a/internal/vendor/vendor_test.go
+++ b/internal/vendor/vendor_test.go
@@ -35,7 +35,7 @@ func TestResolve(t *testing.T) {
 
 func TestBuildCommand(t *testing.T) {
 	t.Run("claude non-gate", func(t *testing.T) {
-		cmd, cleanup, err := BuildCommand("claude", "Implement the feature", "/tmp/work", false, nil)
+		cmd, cleanup, err := BuildCommand("claude", "Implement the feature", "/tmp/work", SchemaConfig{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -61,7 +61,7 @@ func TestBuildCommand(t *testing.T) {
 			{Name: "code_quality", Weight: 0.5, Description: "Code quality"},
 			{Name: "test_coverage", Weight: 0.5, Description: "Test coverage"},
 		}
-		cmd, cleanup, err := BuildCommand("codex", "$review", "/tmp/work", true, dims)
+		cmd, cleanup, err := BuildCommand("codex", "$review", "/tmp/work", SchemaConfig{IsGate: true, Dimensions: dims})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -96,7 +96,7 @@ func TestBuildCommand(t *testing.T) {
 		dims := []pipeline.DimensionConfig{
 			{Name: "quality", Weight: 1.0, Description: "Overall quality"},
 		}
-		cmd, cleanup, err := BuildCommand("claude", "Review this", "/tmp/work", true, dims)
+		cmd, cleanup, err := BuildCommand("claude", "Review this", "/tmp/work", SchemaConfig{IsGate: true, Dimensions: dims})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -109,11 +109,116 @@ func TestBuildCommand(t *testing.T) {
 	})
 
 	t.Run("unknown vendor", func(t *testing.T) {
-		_, _, err := BuildCommand("unknown", "test", "/tmp", false, nil)
+		_, _, err := BuildCommand("unknown", "test", "/tmp", SchemaConfig{})
 		if err == nil {
 			t.Error("expected error for unknown vendor")
 		}
 	})
+
+	t.Run("claude router with inline schema", func(t *testing.T) {
+		cmd, cleanup, err := BuildCommand("claude", "Classify this change", "/tmp/work", SchemaConfig{
+			IsRouter:   true,
+			RouteNames: []string{"route-a", "route-b"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cleanup != nil {
+			t.Error("claude router should not have cleanup (inline schema)")
+		}
+		if !strings.Contains(cmd, "--json-schema") {
+			t.Error("claude router should use --json-schema flag")
+		}
+		if !strings.Contains(cmd, "route-a") {
+			t.Error("schema should contain route-a enum value")
+		}
+		if !strings.Contains(cmd, "route-b") {
+			t.Error("schema should contain route-b enum value")
+		}
+	})
+
+	t.Run("codex router with file schema", func(t *testing.T) {
+		cmd, cleanup, err := BuildCommand("codex", "Classify this change", "/tmp/work", SchemaConfig{
+			IsRouter:   true,
+			RouteNames: []string{"route-a", "route-b"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cleanup == nil {
+			t.Error("codex router should have cleanup for temp schema file")
+		}
+		if !strings.Contains(cmd, "--output-schema") {
+			t.Error("codex router should use --output-schema flag")
+		}
+		// Verify the temp file was created and contains the enum values.
+		parts := strings.Split(cmd, "--output-schema ")
+		if len(parts) < 2 {
+			t.Fatal("could not find schema file path in command")
+		}
+		schemaPath := strings.Fields(parts[1])[0]
+		data, err := os.ReadFile(schemaPath)
+		if err != nil {
+			t.Fatalf("schema temp file should exist at %s: %v", schemaPath, err)
+		}
+		if !strings.Contains(string(data), "route-a") {
+			t.Error("schema file should contain route-a enum value")
+		}
+		cleanup()
+		if _, err := os.Stat(schemaPath); !os.IsNotExist(err) {
+			t.Error("cleanup should remove the temp file")
+		}
+	})
+}
+
+func TestRouteResultSchema(t *testing.T) {
+	routeNames := []string{"full-feature-review", "quick-bugfix-review", "refactor-review"}
+	schema := RouteResultSchema(routeNames)
+
+	// Should be valid JSON.
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("schema should be marshallable: %v", err)
+	}
+
+	schemaStr := string(data)
+
+	// Should contain all route names as enum values.
+	for _, name := range routeNames {
+		if !strings.Contains(schemaStr, name) {
+			t.Errorf("schema should contain route name %q", name)
+		}
+	}
+
+	// Should have required fields.
+	for _, field := range []string{"route", "confidence", "reasoning", "rejected"} {
+		if !strings.Contains(schemaStr, field) {
+			t.Errorf("schema should reference field %q", field)
+		}
+	}
+
+	// Should have enum constraint.
+	if !strings.Contains(schemaStr, `"enum"`) {
+		t.Error("schema should have enum constraint on route field")
+	}
+}
+
+func TestBuildCommand_GateAndRouterMutualExclusion(t *testing.T) {
+	// IsRouter takes precedence over IsGate when both are set (defensive).
+	dims := []pipeline.DimensionConfig{{Name: "quality", Weight: 1.0, Description: "Quality"}}
+	cmd, _, err := BuildCommand("claude", "test", "/tmp/work", SchemaConfig{
+		IsGate:     true,
+		Dimensions: dims,
+		IsRouter:   true,
+		RouteNames: []string{"route-a", "route-b"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Router takes precedence: should have enum, not dimension names.
+	if !strings.Contains(cmd, "route-a") {
+		t.Error("router schema should take precedence, expected route-a enum value")
+	}
 }
 
 func TestGateResultSchema(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds N-way agentic routing to belayer pipelines. Router nodes declare route options in YAML; the LLM picks one from an enum-constrained JSON schema. Each route runs as an isolated Temporal child workflow with its own retry counters and completion semantics.
- New `routes:` field on agent nodes (not a new node type), following the same pattern as gates being agent nodes with dimensions. Route decisions produce a structured artifact with choice, confidence, reasoning, and rejected alternatives.
- gstack framework ships a canonical "review depth router" with 3 subpipelines: full-feature-review (5 dimensions, 2 retries), quick-bugfix-review (3 dimensions, 1 retry), and refactor-review (4 dimensions, higher pass threshold).

### Key changes
- `internal/pipeline/model.go`: RouteConfig, RouteOption, IsRouter()
- `internal/vendor/vendor.go`: SchemaConfig refactor, RouteResultSchema with enum constraint
- `internal/temporal/activity.go`: materializeRouteFromStdout, ReadFileActivity
- `internal/temporal/workflow.go`: dispatchRoute (child workflow dispatch + artifact merge)
- `internal/route/`: New package for result parsing, validation, prompt generation
- `internal/cli/climb.go` + `worker.go`: SubpipelineYAMLs pre-resolution at all entrypoints
- `frameworks/gstack/`: review-router node + 3 subpipeline YAMLs

### Design decisions
- Subpipeline YAMLs pre-resolved at startup (not runtime) for Temporal determinism and reproducibility
- Malformed route results → OutcomeRetry (mirrors gate behavior), not immediate fail
- Child outputs namespaced (`routeName/nodeKey`) + un-namespaced alias for downstream consumption
- Route descriptions auto-injected into LLM prompt via route.BuildRoutePrompt()

## Review comment fixes

Resolved 9 inline comments from Copilot review:
- **Temporal determinism**: sorted map iteration for child output merge and validRoutes construction
- **Unused params**: removed `artifacts`, `nodeOutputs`, `ao` from `dispatchRoute`
- **Child workflow ID reuse**: added attempt counter to child ID format
- **Nested routers**: child ClimbInput now receives `SubpipelineYAMLs`
- **Error handling**: `ResolveSubpipelineYAMLs` errors surfaced at worker startup; HTTP handler re-resolves subpipelines when pipeline re-resolved per request
- **Stricter validation**: `RouteResult.Validate` now enforces confidence in [0,1] and non-empty reasoning
- **Performance**: hoisted `routeNameRe` regex to package-level var

## Documentation

Doc diff:
- **docs/PIPELINE_REFERENCE.md**: NEW — full YAML schema reference for constructing pipelines (node types, gates, routers, subpipelines, validation rules, worked examples)
- **README.md**: updated pipeline description to three primitives, added router line to "How It Works" diagram, added route nodes to comparison table, linked to PIPELINE_REFERENCE.md
- **docs/ARCHITECTURE.md**: added `internal/route/` to Code Map table
- **docs/DESIGN.md**: fixed "Two pipeline primitives" → "Three pipeline primitives", added Routers to primitive list
- **docs/QUALITY.md**: added `internal/route/result_test.go` and `internal/vendor/vendor_test.go` to test files table
- **docs/PLANS.md**: fixed stale tech debt entry (StartSHA marked resolved, matching TODOS.md)
- **CLAUDE.md**: added Pipeline Reference to Documentation Map
- **CLI --help**: updated root (three primitives, all commands), climb (Long description + examples), setup (mentions subpipelines + reference doc)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — all 16 packages pass
- [x] `go vet ./...` clean
- [ ] Smoke test: run `belayer climb --file <design.md>` with router pipeline, verify child workflow in Temporal Web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
