### PR TITLE
fix: wire worktree cleanup into session teardown (#51)

### DIFF
--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -182,37 +183,41 @@ changes. Any work not committed will be lost.`,
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "Reflection will run on next daemon cycle (trigger: post-session).")
 
-			// Clean up Docker sandbox if it exists.
-			home, _ := os.UserHomeDir()
-			sandboxDir := filepath.Join(home, ".belayer", "sandboxes", sessionID)
-			composePath := filepath.Join(sandboxDir, "docker-compose.yml")
-			if _, err := os.Stat(composePath); err == nil {
-				fmt.Fprintln(cmd.OutOrStdout(), "Stopping Docker sandbox...")
-				stopCmd := exec.Command("docker", "compose", "-f", composePath, "down")
-				stopCmd.Stdout = cmd.OutOrStdout()
-				stopCmd.Stderr = cmd.ErrOrStderr()
-				if err := stopCmd.Run(); err != nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: docker compose down failed: %v\n", err)
-				} else {
-					fmt.Fprintln(cmd.OutOrStdout(), "Docker sandbox stopped.")
-					os.RemoveAll(sandboxDir)
+			// Clean up Docker sandbox and workbench if home directory is resolvable.
+			if home, err := os.UserHomeDir(); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not resolve home directory, skipping sandbox/workbench cleanup: %v\n", err)
+			} else {
+				sandboxDir := filepath.Join(home, ".belayer", "sandboxes", sessionID)
+				composePath := filepath.Join(sandboxDir, "docker-compose.yml")
+				if _, err := os.Stat(composePath); err == nil {
+					fmt.Fprintln(cmd.OutOrStdout(), "Stopping Docker sandbox...")
+					stopCmd := exec.Command("docker", "compose", "-f", composePath, "down")
+					stopCmd.Stdout = cmd.OutOrStdout()
+					stopCmd.Stderr = cmd.ErrOrStderr()
+					if err := stopCmd.Run(); err != nil {
+						fmt.Fprintf(cmd.ErrOrStderr(), "Warning: docker compose down failed: %v\n", err)
+					} else {
+						fmt.Fprintln(cmd.OutOrStdout(), "Docker sandbox stopped.")
+						if err := os.RemoveAll(sandboxDir); err != nil {
+							fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to remove sandbox directory %s: %v\n", sandboxDir, err)
+						}
+					}
 				}
-			}
 
-			// Clean up workbench if it exists.
-			workbenchDir := filepath.Join(home, ".belayer", "workbenches", sessionID)
-			workbenchComposePath := filepath.Join(workbenchDir, "docker-compose.yml")
-			if _, err := os.Stat(workbenchComposePath); err == nil {
-				fmt.Fprintln(cmd.OutOrStdout(), "Stopping workbench...")
-				stopWorkbenchCmd := exec.Command("docker", "compose", "-f", workbenchComposePath, "down")
-				stopWorkbenchCmd.Stdout = cmd.OutOrStdout()
-				stopWorkbenchCmd.Stderr = cmd.ErrOrStderr()
-				if err := stopWorkbenchCmd.Run(); err != nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: workbench docker compose down failed: %v\n", err)
-				} else {
-					fmt.Fprintln(cmd.OutOrStdout(), "Workbench stopped.")
+				workbenchDir := filepath.Join(home, ".belayer", "workbenches", sessionID)
+				workbenchComposePath := filepath.Join(workbenchDir, "docker-compose.yml")
+				if _, err := os.Stat(workbenchComposePath); err == nil {
+					fmt.Fprintln(cmd.OutOrStdout(), "Stopping workbench...")
+					stopWorkbenchCmd := exec.Command("docker", "compose", "-f", workbenchComposePath, "down")
+					stopWorkbenchCmd.Stdout = cmd.OutOrStdout()
+					stopWorkbenchCmd.Stderr = cmd.ErrOrStderr()
+					if err := stopWorkbenchCmd.Run(); err != nil {
+						fmt.Fprintf(cmd.ErrOrStderr(), "Warning: workbench docker compose down failed: %v\n", err)
+					} else {
+						fmt.Fprintln(cmd.OutOrStdout(), "Workbench stopped.")
+					}
+					os.RemoveAll(workbenchDir) //nolint:errcheck
 				}
-				os.RemoveAll(workbenchDir) //nolint:errcheck
 			}
 
 			// Delete workbench record from store via daemon API if reachable.
@@ -220,9 +225,11 @@ changes. Any work not committed will be lost.`,
 				_ = c.DeleteWorkbenchBySession(sessionID) //nolint:errcheck
 			}
 
-			// Clean up git worktrees created for this session.
-			wsDir := resolveWorkspaceDir()
-			cleanupWorktrees(filepath.Join(wsDir, "sessions", sessionID))
+			// Clean up git worktrees created for this session (tmux mode).
+			// Docker-mode worktrees live inside the sandbox dir and were already removed above.
+			wtBaseDir := filepath.Join(os.TempDir(), "belayer-worktrees", sess.Name)
+			cleanupWorktrees(wtBaseDir)
+			os.RemoveAll(wtBaseDir) //nolint:errcheck
 
 			return nil
 		},
@@ -329,118 +336,41 @@ func newSessionCleanCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "clean",
 		Short: "Clean up orphaned sandbox directories and git worktrees",
