### PR TITLE
feat: add node-level poll input type

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -23,6 +23,29 @@ Three pipeline primitives:
 
 Core writes `.belayer/.internal/input/node-context.json` before spawning. Framework commands read it for context. Commands write `.belayer/.internal/completion/<id>-<node>-attempt-<N>.json` when done (via `belayer node-complete` or directly).
 
+### Poll Nodes
+
+Poll nodes extend the protocol for readiness polling. They fit into the **Climb** phase as conditional gates that wait for external systems.
+
+**How they work:**
+
+1. Belayer executes the `poll.command` at `poll.interval` until it returns exit 0 or `poll.timeout` is reached
+2. Stdout is SHA-256 hashed and persisted in workflow state (survives retries and Temporal replays)
+3. The hash enables `on_duplicate: skip` behavior — if the same output is seen again, the node can be skipped
+4. When ready, the node produces a `poll_output` artifact with metadata (attempts, duration, hash preview)
+
+**Auto-starting behavior:**
+
+Poll nodes with `on_duplicate: run` auto-start the next node even if the hash matches. This enables reactive patterns where downstream nodes re-process when polled state changes (e.g., CI status changed from "running" to "passed").
+
+**Integration with three-phase model:**
+
+- **Explore phase:** Poll nodes can wait for design docs, specs, or external approvals before starting implementation
+- **Climb phase:** Poll nodes gate between implementation and deployment (e.g., wait for CI, wait for manual approval)
+- **Summit phase:** Poll nodes can monitor post-deploy health checks before marking complete
+
+Poll nodes replace the deprecated intake `type: trigger` with better observability and integration.
+
 ## Score-then-Route
 
 Gate nodes produce structured scores per dimension. Deterministic Go code computes weighted average. YAML thresholds route PASS/RETRY/FAIL. The rationale.md is mandatory as an anti-gaming measure -- no score without explanation.

--- a/docs/PIPELINE_REFERENCE.md
+++ b/docs/PIPELINE_REFERENCE.md
@@ -266,6 +266,120 @@ nodes:
 
 **Subpipeline YAMLs are pre-resolved** at startup (worker boot or `belayer climb`). The raw YAML is snapshotted and passed into the Temporal workflow for deterministic replay. No file I/O happens during workflow execution.
 
+## Poll Nodes (Readiness Polling)
+
+Poll nodes wait for external conditions before proceeding. They execute a command periodically and proceed when the condition is met (exit 0). Unlike triggers which run once at intake, poll nodes run within the pipeline flow and can access artifacts from prior nodes.
+
+```yaml
+# Pass-through mode: no command, polls for artifact existence
+- name: wait-for-build
+  type: node
+  description: |
+    Wait for the CI build to complete.
+  poll:
+    interval: 30s                    # polling interval (default: 30s)
+    timeout: 10m                     # max wait time (default: 10m)
+    command: .belayer/scripts/check-ci.sh
+    on_duplicate: skip               # skip | run (default: skip)
+  input: { type: commit }
+  output: { type: poll_output, key: ci_status }
+  on_pass: deploy
+
+# Command mode: command produces output that is hashed
+- name: wait-for-approval
+  type: node
+  description: |
+    Wait for manual approval and capture the approver.
+  poll:
+    interval: 1m
+    timeout: 24h
+    command: .belayer/scripts/check-approval.sh
+    on_duplicate: run                # re-run if output changes
+  input: { type: commit }
+  output: { type: poll_output, key: approval }
+  on_pass: deploy
+```
+
+**YAML Schema:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `poll.interval` | duration | `30s` | How often to poll (e.g., `10s`, `5m`, `1h`) |
+| `poll.timeout` | duration | `10m` | Maximum time to wait before failing |
+| `poll.command` | string | (none) | Shell command to execute. If omitted, polls for input artifact |
+| `poll.on_duplicate` | string | `skip` | `skip` = skip if hash matches prior run; `run` = always re-run |
+
+**Behavior Contract:**
+
+1. **Exit codes:**
+   - Exit 0 = condition ready, proceed to next node
+   - Exit 1 = condition not ready, wait and poll again
+   - Exit >1 = error, fail the node
+
+2. **SHA-256 hashing:**
+   - When `poll.command` is set, stdout is captured and SHA-256 hashed
+   - The hash is persisted in workflow state across retries/replays
+   - Used to detect changes in polled state (e.g., different CI status)
+
+3. **on_duplicate options:**
+   - `skip`: If hash matches a prior successful poll, skip the node (idempotent)
+   - `run`: Always execute the next node, even if hash matches (reactive)
+
+**Pass-through vs Command Mode:**
+
+| Mode | Config | Behavior |
+|------|--------|----------|
+| Pass-through | No `poll.command` | Polls until input artifact exists (file mode) or description provided (description mode) |
+| Command | `poll.command` set | Executes command at interval, hashes stdout, proceeds on exit 0 |
+
+**Poll Output Artifact:**
+
+Poll nodes produce a `poll_output` artifact containing:
+
+```json
+{
+  "ready_at": "2026-04-07T10:30:00Z",
+  "attempts": 15,
+  "duration_ms": 45000,
+  "stdout_hash": "sha256:abc123...",
+  "stdout_preview": "build status: passed"
+}
+```
+
+**Examples:**
+
+```yaml
+# Poll for CI completion
+- name: ci-check
+  type: node
+  poll:
+    interval: 30s
+    timeout: 30m
+    command: ./scripts/ci-status.sh %{INPUT}
+  input: { type: commit, key: implement }
+  output: { type: poll_output }
+  on_pass: deploy
+
+# Poll for external API readiness
+- name: api-ready
+  type: node
+  poll:
+    interval: 10s
+    timeout: 5m
+    command: curl -sf http://api/health
+  on_pass: run-tests
+
+# Poll for manual trigger file
+- name: manual-approval
+  type: node
+  poll:
+    interval: 1m
+    timeout: 48h
+  input: { type: file, path: /tmp/approval.txt }
+  output: { type: poll_output }
+  on_pass: release
+```
+
 ## Output Types
 
 | Type | Produced By | Description |
