### PR TITLE
fix: wire session cleanup into teardown (#51)

### DIFF
--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -23,6 +23,7 @@ func newSessionCmd() *cobra.Command {
 	cmd.AddCommand(
 		newSessionStartCmd(),
 		newSessionListCmd(),
+		newSessionCleanCmd(),
 		newSessionStopCmd(),
 		newSessionWakeCmd(),
 	)
@@ -181,20 +182,10 @@ changes. Any work not committed will be lost.`,
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "Reflection will run on next daemon cycle (trigger: post-session).")
 
-			// Clean up Docker sandbox if it exists.
 			home, _ := os.UserHomeDir()
-			sandboxDir := filepath.Join(home, ".belayer", "sandboxes", sessionID)
-			composePath := filepath.Join(sandboxDir, "docker-compose.yml")
-			if _, err := os.Stat(composePath); err == nil {
-				fmt.Fprintln(cmd.OutOrStdout(), "Stopping Docker sandbox...")
-				stopCmd := exec.Command("docker", "compose", "-f", composePath, "down")
-				stopCmd.Stdout = cmd.OutOrStdout()
-				stopCmd.Stderr = cmd.ErrOrStderr()
-				if err := stopCmd.Run(); err != nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: docker compose down failed: %v\n", err)
-				} else {
-					fmt.Fprintln(cmd.OutOrStdout(), "Docker sandbox stopped.")
-				}
+			paths := buildSessionCleanupPaths(home, os.TempDir(), sessionID, sess.Name)
+			if err := cleanupSessionArtifacts(paths, cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: session cleanup incomplete: %v\n", err)
 			}
 
 			return nil
@@ -202,6 +193,58 @@ changes. Any work not committed will be lost.`,
 	}
 	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
 	cmd.Flags().BoolVar(&force, "force", false, "Force stop even with uncommitted changes (DANGEROUS: uncommitted code will be lost)")
+	return cmd
+}
+
+func newSessionCleanCmd() *cobra.Command {
+	var socket string
+	var sessionName string
+
+	cmd := &cobra.Command{
+		Use:   "clean <session-id-or-name>",
+		Short: "Remove leftover sandbox and worktree artifacts for a session",
+		Long: `Clean up session artifacts without changing daemon state.
+
+This is intended for orphaned local worktrees or Docker sandbox directories left
+behind after an interrupted session stop. When the daemon is reachable, belayer
+resolves both the session ID and name automatically. If the daemon is offline,
+the argument is used as a best-effort identifier for both paths.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := args[0]
+			sessionID := target
+			resolvedName := target
+
+			c := NewClient(resolveSocket(socket))
+			if sessions, err := c.ListSessions(); err == nil {
+				for _, s := range sessions {
+					if strings.HasPrefix(s.ID, target) || s.Name == target {
+						sessionID = s.ID
+						resolvedName = s.Name
+						break
+					}
+				}
+			}
+			if sessionName != "" {
+				resolvedName = sessionName
+			}
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("resolve home directory: %w", err)
+			}
+
+			paths := buildSessionCleanupPaths(home, os.TempDir(), sessionID, resolvedName)
+			if err := cleanupSessionArtifacts(paths, cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
+				return fmt.Errorf("clean session artifacts: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Cleaned artifacts for %s (session ID: %s, session name: %s)\n", target, sessionID, resolvedName)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	cmd.Flags().StringVar(&sessionName, "name", "", "Explicit session name to use for local worktree cleanup")
 	return cmd
 }
 

--- a/internal/cli/session_cleanup.go
+++ b/internal/cli/session_cleanup.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+type sessionCleanupPaths struct {
+	SandboxDir       string
+	LocalWorktreeDir string
+}
+
+func buildSessionCleanupPaths(homeDir, tempDir, sessionID, sessionName string) sessionCleanupPaths {
+	return sessionCleanupPaths{
+		SandboxDir:       filepath.Join(homeDir, ".belayer", "sandboxes", sessionID),
+		LocalWorktreeDir: filepath.Join(tempDir, "belayer-worktrees", sessionName),
+	}
+}
+
+func cleanupSessionArtifacts(paths sessionCleanupPaths, stdout, stderr io.Writer) error {
+	var errs []error
+
+	if err := stopDockerComposeIfPresent(paths.SandboxDir, stdout, stderr); err != nil {
+		errs = append(errs, err)
+	}
+
+	for _, warning := range cleanupWorktrees(paths.SandboxDir) {
+		errs = append(errs, warning)
+	}
+	if err := removeDirIfPresent(paths.SandboxDir); err != nil {
+		errs = append(errs, fmt.Errorf("remove sandbox dir: %w", err))
+	}
+
+	for _, warning := range cleanupWorktrees(paths.LocalWorktreeDir) {
+		errs = append(errs, warning)
+	}
+	if err := removeDirIfPresent(paths.LocalWorktreeDir); err != nil {
+		errs = append(errs, fmt.Errorf("remove local worktree dir: %w", err))
+	}
+
+	return errors.Join(errs...)
+}
+
+func stopDockerComposeIfPresent(sandboxDir string, stdout, stderr io.Writer) error {
+	if sandboxDir == "" {
+		return nil
+	}
+
+	composePath := filepath.Join(sandboxDir, "docker-compose.yml")
+	if _, err := os.Stat(composePath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat compose file: %w", err)
+	}
+
+	fmt.Fprintln(stdout, "Stopping Docker sandbox...")
+	stopCmd := exec.Command("docker", "compose", "-f", composePath, "down")
+	stopCmd.Stdout = stdout
+	stopCmd.Stderr = stderr
+	if err := stopCmd.Run(); err != nil {
+		return fmt.Errorf("docker compose down: %w", err)
+	}
+
+	fmt.Fprintln(stdout, "Docker sandbox stopped.")
+	return nil
+}
+
+func removeDirIfPresent(path string) error {
+	if path == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return os.RemoveAll(path)
+}

--- a/internal/cli/session_cleanup_test.go
+++ b/internal/cli/session_cleanup_test.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCleanupSessionArtifacts_RemovesSandboxAndLocalWorktrees(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses shell scripts and unixy paths")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tmpRoot := t.TempDir()
+	t.Setenv("TMPDIR", tmpRoot)
+
+	repoDir := initGitRepo(t)
+	sessionID := "sess-123"
+	sessionName := "implement-123"
+	sandboxDir := filepath.Join(home, ".belayer", "sandboxes", sessionID)
+	localBaseDir := filepath.Join(tmpRoot, "belayer-worktrees", sessionName)
+	createGitWorktree(t, repoDir, filepath.Join(sandboxDir, "worktrees", "pilot"))
+	createGitWorktree(t, repoDir, filepath.Join(localBaseDir, "worktrees", "pilot"))
+
+	var outBuf, errBuf bytes.Buffer
+	if err := cleanupSessionArtifacts(buildSessionCleanupPaths(home, tmpRoot, sessionID, sessionName), &outBuf, &errBuf); err != nil {
+		t.Fatalf("cleanupSessionArtifacts: %v", err)
+	}
+
+	if _, err := os.Stat(sandboxDir); !os.IsNotExist(err) {
+		t.Fatalf("expected sandbox dir to be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(localBaseDir); !os.IsNotExist(err) {
+		t.Fatalf("expected local worktree base dir to be removed, stat err=%v", err)
+	}
+	if errBuf.Len() != 0 {
+		t.Fatalf("expected no warnings, got: %s", errBuf.String())
+	}
+}
+
+func TestCleanupSessionArtifacts_WarnsButSucceedsForNonGitWorktrees(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tmpRoot := t.TempDir()
+	t.Setenv("TMPDIR", tmpRoot)
+
+	sessionID := "sess-warn"
+	sessionName := "warn-session"
+	sandboxDir := filepath.Join(home, ".belayer", "sandboxes", sessionID, "worktrees", "pilot")
+	localDir := filepath.Join(tmpRoot, "belayer-worktrees", sessionName, "worktrees", "reviewer")
+	if err := os.MkdirAll(sandboxDir, 0o755); err != nil {
+		t.Fatalf("mkdir sandbox worktree: %v", err)
+	}
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatalf("mkdir local worktree: %v", err)
+	}
+
+	var outBuf, errBuf bytes.Buffer
+	if err := cleanupSessionArtifacts(buildSessionCleanupPaths(home, tmpRoot, sessionID, sessionName), &outBuf, &errBuf); err != nil {
+		t.Fatalf("cleanupSessionArtifacts: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, ".belayer", "sandboxes", sessionID)); !os.IsNotExist(err) {
+		t.Fatalf("expected sandbox dir to be removed even for non-git worktrees, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpRoot, "belayer-worktrees", sessionName)); !os.IsNotExist(err) {
+		t.Fatalf("expected local worktree dir to be removed even for non-git worktrees, stat err=%v", err)
+	}
+}
+
+func TestCleanupSessionArtifacts_StopsDockerSandboxWhenComposeExists(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses shell scripts and unixy paths")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	tmpRoot := t.TempDir()
+	t.Setenv("TMPDIR", tmpRoot)
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "docker.log")
+	writeExecutable(t, filepath.Join(binDir, "docker"), "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \""+logPath+"\"\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	sessionID := "sess-docker"
+	sessionName := "docker-session"
+	sandboxDir := filepath.Join(home, ".belayer", "sandboxes", sessionID)
+	if err := os.MkdirAll(sandboxDir, 0o755); err != nil {
+		t.Fatalf("mkdir sandbox: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sandboxDir, "docker-compose.yml"), []byte("services: {}\n"), 0o644); err != nil {
+		t.Fatalf("write compose file: %v", err)
+	}
+
+	var outBuf, errBuf bytes.Buffer
+	if err := cleanupSessionArtifacts(buildSessionCleanupPaths(home, tmpRoot, sessionID, sessionName), &outBuf, &errBuf); err != nil {
+		t.Fatalf("cleanupSessionArtifacts: %v", err)
+	}
+	if errBuf.Len() != 0 {
+		t.Fatalf("expected no stderr warnings, got: %s", errBuf.String())
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read docker log: %v", err)
+	}
+	if got := string(logBytes); !strings.Contains(got, "compose -f "+filepath.Join(sandboxDir, "docker-compose.yml")+" down") {
+		t.Fatalf("expected docker compose down invocation, got %q", got)
+	}
+	if !strings.Contains(outBuf.String(), "Stopping Docker sandbox...") || !strings.Contains(outBuf.String(), "Docker sandbox stopped.") {
+		t.Fatalf("expected cleanup output to mention docker sandbox stop, got: %q", outBuf.String())
+	}
+}
+
+func TestNewSessionCmd_RegistersCleanSubcommand(t *testing.T) {
+	cmd := newSessionCmd()
+	if _, _, err := cmd.Find([]string{"clean"}); err != nil {
+		t.Fatalf("expected session clean subcommand to be registered: %v", err)
+	}
+}
+
+func initGitRepo(t *testing.T) string {
+	t.Helper()
+	repoDir := t.TempDir()
+	runCmd(t, repoDir, "git", "init")
+	runCmd(t, repoDir, "git", "config", "user.email", "test@example.com")
+	runCmd(t, repoDir, "git", "config", "user.name", "Belayer Tests")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	runCmd(t, repoDir, "git", "add", "README.md")
+	runCmd(t, repoDir, "git", "commit", "-m", "seed")
+	return repoDir
+}
+
+func createGitWorktree(t *testing.T, repoDir, worktreePath string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
+		t.Fatalf("mkdir worktree parent: %v", err)
+	}
+	runCmd(t, repoDir, "git", "worktree", "add", worktreePath, "--detach", "HEAD")
+}
+
+func writeExecutable(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
+	}
+}
+
+func runCmd(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, string(out))
+	}
+}

--- a/internal/cli/session_start.go
+++ b/internal/cli/session_start.go
@@ -443,19 +443,53 @@ func createWorktree(repoDir, baseDir, agentName, branch string) (string, error) 
 	return worktreePath, nil
 }
 
-// cleanupWorktrees removes git worktrees created for a session.
-func cleanupWorktrees(baseDir string) {
+// cleanupWorktrees removes git worktrees created for a session and returns any
+// warnings encountered while attempting cleanup.
+func cleanupWorktrees(baseDir string) []error {
 	worktreeDir := filepath.Join(baseDir, "worktrees")
 	entries, err := os.ReadDir(worktreeDir)
 	if err != nil {
-		return
+		return nil
 	}
+	var warnings []error
 	for _, entry := range entries {
 		if entry.IsDir() {
 			wt := filepath.Join(worktreeDir, entry.Name())
-			exec.Command("git", "worktree", "remove", "--force", wt).Run()
+			if err := removeGitWorktree(wt); err != nil {
+				warnings = append(warnings, fmt.Errorf("remove worktree %s: %w", wt, err))
+			}
 		}
 	}
+	return warnings
+}
+
+func removeGitWorktree(worktreePath string) error {
+	commonDirOut, err := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-common-dir").CombinedOutput()
+	if err != nil {
+		if removeErr := os.RemoveAll(worktreePath); removeErr != nil {
+			return fmt.Errorf("read git common dir: %w; fallback remove: %w", err, removeErr)
+		}
+		return nil
+	}
+
+	commonDir := strings.TrimSpace(string(commonDirOut))
+	if commonDir == "" {
+		if removeErr := os.RemoveAll(worktreePath); removeErr != nil {
+			return fmt.Errorf("empty git common dir; fallback remove: %w", removeErr)
+		}
+		return nil
+	}
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Clean(filepath.Join(worktreePath, commonDir))
+	}
+
+	repoDir := filepath.Dir(commonDir)
+	if out, err := exec.Command("git", "-C", repoDir, "worktree", "remove", "--force", worktreePath).CombinedOutput(); err != nil {
+		if removeErr := os.RemoveAll(worktreePath); removeErr != nil {
+			return fmt.Errorf("git worktree remove: %w (%s); fallback remove: %w", err, strings.TrimSpace(string(out)), removeErr)
+		}
+	}
+	return nil
 }
 
 // buildVendorCmd returns the vendor-specific CLI command string.


### PR DESCRIPTION
## Summary
- route `belayer session stop` through shared cleanup logic for Docker sandboxes and per-session worktrees
- add `belayer session clean` for orphaned local artifacts after interrupted runs
- add regression tests covering worktree removal and compose-aware sandbox cleanup

## Testing
- go test ./internal/cli
- go test ./...
- go build ./cmd/belayer

Closes #51