-		Long: `Walk ~/.belayer/sandboxes/ and the workspace worktrees directory,
+		Long: `Walk ~/.belayer/sandboxes/ and the tmux worktrees directory,
 removing directories for sessions that no longer exist or are stopped.
 Also runs 'git worktree prune' to clean up stale worktree refs.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := NewClient(resolveSocket(socket))
 
-			// Build set of active (running) session IDs.
-			activeSessions := map[string]bool{}
+			// Build set of active (running) session IDs and names.
+			// Abort if we can't query the daemon — proceeding with an empty set
+			// would treat ALL sessions as orphaned and delete everything.
 			sessions, err := c.ListSessions()
 			if err != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not list sessions (daemon may be offline): %v\n", err)
-			} else {
-				for _, s := range sessions {
-					if s.Status == "running" {
-						activeSessions[s.ID] = true
-					}
+				return fmt.Errorf("could not list sessions (daemon may be offline); aborting cleanup to avoid removing active sandboxes/worktrees: %w", err)
+			}
+			activeSessions := map[string]bool{}
+			activeSessionNames := map[string]bool{}
+			for _, s := range sessions {
+				if s.Status == "running" {
+					activeSessions[s.ID] = true
+					activeSessionNames[s.Name] = true
 				}
+			}
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("could not resolve user home directory: %w", err)
 			}
 
 			cleaned := 0
-
-			// Clean up sandbox directories.
-			home, _ := os.UserHomeDir()
 			sandboxesDir := filepath.Join(home, ".belayer", "sandboxes")
-			sandboxEntries, err := os.ReadDir(sandboxesDir)
-			if err != nil && !os.IsNotExist(err) {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not read sandboxes dir %s: %v\n", sandboxesDir, err)
-			}
-			for _, entry := range sandboxEntries {
-				if !entry.IsDir() {
-					continue
-				}
-				sessionID := entry.Name()
-				if activeSessions[sessionID] {
-					continue
-				}
-				sandboxDir := filepath.Join(sandboxesDir, sessionID)
-				// Bring down any compose stack that may still be running.
-				composePath := filepath.Join(sandboxDir, "docker-compose.yml")
-				if _, err := os.Stat(composePath); err == nil {
-					stopCmd := exec.Command("docker", "compose", "-f", composePath, "down")
-					stopCmd.Stdout = cmd.OutOrStdout()
-					stopCmd.Stderr = cmd.ErrOrStderr()
-					stopCmd.Run() //nolint:errcheck
-				}
-				if err := os.RemoveAll(sandboxDir); err != nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not remove sandbox dir %s: %v\n", sandboxDir, err)
-				} else {
-					fmt.Fprintf(cmd.OutOrStdout(), "Removed sandbox: %s\n", sandboxDir)
-					cleaned++
-				}
-			}
+			cleaned += cleanupSandboxDirs(sandboxesDir, activeSessions, cmd.OutOrStdout(), cmd.ErrOrStderr())
 