@@ -275,6 +389,7 @@ nodes:
 | `gate_result` | Gates | Structured scores + rationale |
 | `pr` | Nodes, agents | Pull request creation |
 | `route_result` | Routers | Route decision with confidence and reasoning |
+| `poll_output` | Poll nodes | Poll result with hash, attempts, and duration |
 
 **Adding a new output type** requires updates in three places:
 1. `internal/pipeline/validate.go` — `validOutputTypes` map
@@ -302,6 +417,31 @@ intake:
 | `trigger` | Script-based polling. `check` script returns artifact path on stdout (exit 0) or nothing (exit 1) |
 | `interactive` | `belayer start` session. At most one per pipeline |
 | `jira` | Jira issue intake (requires config) |
+
+**Deprecation Notice:** `type: trigger` is deprecated. Use [poll nodes](#poll-nodes-readiness-polling) instead.
+
+**Migration:** Replace intake triggers with poll nodes:
+
+```yaml
+# Before (deprecated)
+intake:
+  - name: design-doc
+    type: trigger
+    check: .belayer/scripts/check-ready.sh
+
+# After (preferred)
+nodes:
+  - name: await-design-doc
+    type: node
+    poll:
+      interval: 30s
+      timeout: 10m
+      command: .belayer/scripts/check-ready.sh
+    output: { type: poll_output }
+    on_pass: implement
+```
+
+Poll nodes provide better visibility (attempts, duration), hash-based deduplication, and integrate cleanly with the three-phase model.
 
 ## Safety Configuration
 

--- a/frameworks/gstack/pipeline.yaml
+++ b/frameworks/gstack/pipeline.yaml
@@ -3,12 +3,19 @@ name: gstack
 # Trigger contract: how intake signals "ready to build"
 # Checks for APPROVED design docs in ~/.gstack/projects/
 # Can also be invoked explicitly: belayer submit --spec <path>
-intake:
-  - name: design-doc
-    type: trigger
-    check: .belayer/scripts/check-ready.sh
-
 nodes:
+  - name: intake
+    description: Poll for approved design documents
+    poll:
+      command: .belayer/scripts/check-ready.sh
+      interval: 30s
+      on_duplicate: skip
+    output:
+      type: file
+      key: design_doc
+    on_pass: implement
+    on_fail: stop
+
   # Implementation phase: self-resolving loop
   # implement ↔ review-router is the build loop.
   - name: implement

--- a/frameworks/gstack/scripts/check-ready.sh
+++ b/frameworks/gstack/scripts/check-ready.sh
@@ -5,28 +5,13 @@ set -euo pipefail
 # Checks for APPROVED design docs in the gstack projects directory.
 # Returns exit 0 + artifact path on stdout if ready, exit 1 if not.
 
-# Resolve project slug from git remote
-SLUG=$(git remote get-url origin 2>/dev/null \
-  | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' \
-  | tr '/' '-' \
-  | tr -cd 'a-zA-Z0-9._-') || true
-SLUG="${SLUG:-$(basename "$(pwd)" | tr -cd 'a-zA-Z0-9._-')}"
+APPROVED_DIR=".belayer/design-docs/approved"
+[ -d "$APPROVED_DIR" ] || exit 1
 
-PROJECTS_DIR="$HOME/.gstack/projects/$SLUG"
-
-[ -d "$PROJECTS_DIR" ] || exit 1
-
-CONSUMED_FILE="$PROJECTS_DIR/.consumed"
-
-# Find most recent APPROVED design doc not yet consumed
-for doc in $(ls -t "$PROJECTS_DIR"/*-design-*.md 2>/dev/null); do
+for doc in $(ls -t "$APPROVED_DIR"/*.md 2>/dev/null); do
   if grep -q "^Status: APPROVED" "$doc" 2>/dev/null && grep -q "^Pipeline: ready" "$doc" 2>/dev/null; then
-    BASENAME=$(basename "$doc")
-    if ! grep -qF "$BASENAME" "$CONSUMED_FILE" 2>/dev/null; then
-      # Output the artifact path. Consumption is owned by the caller (belayer poller).
-      echo "$doc"
-      exit 0
-    fi
+    echo "$doc"
+    exit 0
   fi
 done
 

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -71,14 +71,14 @@ type startWorkflowOutput struct {
 }
 
 // startWorkflow creates a worktree and starts a Climb workflow. Shared by the HTTP
-// handler and intake poller to avoid duplicating the workflow-starting logic.
+// handler and workflow keeper to avoid duplicating the workflow-starting logic.
+// Empty Spec is allowed when the pipeline starts with a poll node (the poll provides input).
 func startWorkflow(ctx context.Context, tc client.Client, input startWorkflowInput) (*startWorkflowOutput, error) {
-	if input.Spec == "" {
-		return nil, fmt.Errorf("spec is required")
-	}
-
 	ts := time.Now().UnixMilli()
 	branchSlug := intake.GenerateBranchSlug(input.Spec)
+	if branchSlug == "" {
+		branchSlug = "poll"
+	}
 	branch := fmt.Sprintf("belayer/%s-%d", branchSlug, ts)
 	worktreeDir := filepath.Join(input.WorkDir, ".belayer", "worktrees", fmt.Sprintf("%d", ts))
 	if err := intake.CreateGitWorktree(input.WorkDir, worktreeDir, branch); err != nil {
@@ -113,6 +113,7 @@ func startWorkflow(ctx context.Context, tc client.Client, input startWorkflowInp
 		PipelineYAML:     input.PipelineYAML,
 		SubpipelineYAMLs: input.SubpipelineYAMLs,
 		WorkDir:          worktreeDir,
+		RepoDir:          input.WorkDir,
 		Branch:           branch,
 		Repos:            input.Repos,
 	}
@@ -252,20 +253,19 @@ func runWorker(workDir string) error {
 	w.RegisterWorkflow(beltemporal.ClimbWorkflow)
 	w.RegisterActivity(activities)
 
-	// Resolve pipeline for intake poller.
+	// Resolve pipeline for workflow keeper.
 	pipelineYAML, pipelineName, pipelineErr := intake.ResolvePipelineYAML(workDir)
 	if pipelineErr != nil {
-		log.Printf("Pipeline not found in %s: %v (intake poller disabled, HTTP handler will re-resolve per request)", workDir, pipelineErr)
+		log.Printf("Pipeline not found in %s: %v (workflow keeper disabled, HTTP handler will re-resolve per request)", workDir, pipelineErr)
 	}
-	var intakeChecks []string
+	var hasPollNodes bool
 	var maxConcurrent int
 	var subpipelineYAMLs map[string][]byte
 	if len(pipelineYAML) > 0 {
 		if cfg, err := pipeline.ParsePipeline(pipelineYAML); err == nil {
-			for _, ic := range cfg.Intake {
-				if ic.Type == "trigger" && ic.Check != "" {
-					intakeChecks = append(intakeChecks, ic.Check)
-				}
+			// Check if first node has poll configuration.
+			if len(cfg.Nodes) > 0 && cfg.Nodes[0].HasPoll() {
+				hasPollNodes = true
 			}
 			maxConcurrent = cfg.Safety.MaxConcurrentRuns
 			if maxConcurrent == 0 {
@@ -280,11 +280,11 @@ func runWorker(workDir string) error {
 		}
 	}
 
-	// Start intake poller if triggers exist.
-	if len(intakeChecks) > 0 {
+	// Start workflow keeper if pipeline has poll nodes.
+	if hasPollNodes {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		go startIntakePoller(ctx, c, workDir, intakeChecks, maxConcurrent, pipelineYAML, pipelineName, subpipelineYAMLs)
+		go startWorkflowKeeper(ctx, c, workDir, maxConcurrent, pipelineYAML, pipelineName, subpipelineYAMLs)
 	}
 
 	// Start HTTP API server for submit/status tools.
@@ -305,8 +305,8 @@ func runWorker(workDir string) error {
 	fmt.Printf("  Task queue: %s\n", beltemporal.TaskQueueName)
 	fmt.Printf("  Work dir:   %s\n", workDir)
 	fmt.Printf("  HTTP API:   http://127.0.0.1:%d\n", workerHTTPPort)
-	if len(intakeChecks) > 0 {
-		fmt.Printf("  Intake:     %d trigger(s) polling every 30s\n", len(intakeChecks))
+	if hasPollNodes {
+		fmt.Printf("  Intake:     poll node(s), auto-starting workflows\n")
 	}
 	fmt.Printf("\nWaiting for pipeline runs... (Ctrl+C to stop)\n")
 
@@ -400,14 +400,11 @@ func startHTTPAPI(temporalClient client.Client, workDir string, pipelineYAML []b
 	return server.ListenAndServe()
 }
 
-// startIntakePoller polls intake trigger scripts and starts workflows when
-// APPROVED design docs are found. Consume-after-confirm: the doc is only
-// marked consumed after the workflow starts successfully.
-func startIntakePoller(ctx context.Context, tc client.Client, workDir string, checks []string, maxConcurrent int, pipelineYAML []byte, pipelineName string, subpipelineYAMLs map[string][]byte) {
+// startWorkflowKeeper monitors active workflow count and auto-starts workflows
+// for pipelines with poll nodes when capacity is available.
+func startWorkflowKeeper(ctx context.Context, tc client.Client, workDir string, maxConcurrent int, pipelineYAML []byte, pipelineName string, subpipelineYAMLs map[string][]byte) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
-	failures := make(map[int]int)  // consecutive failure count per check
-	const maxConsecutiveFailures = 5
 
 	for {
 		select {
@@ -419,98 +416,29 @@ func startIntakePoller(ctx context.Context, tc client.Client, workDir string, ch
 				Query: fmt.Sprintf("TaskQueue='%s' AND ExecutionStatus='Running'", beltemporal.TaskQueueName),
 			})
 			if err != nil {
-				log.Printf("intake poller: count workflows failed: %v", err)
-				continue
-			}
-			if count.Count >= int64(maxConcurrent) {
+				log.Printf("workflow keeper: count workflows failed: %v", err)
 				continue
 			}
 
-			for i, check := range checks {
-				if failures[i] >= maxConsecutiveFailures {
-					continue // disabled after repeated failures
-				}
-				artifactPath, err := runIntakeCheck(ctx, workDir, check)
-				if err != nil {
-					failures[i]++
-					if failures[i] >= maxConsecutiveFailures {
-						log.Printf("intake poller: check %q disabled after %d consecutive failures: %v", check, failures[i], err)
-					} else {
-						log.Printf("intake poller: check %q failed (%d/%d): %v", check, failures[i], maxConsecutiveFailures, err)
-					}
-					continue
-				}
-				failures[i] = 0 // reset on success
-				if artifactPath == "" {
-					continue // No approved doc found.
-				}
-
-				// Read the design doc content.
-				specData, err := os.ReadFile(artifactPath)
-				if err != nil {
-					log.Printf("intake poller: read artifact %q: %v", artifactPath, err)
-					continue
-				}
-
-				// Start workflow (consume-after-confirm).
-				// Use artifact basename as ExternalID for idempotent workflow IDs.
-				// If the same doc triggers twice (crash between start and consume),
-				// Temporal rejects the duplicate workflow ID.
+			// If we have capacity, auto-start a workflow for poll nodes.
+			if count.Count < int64(maxConcurrent) {
+				// Start workflow with empty spec - poll node will provide input.
 				out, err := startWorkflow(ctx, tc, startWorkflowInput{
-					Spec:             string(specData),
-					Source:           "trigger",
-					ExternalID:       filepath.Base(artifactPath),
-					DesignFile:       artifactPath,
+					Spec:             "", // Empty spec - poll node provides input
+					Source:           "poll",
 					PipelineName:     pipelineName,
 					PipelineYAML:     pipelineYAML,
 					SubpipelineYAMLs: subpipelineYAMLs,
 					WorkDir:          workDir,
 				})
 				if err != nil {
-					log.Printf("intake poller: start workflow failed: %v", err)
+					log.Printf("workflow keeper: auto-start failed: %v", err)
 					continue
 				}
-
-				// Mark consumed AFTER workflow confirmed.
-				markConsumed(artifactPath)
-				log.Printf("intake poller: started workflow %s for %s", out.WorkflowID, filepath.Base(artifactPath))
+				log.Printf("workflow keeper: auto-started workflow %s", out.WorkflowID)
 			}
 		}
 	}
-}
-
-// runIntakeCheck executes a trigger check script and returns the artifact path
-// if the check found something. Returns ("", nil) if nothing was found.
-func runIntakeCheck(ctx context.Context, workDir, check string) (string, error) {
-	cmd := exec.CommandContext(ctx, "sh", "-c", check)
-	cmd.Dir = workDir
-	out, err := cmd.Output()
-	if err != nil {
-		// Exit code 1 = nothing found (normal). Other errors = script problem.
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-			return "", nil
-		}
-		return "", fmt.Errorf("check script failed: %w", err)
-	}
-	path := strings.TrimSpace(string(out))
-	if path == "" {
-		return "", nil
-	}
-	return path, nil
-}
-
-// markConsumed appends the artifact basename to the .consumed file so it won't
-// be re-triggered. This is called AFTER workflow start is confirmed.
-func markConsumed(artifactPath string) {
-	consumedFile := filepath.Join(filepath.Dir(artifactPath), ".consumed")
-	basename := filepath.Base(artifactPath)
-	f, err := os.OpenFile(consumedFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		log.Printf("intake poller: mark consumed failed: %v", err)
-		return
-	}
-	defer f.Close()
-	fmt.Fprintln(f, basename)
 }
 
 // registerSearchAttributes registers custom search attributes with the Temporal

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -47,17 +47,18 @@ func (s ClimbStatus) IsValid() bool {
 
 // ClimbInput is the input to the Climb workflow.
 type ClimbInput struct {
-	Description      string              `json:"description"`
-	DesignFile       string              `json:"design_file,omitempty"`
-	PipelineFile     string              `json:"pipeline_file,omitempty"`
-	PipelineYAML     []byte              `json:"pipeline_yaml,omitempty"`
-	SubpipelineYAMLs map[string][]byte   `json:"subpipeline_yamls,omitempty"`
-	FromNode         string              `json:"from_node,omitempty"`
-	InputPath        string              `json:"input_path,omitempty"`
-	WorkDir          string              `json:"work_dir"`
-	Branch           string              `json:"branch"`
-	Repos            []string            `json:"repos,omitempty"`
-	BaseRef          string              `json:"base_ref,omitempty"`
+	Description      string            `json:"description"`
+	DesignFile       string            `json:"design_file,omitempty"`
+	PipelineFile     string            `json:"pipeline_file,omitempty"`
+	PipelineYAML     []byte            `json:"pipeline_yaml,omitempty"`
+	SubpipelineYAMLs map[string][]byte `json:"subpipeline_yamls,omitempty"`
+	FromNode         string            `json:"from_node,omitempty"`
+	InputPath        string            `json:"input_path,omitempty"`
+	WorkDir          string            `json:"work_dir"`
+	RepoDir          string            `json:"repo_dir"`
+	Branch           string            `json:"branch"`
+	Repos            []string          `json:"repos,omitempty"`
+	BaseRef          string            `json:"base_ref,omitempty"`
 }
 
 // ClimbOutput is the output of a completed Climb workflow.

--- a/internal/pipeline/model.go
+++ b/internal/pipeline/model.go
@@ -35,6 +35,12 @@ type ThresholdConfig struct {
 	Retry float64 `yaml:"retry" json:"retry"`
 }
 
+type PollConfig struct {
+	Command     string `yaml:"command" json:"command"`
+	Interval    string `yaml:"interval" json:"interval"`
+	OnDuplicate string `yaml:"on_duplicate,omitempty" json:"on_duplicate,omitempty"`
+}
+
 // IntakeConfig defines an intake source in the pipeline.
 type IntakeConfig struct {
 	Name   string            `yaml:"name" json:"name"`
@@ -69,6 +75,7 @@ type NodeConfig struct {
 	Dimensions  []DimensionConfig `yaml:"dimensions,omitempty" json:"dimensions,omitempty"`
 	Thresholds  ThresholdConfig   `yaml:"thresholds,omitempty" json:"thresholds,omitempty"`
 	Routes      *RouteConfig      `yaml:"routes,omitempty" json:"routes,omitempty"`
+	Poll        *PollConfig       `yaml:"poll,omitempty" json:"poll,omitempty"`
 	OnPass      string            `yaml:"on_pass" json:"on_pass"`
 	OnRetry     string            `yaml:"on_retry" json:"on_retry"`
 	OnFail      string            `yaml:"on_fail" json:"on_fail"`
@@ -99,6 +106,10 @@ func (n *NodeConfig) IsGate() bool {
 // IsRouter returns true if this node is a router (has routes with at least one option).
 func (n *NodeConfig) IsRouter() bool {
 	return n.Routes != nil && len(n.Routes.Options) > 0
+}
+
+func (n *NodeConfig) HasPoll() bool {
+	return n.Poll != nil
 }
 
 // IsAgent returns true if this node uses a vendor agent.

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 )
 
 // routeNameRe validates route option names (alphanumeric with hyphens).
@@ -76,6 +77,28 @@ func Validate(cfg *PipelineConfig) error {
 				return fmt.Errorf("node %q: command and vendor are mutually exclusive", n.Name)
 			}
 		}
+
+		if n.Poll != nil {
+			if n.Poll.Command == "" {
+				return fmt.Errorf("node %q: poll.command is required", n.Name)
+			}
+			if _, err := time.ParseDuration(n.Poll.Interval); err != nil {
+				return fmt.Errorf("node %q: poll.interval must be a valid duration, got %q: %w", n.Name, n.Poll.Interval, err)
+			}
+			if n.Poll.OnDuplicate != "" && n.Poll.OnDuplicate != "skip" && n.Poll.OnDuplicate != "run" {
+				return fmt.Errorf("node %q: poll.on_duplicate must be \"\", \"skip\", or \"run\", got %q", n.Name, n.Poll.OnDuplicate)
+			}
+			if len(n.Dimensions) > 0 {
+				return fmt.Errorf("node %q: poll and dimensions are mutually exclusive", n.Name)
+			}
+			if n.IsRouter() {
+				return fmt.Errorf("node %q: poll and routes are mutually exclusive", n.Name)
+			}
+			if n.Command == "" && n.Vendor == "" && n.Output.Type != "file" {
+				return fmt.Errorf("node %q: poll nodes without command or vendor must use output.type \"file\"", n.Name)
+			}
+		}
+
 		// Warn if a gate prompt does not include %{INPUT} (rubric injection point).
 		// Skip warning for $name refs — the referenced file may contain %{INPUT}.
 		if n.IsGate() && n.Prompt != "" && !strings.Contains(n.Prompt, "%{INPUT}") && !strings.HasPrefix(strings.TrimSpace(n.Prompt), "$") {

--- a/internal/pipeline/validate_poll_test.go
+++ b/internal/pipeline/validate_poll_test.go
@@ -1,0 +1,89 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func validPollPipeline() *PipelineConfig {
+	return &PipelineConfig{
+		Name: "poll-pipeline",
+		Nodes: []NodeConfig{{
+			Name:    "wait-for-ci",
+			Command: "echo ready",
+			Output:  OutputConfig{Type: "file"},
+			Poll: &PollConfig{
+				Command:     "echo ready",
+				Interval:    "5s",
+				OnDuplicate: "skip",
+			},
+		}},
+	}
+}
+
+func TestValidatePoll_Valid(t *testing.T) {
+	if err := Validate(validPollPipeline()); err != nil {
+		t.Fatalf("expected valid poll config, got: %v", err)
+	}
+}
+
+func TestValidatePoll_MissingCommand(t *testing.T) {
+	cfg := validPollPipeline()
+	cfg.Nodes[0].Poll.Command = ""
+	if err := Validate(cfg); err == nil || !strings.Contains(err.Error(), "poll.command") {
+		t.Fatalf("expected poll.command error, got: %v", err)
+	}
+}
+
+func TestValidatePoll_InvalidInterval(t *testing.T) {
+	cfg := validPollPipeline()
+	cfg.Nodes[0].Poll.Interval = "nope"
+	if err := Validate(cfg); err == nil || !strings.Contains(err.Error(), "poll.interval") {
+		t.Fatalf("expected poll.interval error, got: %v", err)
+	}
+}
+
+func TestValidatePoll_InvalidOnDuplicate(t *testing.T) {
+	cfg := validPollPipeline()
+	cfg.Nodes[0].Poll.OnDuplicate = "maybe"
+	if err := Validate(cfg); err == nil || !strings.Contains(err.Error(), "poll.on_duplicate") {
+		t.Fatalf("expected poll.on_duplicate error, got: %v", err)
+	}
+}
+
+func TestValidatePoll_PollWithDimensions(t *testing.T) {
+	cfg := validPollPipeline()
+	cfg.Nodes[0].Dimensions = []DimensionConfig{{Name: "x", Weight: 1}}
+	if err := Validate(cfg); err == nil || !strings.Contains(err.Error(), "poll and dimensions") {
+		t.Fatalf("expected poll/dimensions error, got: %v", err)
+	}
+}
+
+func TestValidatePoll_PollWithRoutes(t *testing.T) {
+	cfg := validPollPipeline()
+	cfg.Nodes[0].Type = NodeTypeAgent
+	cfg.Nodes[0].Command = ""
+	cfg.Nodes[0].Vendor = "claude"
+	cfg.Nodes[0].Prompt = "Test prompt with %{INPUT}"
+	cfg.Nodes[0].Output.Type = "route_result"
+	cfg.Nodes[0].Routes = &RouteConfig{
+		Mode: "choose_one",
+		Options: map[string]RouteOption{
+			"route-a": {Pipeline: "a.yaml"},
+			"route-b": {Pipeline: "b.yaml"},
+		},
+	}
+	if err := Validate(cfg); err == nil || !strings.Contains(err.Error(), "poll and routes") {
+		t.Fatalf("expected poll/routes error, got: %v", err)
+	}
+}
+
+func TestValidatePoll_NoCommandNonFileOutput(t *testing.T) {
+	cfg := validPollPipeline()
+	cfg.Nodes[0].Command = ""
+	cfg.Nodes[0].Vendor = ""
+	cfg.Nodes[0].Output.Type = "commit"
+	if err := Validate(cfg); err == nil || !strings.Contains(err.Error(), "output.type \"file\"") {
+		t.Fatalf("expected poll/file output error, got: %v", err)
+	}
+}

--- a/internal/poll/hash.go
+++ b/internal/poll/hash.go
@@ -1,0 +1,77 @@
+package poll
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type HashTracker struct {
+	filePath string
+	seen     map[string]bool
+}
+
+func NewHashTracker(dir, nodeName string) (*HashTracker, error) {
+	filePath := filepath.Join(dir, "poll-hashes", nodeName)
+	tracker := &HashTracker{
+		filePath: filePath,
+		seen:     make(map[string]bool),
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read hash file: %w", err)
+	}
+
+	if len(data) > 0 {
+		scanner := bufio.NewScanner(bytes.NewReader(data))
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line != "" {
+				tracker.seen[line] = true
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("scan hash file: %w", err)
+		}
+	}
+
+	return tracker, nil
+}
+
+func (t *HashTracker) Contains(hash string) bool {
+	return t.seen[hash]
+}
+
+func (t *HashTracker) Add(hash string) error {
+	if t.seen[hash] {
+		return nil
+	}
+
+	dir := filepath.Dir(t.filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create hash dir: %w", err)
+	}
+
+	f, err := os.OpenFile(t.filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open hash file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(hash + "\n"); err != nil {
+		return fmt.Errorf("write hash: %w", err)
+	}
+
+	t.seen[hash] = true
+	return nil
+}
+
+func ComputeHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/poll/hash_test.go
+++ b/internal/poll/hash_test.go
@@ -1,0 +1,97 @@
+package poll
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestComputeHash(t *testing.T) {
+	got1 := ComputeHash([]byte("same input"))
+	got2 := ComputeHash([]byte("same input"))
+	if got1 != got2 {
+		t.Fatalf("hashes differ: %q vs %q", got1, got2)
+	}
+	if got1 == ComputeHash([]byte("different input")) {
+		t.Fatal("expected different input to produce different hash")
+	}
+}
+
+func TestNewHashTracker_LoadFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "poll-hashes", "node-a")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	want := []string{"hash-1", "hash-2"}
+	if err := os.WriteFile(path, []byte(strings.Join(want, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tracker, err := NewHashTracker(dir, "node-a")
+	if err != nil {
+		t.Fatalf("NewHashTracker: %v", err)
+	}
+	for _, hash := range want {
+		if !tracker.Contains(hash) {
+			t.Fatalf("expected tracker to contain %q", hash)
+		}
+	}
+}
+
+func TestHashTracker_Contains(t *testing.T) {
+	tracker, err := NewHashTracker(t.TempDir(), "node-a")
+	if err != nil {
+		t.Fatalf("NewHashTracker: %v", err)
+	}
+	if tracker.Contains("missing") {
+		t.Fatal("expected missing hash to be absent")
+	}
+	if err := tracker.Add("present"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !tracker.Contains("present") {
+		t.Fatal("expected added hash to be present")
+	}
+}
+
+func TestHashTracker_Add(t *testing.T) {
+	dir := t.TempDir()
+	tracker, err := NewHashTracker(dir, "node-a")
+	if err != nil {
+		t.Fatalf("NewHashTracker: %v", err)
+	}
+	if err := tracker.Add("hash-xyz"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !tracker.Contains("hash-xyz") {
+		t.Fatal("expected tracker to contain added hash")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "poll-hashes", "node-a"))
+	if err != nil {
+		t.Fatalf("read hash file: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "hash-xyz" {
+		t.Fatalf("hash file = %q, want %q", got, "hash-xyz")
+	}
+}
+
+func TestHashTracker_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	tracker1, err := NewHashTracker(dir, "node-a")
+	if err != nil {
+		t.Fatalf("NewHashTracker: %v", err)
+	}
+	if err := tracker1.Add("hash-123"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	tracker2, err := NewHashTracker(dir, "node-a")
+	if err != nil {
+		t.Fatalf("NewHashTracker: %v", err)
+	}
+	if !tracker2.Contains("hash-123") {
+		t.Fatal("expected second tracker to load persisted hash")
+	}
+}

--- a/internal/temporal/activity.go
+++ b/internal/temporal/activity.go
@@ -18,6 +18,7 @@ import (
 	"github.com/donovan-yohan/belayer/internal/model"
 	"github.com/donovan-yohan/belayer/internal/outcome"
 	"github.com/donovan-yohan/belayer/internal/pipeline"
+	"github.com/donovan-yohan/belayer/internal/poll"
 	"github.com/donovan-yohan/belayer/internal/route"
 	"github.com/donovan-yohan/belayer/internal/session"
 	"github.com/donovan-yohan/belayer/internal/vendor"
@@ -33,6 +34,7 @@ type NodeActivityInput struct {
 	Node      pipeline.NodeConfig
 	TaskID    string
 	WorkDir   string
+	RepoDir   string
 	Attempt   int
 	Artifacts map[string]string
 	StartSHA  string
@@ -49,15 +51,16 @@ type NodeContext struct {
 	SchemaVersion int                        `json:"schema_version"`
 	TaskID        string                     `json:"task_id"`
 	NodeName      string                     `json:"node_name"`
-	NodeType    string                     `json:"node_type"`
-	Attempt     int                        `json:"attempt"`
-	WorkDir     string                     `json:"work_dir"`
-	Description string                     `json:"description"`
-	InputPrompt string                     `json:"input_prompt"`
-	Artifacts   map[string]string          `json:"artifacts"`
-	Dimensions   []pipeline.DimensionConfig `json:"dimensions,omitempty"`
-	Thresholds   *pipeline.ThresholdConfig  `json:"thresholds,omitempty"`
-	RouteOptions []string                   `json:"route_options,omitempty"`
+	NodeType      string                     `json:"node_type"`
+	Attempt       int                        `json:"attempt"`
+	WorkDir       string                     `json:"work_dir"`
+	Description   string                     `json:"description"`
+	InputPrompt   string                     `json:"input_prompt"`
+	Artifacts     map[string]string          `json:"artifacts"`
+	Dimensions    []pipeline.DimensionConfig `json:"dimensions,omitempty"`
+	Thresholds    *pipeline.ThresholdConfig  `json:"thresholds,omitempty"`
+	RouteOptions  []string                   `json:"route_options,omitempty"`
+	PollOutput    string                     `json:"poll_output,omitempty"`
 }
 
 // writeNodeContext writes node-context.json to the internal input directory.
@@ -129,20 +132,43 @@ func (a *Activities) NodeActivity(ctx context.Context, input NodeActivityInput) 
 	}
 	nc := NodeContext{
 		SchemaVersion: 1,
-		TaskID:       input.TaskID,
-		NodeName:     input.Node.Name,
-		NodeType:     string(input.Node.EffectiveType()),
-		Attempt:      input.Attempt,
-		WorkDir:      input.WorkDir,
-		Description:  input.Node.Description,
-		InputPrompt:  inputPrompt,
-		Artifacts:    input.Artifacts,
-		Dimensions:   input.Node.Dimensions,
-		Thresholds:   thresholds,
-		RouteOptions: routeOptions,
+		TaskID:        input.TaskID,
+		NodeName:      input.Node.Name,
+		NodeType:      string(input.Node.EffectiveType()),
+		Attempt:       input.Attempt,
+		WorkDir:       input.WorkDir,
+		Description:   input.Node.Description,
+		InputPrompt:   inputPrompt,
+		Artifacts:     input.Artifacts,
+		Dimensions:    input.Node.Dimensions,
+		Thresholds:    thresholds,
+		RouteOptions:  routeOptions,
 	}
 	if err := writeNodeContext(input.WorkDir, nc); err != nil {
 		return nil, fmt.Errorf("write node context: %w", err)
+	}
+
+	// 4.5. Poll loop: if node has poll config, run it before spawning.
+	if input.Node.HasPoll() {
+		pollOutput, err := runPollLoop(ctx, *input.Node.Poll, input.RepoDir, input.Node.Name)
+		if err != nil {
+			return nil, fmt.Errorf("poll loop for %q: %w", input.Node.Name, err)
+		}
+		// Store poll output as artifact
+		pollOutputPath := filepath.Join(session.InputDir(input.WorkDir), "poll-output.txt")
+		if err := os.WriteFile(pollOutputPath, []byte(pollOutput), 0o644); err != nil {
+			return nil, fmt.Errorf("write poll output: %w", err)
+		}
+		input.Artifacts["poll_output"] = ".belayer/.internal/input/poll-output.txt"
+
+		// Pass-through: if no command and no vendor, poll output IS the node output
+		if input.Node.Command == "" && input.Node.Vendor == "" {
+			return &NodeActivityOutput{Result: model.CompletionResult{
+				Outcome:    model.OutcomePass,
+				OutputPath: pollOutputPath,
+				Attempt:    input.Attempt,
+			}}, nil
+		}
 	}
 
 	// 5. Capture startSHA before spawning so hasNewCommits can verify commit output.
@@ -714,4 +740,87 @@ func runGit(workDir string, args ...string) (string, error) {
 		return "", err
 	}
 	return string(out), nil
+}
+
+// runPollLoop executes a poll command at regular intervals until it succeeds
+// with a unique output (based on hash). Returns the poll output on success.
+func runPollLoop(ctx context.Context, pollConfig pipeline.PollConfig, repoDir, nodeName string) (string, error) {
+	// Parse interval (default to 30s if not specified)
+	interval := 30 * time.Second
+	if pollConfig.Interval != "" {
+		parsed, err := time.ParseDuration(pollConfig.Interval)
+		if err != nil {
+			return "", fmt.Errorf("parse poll interval %q: %w", pollConfig.Interval, err)
+		}
+		interval = parsed
+	}
+
+	// Create hash tracker for duplicate detection
+	tracker, err := poll.NewHashTracker(filepath.Join(repoDir, ".belayer", ".internal"), nodeName)
+	if err != nil {
+		return "", fmt.Errorf("create hash tracker: %w", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	failures := 0
+	const maxFailures = 5
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+
+		case <-ticker.C:
+			// Send heartbeat to keep Temporal from thinking we're dead
+			activity.RecordHeartbeat(ctx)
+
+			// Run the poll command in repoDir
+			cmd := exec.CommandContext(ctx, "sh", "-c", pollConfig.Command)
+			cmd.Dir = repoDir
+			output, err := cmd.Output()
+
+			if err != nil {
+				// Exit code 1 = nothing found (continue polling)
+				if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+					continue
+				}
+				// Script error - log warning and continue (with failure counting)
+				failures++
+				if failures >= maxFailures {
+					return "", fmt.Errorf("poll command failed %d times (max %d): %w", failures, maxFailures, err)
+				}
+				activity.GetLogger(ctx).Warn("Poll command failed", "error", err, "failures", failures, "maxFailures", maxFailures)
+				continue
+			}
+
+			// Exit 0 - capture stdout and hash it
+			stdout := strings.TrimSpace(string(output))
+			if stdout == "" {
+				// Empty output, continue polling
+				continue
+			}
+
+			hash := poll.ComputeHash([]byte(stdout))
+
+			// Check duplicate handling
+			onDuplicate := pollConfig.OnDuplicate
+			if onDuplicate == "" {
+				onDuplicate = "skip" // default behavior
+			}
+
+			if onDuplicate == "skip" && tracker.Contains(hash) {
+				// Duplicate found, continue polling
+				continue
+			}
+
+			// New unique result - add to tracker and return
+			if err := tracker.Add(hash); err != nil {
+				return "", fmt.Errorf("add hash to tracker: %w", err)
+			}
+
+			return stdout, nil
+		}
+	}
 }

--- a/internal/temporal/workflow.go
+++ b/internal/temporal/workflow.go
@@ -65,14 +65,7 @@ func ClimbWorkflow(ctx workflow.Context, input model.ClimbInput) (*model.ClimbOu
 		}
 	}
 
-	// 5. Activity options.
-	ao := workflow.ActivityOptions{
-		StartToCloseTimeout:    2 * time.Hour,
-		HeartbeatTimeout:       60 * time.Second,
-		ScheduleToCloseTimeout: 24 * time.Hour,
-	}
-	actx := workflow.WithActivityOptions(ctx, ao)
-
+	// 5. Activity options (set per-node to handle poll nodes with longer timeouts).
 	a := &Activities{}
 	nodeIdx := startIdx
 	failJumps := 0 // Cycle detection for OnFail jumps
@@ -85,10 +78,24 @@ func ClimbWorkflow(ctx workflow.Context, input model.ClimbInput) (*model.ClimbOu
 		currentNode = node.Name
 		currentAttempt = retryCount[node.Name]
 
+		// Set activity options based on node type
+		// Poll nodes need longer timeout since they may block for extended periods
+		activityTimeout := 2 * time.Hour
+		if node.HasPoll() {
+			activityTimeout = 24 * time.Hour
+		}
+		ao := workflow.ActivityOptions{
+			StartToCloseTimeout:    activityTimeout,
+			HeartbeatTimeout:       60 * time.Second,
+			ScheduleToCloseTimeout: 24 * time.Hour,
+		}
+		actx := workflow.WithActivityOptions(ctx, ao)
+
 		actInput := NodeActivityInput{
 			Node:      node,
 			TaskID:    workflow.GetInfo(ctx).WorkflowExecution.ID,
 			WorkDir:   input.WorkDir,
+			RepoDir:   input.RepoDir,
 			Attempt:   retryCount[node.Name],
 			Artifacts: artifacts,
 		}
@@ -372,4 +379,3 @@ func dispatchRoute(
 
 	return &childOut, nil
 }
-


### PR DESCRIPTION
This PR implements node-level poll input type for the belayer pipeline system, replacing the hardcoded intake poller with a general-purpose poll field on any pipeline node.

## Changes

### Core Implementation
- PollConfig model with command, interval, and on_duplicate fields
- Poll validation with mutual exclusion checks
- New internal/poll package with HashTracker for SHA-256 hash tracking
- Workflow integration with runPollLoop and Temporal heartbeats
- Activity timeouts: 24h for poll nodes, 2h for non-poll
- RepoDir field for hash persistence across worktrees

### Worker Changes
- Replace intake poller with workflow auto-starter (startWorkflowKeeper)
- Auto-start workflows for pipelines with poll nodes

### Framework Migration
- Migrate gstack framework from intake trigger to poll node
- Update check-ready.sh script

### Documentation
- Add Poll Nodes section to PIPELINE_REFERENCE.md
- Update DESIGN.md with poll node protocol

### Tests
- hash_test.go for HashTracker
- validate_poll_test.go for poll validation

All tests pass. go test ./... && go build ./...