-			// Clean up worktree directories.
-			wsDir := resolveWorkspaceDir()
-			sessionsDir := filepath.Join(wsDir, "sessions")
-			sessionEntries, err := os.ReadDir(sessionsDir)
-			if err != nil && !os.IsNotExist(err) {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not read sessions dir %s: %v\n", sessionsDir, err)
-			}
-
-			// Track which repo dirs had worktrees pruned.
-			prunedRepos := map[string]bool{}
-
-			for _, entry := range sessionEntries {
-				if !entry.IsDir() {
-					continue
-				}
-				sessionID := entry.Name()
-				if activeSessions[sessionID] {
-					continue
-				}
-				sessionDir := filepath.Join(sessionsDir, sessionID)
-				worktreeDir := filepath.Join(sessionDir, "worktrees")
-				wtEntries, err := os.ReadDir(worktreeDir)
-				if err != nil {
-					// No worktrees dir — remove the whole session dir if it's otherwise empty.
-					os.Remove(sessionDir) //nolint:errcheck
-					continue
-				}
-				for _, wt := range wtEntries {
-					if !wt.IsDir() {
-						continue
-					}
-					wtPath := filepath.Join(worktreeDir, wt.Name())
-					// Attempt git worktree remove (graceful).
-					exec.Command("git", "worktree", "remove", "--force", wtPath).Run() //nolint:errcheck
-					// Fall back to raw removal.
-					if err := os.RemoveAll(wtPath); err != nil {
-						fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not remove worktree %s: %v\n", wtPath, err)
-					} else {
-						// Track parent repo for prune pass.
-						// The worktree dir name is the repo base dir by convention.
-						if repoDir := repoForWorktree(wtPath); repoDir != "" && !prunedRepos[repoDir] {
-							prunedRepos[repoDir] = true
-						}
-						fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree: %s\n", wtPath)
-						cleaned++
-					}
-				}
-				os.RemoveAll(sessionDir) //nolint:errcheck
-			}
-
-			// Run 'git worktree prune' for each affected repo.
-			for repoDir := range prunedRepos {
-				pruneCmd := exec.Command("git", "-C", repoDir, "worktree", "prune")
-				if out, err := pruneCmd.CombinedOutput(); err != nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: git worktree prune in %s failed: %v: %s\n", repoDir, err, string(out))
-				} else {
-					fmt.Fprintf(cmd.OutOrStdout(), "Pruned worktree refs in: %s\n", repoDir)
-				}
-			}
+			// Docker-mode worktrees live under the sandbox dir and are removed above.
+			// Tmux-mode worktrees live under os.TempDir()/belayer-worktrees/<sessionName>/.
+			belayerWorktreesDir := filepath.Join(os.TempDir(), "belayer-worktrees")
+			cleaned += cleanupTmuxWorktreeDirs(belayerWorktreesDir, activeSessionNames, cmd.OutOrStdout(), cmd.ErrOrStderr())
 
 			if cleaned == 0 {
 				fmt.Fprintln(cmd.OutOrStdout(), "Nothing to clean up.")
@@ -452,6 +382,102 @@ Also runs 'git worktree prune' to clean up stale worktree refs.`,
 	}
 	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
 	return cmd
+}
+
+// cleanupSandboxDirs removes sandbox directories for sessions not in activeSessions.
+// It first runs docker compose down if a compose file exists. Returns the count removed.
+func cleanupSandboxDirs(sandboxesDir string, activeSessions map[string]bool, out, errOut io.Writer) int {
+	entries, err := os.ReadDir(sandboxesDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(errOut, "Warning: could not read sandboxes dir %s: %v\n", sandboxesDir, err)
+		}
+		return 0
+	}
+	cleaned := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sessionID := entry.Name()
+		if activeSessions[sessionID] {
+			continue
+		}
+		sandboxDir := filepath.Join(sandboxesDir, sessionID)
+		composePath := filepath.Join(sandboxDir, "docker-compose.yml")
+		if _, err := os.Stat(composePath); err == nil {
+			stopCmd := exec.Command("docker", "compose", "-f", composePath, "down")
+			stopCmd.Stdout = out
+			stopCmd.Stderr = errOut
+			stopCmd.Run() //nolint:errcheck
+		}
+		if err := os.RemoveAll(sandboxDir); err != nil {
+			fmt.Fprintf(errOut, "Warning: could not remove sandbox dir %s: %v\n", sandboxDir, err)
+		} else {
+			fmt.Fprintf(out, "Removed sandbox: %s\n", sandboxDir)
+			cleaned++
+		}
+	}
+	return cleaned
+}
+
+// cleanupTmuxWorktreeDirs removes tmux-mode worktree directories for sessions not in
+// activeSessionNames. Each subdirectory of belayerWorktreesDir is named after a session name.
+// Captures repo dirs before removal so git worktree prune can run on affected repos.
+// Returns the count of worktree items removed.
+func cleanupTmuxWorktreeDirs(belayerWorktreesDir string, activeSessionNames map[string]bool, out, errOut io.Writer) int {
+	entries, err := os.ReadDir(belayerWorktreesDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(errOut, "Warning: could not read worktrees dir %s: %v\n", belayerWorktreesDir, err)
+		}
+		return 0
+	}
+	prunedRepos := map[string]bool{}
+	cleaned := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sessionName := entry.Name()
+		if activeSessionNames[sessionName] {
+			continue
+		}
+		sessionWtDir := filepath.Join(belayerWorktreesDir, sessionName)
+		worktreeDir := filepath.Join(sessionWtDir, "worktrees")
+		wtEntries, err := os.ReadDir(worktreeDir)
+		if err != nil {
+			os.RemoveAll(sessionWtDir) //nolint:errcheck
+			continue
+		}
+		for _, wt := range wtEntries {
+			if !wt.IsDir() {
+				continue
+			}
+			wtPath := filepath.Join(worktreeDir, wt.Name())
+			// Capture repo dir before removing — git can't run on a deleted path.
+			if repoDir := repoForWorktree(wtPath); repoDir != "" && !prunedRepos[repoDir] {
+				prunedRepos[repoDir] = true
+			}
+			exec.Command("git", "-C", wtPath, "worktree", "remove", "--force", wtPath).Run() //nolint:errcheck
+			if err := os.RemoveAll(wtPath); err != nil {
+				fmt.Fprintf(errOut, "Warning: could not remove worktree %s: %v\n", wtPath, err)
+			} else {
+				fmt.Fprintf(out, "Removed worktree: %s\n", wtPath)
+				cleaned++
+			}
+		}
+		os.RemoveAll(sessionWtDir) //nolint:errcheck
+	}
+	for repoDir := range prunedRepos {
+		pruneCmd := exec.Command("git", "-C", repoDir, "worktree", "prune")
+		if pruneOut, err := pruneCmd.CombinedOutput(); err != nil {
+			fmt.Fprintf(errOut, "Warning: git worktree prune in %s failed: %v: %s\n", repoDir, err, string(pruneOut))
+		} else {
+			fmt.Fprintf(out, "Pruned worktree refs in: %s\n", repoDir)
+		}
+	}
+	return cleaned
 }
 
 // repoForWorktree returns the main git repo directory that owns the given worktree path,

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -25,6 +25,7 @@ func newSessionCmd() *cobra.Command {
 		newSessionListCmd(),
 		newSessionStopCmd(),
 		newSessionWakeCmd(),
+		newSessionCleanCmd(),
 	)
 	return cmd
 }
@@ -194,6 +195,7 @@ changes. Any work not committed will be lost.`,
 					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: docker compose down failed: %v\n", err)
 				} else {
 					fmt.Fprintln(cmd.OutOrStdout(), "Docker sandbox stopped.")
+					os.RemoveAll(sandboxDir)
 				}
 			}
 
@@ -217,6 +219,10 @@ changes. Any work not committed will be lost.`,
 			if err := c.Health(); err == nil {
 				_ = c.DeleteWorkbenchBySession(sessionID) //nolint:errcheck
 			}
+
+			// Clean up git worktrees created for this session.
+			wsDir := resolveWorkspaceDir()
+			cleanupWorktrees(filepath.Join(wsDir, "sessions", sessionID))
 
 			return nil
 		},
@@ -315,6 +321,156 @@ that context prepended to its prompt.`,
 	cmd.Flags().StringVar(&agentName, "agent", "", "Agent to wake (required)")
 	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
 	return cmd
+}
+
+func newSessionCleanCmd() *cobra.Command {
+	var socket string
+
+	cmd := &cobra.Command{
+		Use:   "clean",
+		Short: "Clean up orphaned sandbox directories and git worktrees",
+		Long: `Walk ~/.belayer/sandboxes/ and the workspace worktrees directory,
+removing directories for sessions that no longer exist or are stopped.
+Also runs 'git worktree prune' to clean up stale worktree refs.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := NewClient(resolveSocket(socket))
+
+			// Build set of active (running) session IDs.
+			activeSessions := map[string]bool{}
+			sessions, err := c.ListSessions()
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not list sessions (daemon may be offline): %v\n", err)
+			} else {
+				for _, s := range sessions {
+					if s.Status == "running" {
+						activeSessions[s.ID] = true
+					}
+				}
+			}
+
+			cleaned := 0
+
+			// Clean up sandbox directories.
+			home, _ := os.UserHomeDir()
+			sandboxesDir := filepath.Join(home, ".belayer", "sandboxes")
+			sandboxEntries, err := os.ReadDir(sandboxesDir)
+			if err != nil && !os.IsNotExist(err) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not read sandboxes dir %s: %v\n", sandboxesDir, err)
+			}
+			for _, entry := range sandboxEntries {
+				if !entry.IsDir() {
+					continue
+				}
+				sessionID := entry.Name()
+				if activeSessions[sessionID] {
+					continue
+				}
+				sandboxDir := filepath.Join(sandboxesDir, sessionID)
+				// Bring down any compose stack that may still be running.
+				composePath := filepath.Join(sandboxDir, "docker-compose.yml")
+				if _, err := os.Stat(composePath); err == nil {
+					stopCmd := exec.Command("docker", "compose", "-f", composePath, "down")
+					stopCmd.Stdout = cmd.OutOrStdout()
+					stopCmd.Stderr = cmd.ErrOrStderr()
+					stopCmd.Run() //nolint:errcheck
+				}
+				if err := os.RemoveAll(sandboxDir); err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not remove sandbox dir %s: %v\n", sandboxDir, err)
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "Removed sandbox: %s\n", sandboxDir)
+					cleaned++
+				}
+			}
+
+			// Clean up worktree directories.
+			wsDir := resolveWorkspaceDir()
+			sessionsDir := filepath.Join(wsDir, "sessions")
+			sessionEntries, err := os.ReadDir(sessionsDir)
+			if err != nil && !os.IsNotExist(err) {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not read sessions dir %s: %v\n", sessionsDir, err)
+			}
+
+			// Track which repo dirs had worktrees pruned.
+			prunedRepos := map[string]bool{}
+
+			for _, entry := range sessionEntries {
+				if !entry.IsDir() {
+					continue
+				}
+				sessionID := entry.Name()
+				if activeSessions[sessionID] {
+					continue
+				}
+				sessionDir := filepath.Join(sessionsDir, sessionID)
+				worktreeDir := filepath.Join(sessionDir, "worktrees")
+				wtEntries, err := os.ReadDir(worktreeDir)
+				if err != nil {
+					// No worktrees dir — remove the whole session dir if it's otherwise empty.
+					os.Remove(sessionDir) //nolint:errcheck
+					continue
+				}
+				for _, wt := range wtEntries {
+					if !wt.IsDir() {
+						continue
+					}
+					wtPath := filepath.Join(worktreeDir, wt.Name())
+					// Attempt git worktree remove (graceful).
+					exec.Command("git", "worktree", "remove", "--force", wtPath).Run() //nolint:errcheck
+					// Fall back to raw removal.
+					if err := os.RemoveAll(wtPath); err != nil {
+						fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not remove worktree %s: %v\n", wtPath, err)
+					} else {
+						// Track parent repo for prune pass.
+						// The worktree dir name is the repo base dir by convention.
+						if repoDir := repoForWorktree(wtPath); repoDir != "" && !prunedRepos[repoDir] {
+							prunedRepos[repoDir] = true
+						}
+						fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree: %s\n", wtPath)
+						cleaned++
+					}
+				}
+				os.RemoveAll(sessionDir) //nolint:errcheck
+			}
+
+			// Run 'git worktree prune' for each affected repo.
+			for repoDir := range prunedRepos {
+				pruneCmd := exec.Command("git", "-C", repoDir, "worktree", "prune")
+				if out, err := pruneCmd.CombinedOutput(); err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: git worktree prune in %s failed: %v: %s\n", repoDir, err, string(out))
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "Pruned worktree refs in: %s\n", repoDir)
+				}
+			}
+
+			if cleaned == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "Nothing to clean up.")
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "Cleaned %d item(s).\n", cleaned)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	return cmd
+}
+
+// repoForWorktree returns the main git repo directory that owns the given worktree path,
+// or an empty string if it cannot be determined.
+func repoForWorktree(wtPath string) string {
+	out, err := exec.Command("git", "-C", wtPath, "rev-parse", "--git-common-dir").CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	commonDir := strings.TrimSpace(string(out))
+	if commonDir == "" {
+		return ""
+	}
+	// --git-common-dir returns an absolute path or a path relative to the worktree.
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(wtPath, commonDir)
+	}
+	// The common git dir is typically <repo>/.git; the repo root is its parent.
+	return filepath.Dir(commonDir)
 }
 
 // lookupSessionID resolves a session name, ID prefix, or full ID to a full session ID.

--- a/internal/cli/session_start.go
+++ b/internal/cli/session_start.go
@@ -456,8 +456,8 @@ func cleanupWorktrees(baseDir string) {
 	for _, entry := range entries {
 		if entry.IsDir() {
 			wt := filepath.Join(worktreeDir, entry.Name())
-			exec.Command("git", "worktree", "remove", "--force", wt).Run() //nolint:errcheck
-			os.RemoveAll(wt)                                                //nolint:errcheck
+			exec.Command("git", "-C", wt, "worktree", "remove", "--force", wt).Run() //nolint:errcheck
+			os.RemoveAll(wt)                                                         //nolint:errcheck
 		}
 	}
 }

--- a/internal/cli/session_start.go
+++ b/internal/cli/session_start.go
@@ -444,6 +444,9 @@ func createWorktree(repoDir, baseDir, agentName, branch string) (string, error) 
 }
 
 // cleanupWorktrees removes git worktrees created for a session.
+// It first attempts a graceful `git worktree remove --force` to deregister the
+// worktree from git's internal tracking, then removes the directory from disk
+// regardless of whether the git command succeeded.
 func cleanupWorktrees(baseDir string) {
 	worktreeDir := filepath.Join(baseDir, "worktrees")
 	entries, err := os.ReadDir(worktreeDir)
@@ -453,7 +456,8 @@ func cleanupWorktrees(baseDir string) {
 	for _, entry := range entries {
 		if entry.IsDir() {
 			wt := filepath.Join(worktreeDir, entry.Name())
-			exec.Command("git", "worktree", "remove", "--force", wt).Run()
+			exec.Command("git", "worktree", "remove", "--force", wt).Run() //nolint:errcheck
+			os.RemoveAll(wt)                                                //nolint:errcheck
 		}
 	}
 }

--- a/internal/cli/session_test.go
+++ b/internal/cli/session_test.go
@@ -34,27 +34,16 @@ func TestCleanupWorktrees_RemovesWorktreeDirectories(t *testing.T) {
 		}
 	}
 
-	// cleanupWorktrees calls `git worktree remove --force <path>` then returns.
-	// For non-git directories the git command fails silently; the directories
-	// themselves are NOT removed by cleanupWorktrees (it delegates to git).
-	// The function contract is: call git worktree remove for each subdir.
-	// We test that the function runs without panicking and touches each entry.
+	// cleanupWorktrees calls `git -C <path> worktree remove --force <path>` then
+	// unconditionally calls os.RemoveAll on each subdir. For non-git directories the
+	// git command fails silently, but the directory is removed from disk regardless.
 	cleanupWorktrees(baseDir)
 
-	// After calling cleanupWorktrees the worktrees directory itself still exists
-	// (the function does not remove the parent), and the subdirs may or may not
-	// still exist depending on whether git succeeded.  What we can assert is that
-	// the function does not leave extra unexpected directories.
-	entries, err := os.ReadDir(worktreeDir)
-	if err != nil {
-		t.Fatalf("ReadDir after cleanup: %v", err)
-	}
-	// Both entries were there before; after cleanup each should have had
-	// `git worktree remove --force` attempted.  On a CI machine without a real
-	// git repo, the dirs survive (git exits non-zero, error is ignored).
-	// We just verify the count didn't increase.
-	if len(entries) > 2 {
-		t.Errorf("unexpected extra entries after cleanupWorktrees: %d", len(entries))
+	// Both worktree subdirs should have been removed unconditionally by os.RemoveAll.
+	for _, wt := range []string{wt1, wt2} {
+		if _, err := os.Stat(wt); !os.IsNotExist(err) {
+			t.Errorf("expected worktree dir %s to be removed after cleanupWorktrees, stat err: %v", wt, err)
+		}
 	}
 }
 
@@ -113,17 +102,15 @@ func TestCleanupWorktrees_RealGitWorktree(t *testing.T) {
 	}
 }
 
-// TestSessionCleanCmd_SandboxCleanup tests the session clean command's sandbox
-// removal logic using a temporary directory that simulates ~/.belayer/sandboxes/.
+// TestSessionCleanCmd_SandboxCleanup tests cleanupSandboxDirs using a temporary
+// directory that simulates ~/.belayer/sandboxes/.
 func TestSessionCleanCmd_SandboxCleanup(t *testing.T) {
-	// Build a fake home dir with sandbox directories.
 	fakeHome := t.TempDir()
 	sandboxesDir := filepath.Join(fakeHome, ".belayer", "sandboxes")
 	if err := os.MkdirAll(sandboxesDir, 0o700); err != nil {
 		t.Fatalf("mkdir sandboxes: %v", err)
 	}
 
-	// Create two sandbox directories for "stopped" session IDs (no active sessions).
 	stoppedID1 := "session-dead-0001"
 	stoppedID2 := "session-dead-0002"
 	for _, id := range []string{stoppedID1, stoppedID2} {
@@ -131,54 +118,32 @@ func TestSessionCleanCmd_SandboxCleanup(t *testing.T) {
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			t.Fatalf("mkdir sandbox %s: %v", id, err)
 		}
-		// Write a placeholder file (not docker-compose.yml so no docker call).
+		// Use info.txt (not docker-compose.yml) so no docker call is attempted.
 		if err := os.WriteFile(filepath.Join(dir, "info.txt"), []byte("test"), 0o600); err != nil {
 			t.Fatalf("write info: %v", err)
 		}
 	}
 
-	// Directly exercise the sandbox-removal logic extracted from newSessionCleanCmd.
-	// We simulate "no active sessions" by passing an empty activeSessions map.
-	activeSessions := map[string]bool{}
-	var out bytes.Buffer
-	cleaned := 0
-
-	entries, err := os.ReadDir(sandboxesDir)
-	if err != nil {
-		t.Fatalf("ReadDir sandboxes: %v", err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		sessionID := entry.Name()
-		if activeSessions[sessionID] {
-			continue
-		}
-		sandboxDir := filepath.Join(sandboxesDir, sessionID)
-		if err := os.RemoveAll(sandboxDir); err != nil {
-			t.Errorf("RemoveAll %s: %v", sandboxDir, err)
-		} else {
-			out.WriteString("Removed sandbox: " + sandboxDir + "\n")
-			cleaned++
-		}
-	}
+	var out, errOut bytes.Buffer
+	cleaned := cleanupSandboxDirs(sandboxesDir, map[string]bool{}, &out, &errOut)
 
 	if cleaned != 2 {
 		t.Errorf("expected 2 cleaned sandboxes, got %d; output: %s", cleaned, out.String())
 	}
-
-	// Verify they're gone.
 	for _, id := range []string{stoppedID1, stoppedID2} {
 		dir := filepath.Join(sandboxesDir, id)
 		if _, err := os.Stat(dir); !os.IsNotExist(err) {
-			t.Errorf("sandbox dir %s should be removed, stat err: %v", dir, err)
+			t.Errorf("sandbox dir %s should be removed, stat err: %v; output: %s", dir, err, out.String())
+		}
+		sandboxDir := filepath.Join(sandboxesDir, id)
+		if !strings.Contains(out.String(), "Removed sandbox: "+sandboxDir) {
+			t.Errorf("expected output to mention removed sandbox %s; output: %s", sandboxDir, out.String())
 		}
 	}
 }
 
 // TestSessionCleanCmd_ActiveSessionsPreserved verifies that sandbox dirs for
-// active (running) sessions are NOT removed.
+// active (running) sessions are NOT removed by cleanupSandboxDirs.
 func TestSessionCleanCmd_ActiveSessionsPreserved(t *testing.T) {
 	fakeHome := t.TempDir()
 	sandboxesDir := filepath.Join(fakeHome, ".belayer", "sandboxes")
@@ -195,26 +160,15 @@ func TestSessionCleanCmd_ActiveSessionsPreserved(t *testing.T) {
 		}
 	}
 
-	activeSessions := map[string]bool{activeID: true}
-	cleaned := 0
-
-	entries, _ := os.ReadDir(sandboxesDir)
-	for _, entry := range entries {
-		if !entry.IsDir() || activeSessions[entry.Name()] {
-			continue
-		}
-		os.RemoveAll(filepath.Join(sandboxesDir, entry.Name())) //nolint:errcheck
-		cleaned++
-	}
+	var out, errOut bytes.Buffer
+	cleaned := cleanupSandboxDirs(sandboxesDir, map[string]bool{activeID: true}, &out, &errOut)
 
 	if cleaned != 1 {
 		t.Errorf("expected 1 cleaned, got %d", cleaned)
 	}
-	// Active session dir must still exist.
 	if _, err := os.Stat(filepath.Join(sandboxesDir, activeID)); err != nil {
 		t.Errorf("active session sandbox should still exist: %v", err)
 	}
-	// Dead session dir must be gone.
 	if _, err := os.Stat(filepath.Join(sandboxesDir, deadID)); !os.IsNotExist(err) {
 		t.Errorf("dead session sandbox should be removed")
 	}

--- a/internal/cli/session_test.go
+++ b/internal/cli/session_test.go
@@ -1,0 +1,275 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCleanupWorktrees_RemovesWorktreeDirectories verifies that cleanupWorktrees
+// removes worktree subdirectories inside <baseDir>/worktrees/.
+func TestCleanupWorktrees_RemovesWorktreeDirectories(t *testing.T) {
+	// Create a temporary base directory simulating a session dir.
+	baseDir := t.TempDir()
+	worktreeDir := filepath.Join(baseDir, "worktrees")
+	if err := os.MkdirAll(worktreeDir, 0o700); err != nil {
+		t.Fatalf("mkdir worktrees: %v", err)
+	}
+
+	// Create two fake worktree subdirectories (not real git worktrees, so the
+	// `git worktree remove` call inside cleanupWorktrees will silently fail and
+	// that is fine — the function does not require git to succeed).
+	wt1 := filepath.Join(worktreeDir, "repo-a")
+	wt2 := filepath.Join(worktreeDir, "repo-b")
+	for _, d := range []string{wt1, wt2} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+		// Add a file so the directory is non-empty.
+		if err := os.WriteFile(filepath.Join(d, "dummy.txt"), []byte("test"), 0o600); err != nil {
+			t.Fatalf("write dummy: %v", err)
+		}
+	}
+
+	// cleanupWorktrees calls `git worktree remove --force <path>` then returns.
+	// For non-git directories the git command fails silently; the directories
+	// themselves are NOT removed by cleanupWorktrees (it delegates to git).
+	// The function contract is: call git worktree remove for each subdir.
+	// We test that the function runs without panicking and touches each entry.
+	cleanupWorktrees(baseDir)
+
+	// After calling cleanupWorktrees the worktrees directory itself still exists
+	// (the function does not remove the parent), and the subdirs may or may not
+	// still exist depending on whether git succeeded.  What we can assert is that
+	// the function does not leave extra unexpected directories.
+	entries, err := os.ReadDir(worktreeDir)
+	if err != nil {
+		t.Fatalf("ReadDir after cleanup: %v", err)
+	}
+	// Both entries were there before; after cleanup each should have had
+	// `git worktree remove --force` attempted.  On a CI machine without a real
+	// git repo, the dirs survive (git exits non-zero, error is ignored).
+	// We just verify the count didn't increase.
+	if len(entries) > 2 {
+		t.Errorf("unexpected extra entries after cleanupWorktrees: %d", len(entries))
+	}
+}
+
+// TestCleanupWorktrees_MissingWorktreeDirIsNoop verifies that cleanupWorktrees
+// is a no-op (does not panic or error) when the worktrees sub-directory does
+// not exist.
+func TestCleanupWorktrees_MissingWorktreeDirIsNoop(t *testing.T) {
+	baseDir := t.TempDir()
+	// Do NOT create the worktrees subdirectory.
+	cleanupWorktrees(baseDir) // must not panic
+}
+
+// TestCleanupWorktrees_RealGitWorktree creates a real git repo and worktree,
+// then verifies that cleanupWorktrees removes the worktree directory.
+func TestCleanupWorktrees_RealGitWorktree(t *testing.T) {
+	// Skip if git is not available.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Create a bare-minimum git repo.
+	repoDir := t.TempDir()
+	mustGit(t, repoDir, "init")
+	mustGit(t, repoDir, "config", "user.email", "test@test.com")
+	mustGit(t, repoDir, "config", "user.name", "Test")
+	// Need at least one commit for worktree add to work.
+	readmeFile := filepath.Join(repoDir, "README")
+	if err := os.WriteFile(readmeFile, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	mustGit(t, repoDir, "add", ".")
+	mustGit(t, repoDir, "commit", "-m", "init")
+
+	// Create a session-like directory structure.
+	baseDir := t.TempDir()
+	worktreeDir := filepath.Join(baseDir, "worktrees")
+	if err := os.MkdirAll(worktreeDir, 0o700); err != nil {
+		t.Fatalf("mkdir worktrees: %v", err)
+	}
+	wtPath := filepath.Join(worktreeDir, "repo-a")
+
+	// Add a git worktree.
+	mustGit(t, repoDir, "worktree", "add", "--detach", wtPath)
+
+	// Verify the worktree exists before cleanup.
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("worktree not created: %v", err)
+	}
+
+	// Run cleanup.
+	cleanupWorktrees(baseDir)
+
+	// The worktree directory should have been removed.
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("expected worktree dir to be removed, got err: %v", err)
+	}
+}
+
+// TestSessionCleanCmd_SandboxCleanup tests the session clean command's sandbox
+// removal logic using a temporary directory that simulates ~/.belayer/sandboxes/.
+func TestSessionCleanCmd_SandboxCleanup(t *testing.T) {
+	// Build a fake home dir with sandbox directories.
+	fakeHome := t.TempDir()
+	sandboxesDir := filepath.Join(fakeHome, ".belayer", "sandboxes")
+	if err := os.MkdirAll(sandboxesDir, 0o700); err != nil {
+		t.Fatalf("mkdir sandboxes: %v", err)
+	}
+
+	// Create two sandbox directories for "stopped" session IDs (no active sessions).
+	stoppedID1 := "session-dead-0001"
+	stoppedID2 := "session-dead-0002"
+	for _, id := range []string{stoppedID1, stoppedID2} {
+		dir := filepath.Join(sandboxesDir, id)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir sandbox %s: %v", id, err)
+		}
+		// Write a placeholder file (not docker-compose.yml so no docker call).
+		if err := os.WriteFile(filepath.Join(dir, "info.txt"), []byte("test"), 0o600); err != nil {
+			t.Fatalf("write info: %v", err)
+		}
+	}
+
+	// Directly exercise the sandbox-removal logic extracted from newSessionCleanCmd.
+	// We simulate "no active sessions" by passing an empty activeSessions map.
+	activeSessions := map[string]bool{}
+	var out bytes.Buffer
+	cleaned := 0
+
+	entries, err := os.ReadDir(sandboxesDir)
+	if err != nil {
+		t.Fatalf("ReadDir sandboxes: %v", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sessionID := entry.Name()
+		if activeSessions[sessionID] {
+			continue
+		}
+		sandboxDir := filepath.Join(sandboxesDir, sessionID)
+		if err := os.RemoveAll(sandboxDir); err != nil {
+			t.Errorf("RemoveAll %s: %v", sandboxDir, err)
+		} else {
+			out.WriteString("Removed sandbox: " + sandboxDir + "\n")
+			cleaned++
+		}
+	}
+
+	if cleaned != 2 {
+		t.Errorf("expected 2 cleaned sandboxes, got %d; output: %s", cleaned, out.String())
+	}
+
+	// Verify they're gone.
+	for _, id := range []string{stoppedID1, stoppedID2} {
+		dir := filepath.Join(sandboxesDir, id)
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("sandbox dir %s should be removed, stat err: %v", dir, err)
+		}
+	}
+}
+
+// TestSessionCleanCmd_ActiveSessionsPreserved verifies that sandbox dirs for
+// active (running) sessions are NOT removed.
+func TestSessionCleanCmd_ActiveSessionsPreserved(t *testing.T) {
+	fakeHome := t.TempDir()
+	sandboxesDir := filepath.Join(fakeHome, ".belayer", "sandboxes")
+	if err := os.MkdirAll(sandboxesDir, 0o700); err != nil {
+		t.Fatalf("mkdir sandboxes: %v", err)
+	}
+
+	activeID := "session-alive-0001"
+	deadID := "session-dead-0001"
+	for _, id := range []string{activeID, deadID} {
+		dir := filepath.Join(sandboxesDir, id)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", id, err)
+		}
+	}
+
+	activeSessions := map[string]bool{activeID: true}
+	cleaned := 0
+
+	entries, _ := os.ReadDir(sandboxesDir)
+	for _, entry := range entries {
+		if !entry.IsDir() || activeSessions[entry.Name()] {
+			continue
+		}
+		os.RemoveAll(filepath.Join(sandboxesDir, entry.Name())) //nolint:errcheck
+		cleaned++
+	}
+
+	if cleaned != 1 {
+		t.Errorf("expected 1 cleaned, got %d", cleaned)
+	}
+	// Active session dir must still exist.
+	if _, err := os.Stat(filepath.Join(sandboxesDir, activeID)); err != nil {
+		t.Errorf("active session sandbox should still exist: %v", err)
+	}
+	// Dead session dir must be gone.
+	if _, err := os.Stat(filepath.Join(sandboxesDir, deadID)); !os.IsNotExist(err) {
+		t.Errorf("dead session sandbox should be removed")
+	}
+}
+
+// TestRepoForWorktree_NonGitDir returns empty string for a non-git directory.
+func TestRepoForWorktree_NonGitDir(t *testing.T) {
+	dir := t.TempDir()
+	result := repoForWorktree(dir)
+	if result != "" {
+		t.Errorf("expected empty string for non-git dir, got %q", result)
+	}
+}
+
+// TestRepoForWorktree_WithRealWorktree verifies that repoForWorktree returns
+// the main repo root for a real git worktree.
+func TestRepoForWorktree_WithRealWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repoDir := t.TempDir()
+	mustGit(t, repoDir, "init")
+	mustGit(t, repoDir, "config", "user.email", "test@test.com")
+	mustGit(t, repoDir, "config", "user.name", "Test")
+	readmeFile := filepath.Join(repoDir, "README")
+	if err := os.WriteFile(readmeFile, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	mustGit(t, repoDir, "add", ".")
+	mustGit(t, repoDir, "commit", "-m", "init")
+
+	wtPath := t.TempDir()
+	// Remove the temp dir so git worktree add can create it.
+	os.RemoveAll(wtPath)
+	mustGit(t, repoDir, "worktree", "add", "--detach", wtPath)
+	defer exec.Command("git", "-C", repoDir, "worktree", "remove", "--force", wtPath).Run() //nolint:errcheck
+
+	result := repoForWorktree(wtPath)
+	if result == "" {
+		t.Fatal("expected non-empty repo dir for real worktree")
+	}
+	// The returned path should match repoDir (resolve symlinks for macOS /var -> /private/var).
+	wantAbs, _ := filepath.EvalSymlinks(repoDir)
+	gotAbs, _ := filepath.EvalSymlinks(result)
+	if !strings.EqualFold(wantAbs, gotAbs) {
+		t.Errorf("repoForWorktree returned %q, want %q", gotAbs, wantAbs)
+	}
+}
+
+// mustGit is a test helper that runs a git command in dir and fails the test on error.
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, string(out))
+	}
+}


### PR DESCRIPTION
## Summary

- Wire existing `cleanupWorktrees()` into `session stop` — called after Docker sandbox teardown
- Remove sandbox directory from disk after `docker compose down` (was leaking `~/.belayer/sandboxes/<id>/`)
- Add `belayer session clean` command for manual cleanup of orphaned sessions
  - Walks `~/.belayer/sandboxes/` and workspace worktree dirs
  - Compares against active sessions from daemon
  - Removes dirs for stopped/missing sessions + runs `git worktree prune`

## Test plan

- [x] `TestCleanupWorktrees_RemovesWorktreeDirectories` — basic cleanup invocation
- [x] `TestCleanupWorktrees_MissingWorktreeDirIsNoop` — no panic on absent dir
- [x] `TestCleanupWorktrees_RealGitWorktree` — e2e with real git repo + worktree
- [x] `TestSessionCleanCmd_SandboxCleanup` — sandbox removal for stopped sessions
- [x] `TestSessionCleanCmd_ActiveSessionsPreserved` — active session dirs untouched
- [x] `TestRepoForWorktree_NonGitDir` / `TestRepoForWorktree_WithRealWorktree`
- [x] `go build ./cmd/belayer` passes
- [x] `go test ./...` passes (pre-existing temporal failure unrelated)

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)