### PR TITLE
test: lock the climb acceptance path with CLI smoke coverage

### DIFF
--- a/examples/environments/extend-fullstack/workbench.yaml
+++ b/examples/environments/extend-fullstack/workbench.yaml
@@ -1,29 +1,30 @@
-# Workbench spec — provisioned on demand via `belayer workbench up`
-# Runs the extend stack for integration testing.
-
+timeout: 5m
 services:
-  postgres:
+  - name: postgres
     image: postgres:16
     environment:
       POSTGRES_DB: "extend_{{.SessionID}}"
       POSTGRES_USER: extend
       POSTGRES_PASSWORD: localdev
     ports: ["5432"]
-    healthcheck:
+    networks: ["infra-net"]
+    health_check:
       test: ["CMD", "pg_isready", "-U", "extend"]
       interval: 5s
       timeout: 3s
       retries: 10
 
-  localstack:
+  - name: localstack
     image: localstack/localstack:3
     ports: ["4566"]
+    networks: ["infra-net"]
 
-  rabbitmq:
+  - name: rabbitmq
     image: rabbitmq:3-management
     ports: ["5672", "15672"]
+    networks: ["infra-net"]
 
-  extend-api:
+  - name: extend-api
     build:
       context: "{{.Worktree.extend-api}}"
       dockerfile: Dockerfile
@@ -38,14 +39,14 @@ services:
       postgres:
         condition: service_healthy
     ports: ["8080"]
-    healthcheck:
+    health_check:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 5s
       timeout: 3s
       start_period: 90s
       retries: 24
 
-  extend-app:
+  - name: extend-app
     build:
       context: "{{.Worktree.extend-app}}"
     environment:
@@ -54,7 +55,7 @@ services:
       extend-api:
         condition: service_healthy
     ports: ["3000"]
-    healthcheck:
+    health_check:
       test: ["CMD", "curl", "-f", "http://localhost:3000"]
       interval: 5s
       timeout: 3s

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -11,7 +13,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
+
+	"github.com/donovan-yohan/belayer/internal/agent"
 )
 
 // Client connects to the belayer daemon via Unix socket.
@@ -184,7 +190,26 @@ func (c *Client) LogEvent(sessionID, eventType, data string) error {
 
 // GetEvents returns events for a session.
 func (c *Client) GetEvents(sessionID string) ([]eventResponse, error) {
-	resp, err := c.do("GET", "/sessions/"+sessionID+"/events", nil)
+	return c.GetEventsAfter(sessionID, 0, 0)
+}
+
+// GetEventsAfter returns events for a session after the given event ID. When
+// waitFor is positive, the daemon long-polls until new events arrive or the
+// wait interval expires.
+func (c *Client) GetEventsAfter(sessionID string, afterID int64, waitFor time.Duration) ([]eventResponse, error) {
+	path := "/sessions/" + sessionID + "/events"
+	query := url.Values{}
+	if afterID > 0 {
+		query.Set("after", strconv.FormatInt(afterID, 10))
+	}
+	if waitFor > 0 {
+		query.Set("wait", waitFor.String())
+	}
+	if encoded := query.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	resp, err := c.do("GET", path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -194,6 +219,57 @@ func (c *Client) GetEvents(sessionID string) ([]eventResponse, error) {
 		return nil, fmt.Errorf("decode events: %w", err)
 	}
 	return events, nil
+}
+
+// WatchSessions streams multiplexed session events over the SSE endpoint until
+// the provided context is cancelled.
+func (c *Client) WatchSessions(ctx context.Context, sessionIDs []string, afterID int64, onEvent func(eventResponse) error) error {
+	query := url.Values{}
+	query.Set("sessions", strings.Join(sessionIDs, ","))
+	if afterID > 0 {
+		query.Set("after", strconv.FormatInt(afterID, 10))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://daemon/events/stream?"+query.Encode(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("watch sessions: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	var payload strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data: ") {
+			payload.WriteString(strings.TrimPrefix(line, "data: "))
+			continue
+		}
+		if line == "" && payload.Len() > 0 {
+			var evt eventResponse
+			if err := json.Unmarshal([]byte(payload.String()), &evt); err != nil {
+				return fmt.Errorf("watch sessions: decode event: %w", err)
+			}
+			if err := onEvent(evt); err != nil {
+				return err
+			}
+			payload.Reset()
+		}
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("watch sessions: %w", err)
+	}
+	if err := ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
 }
 
 type workbenchResponse struct {
@@ -216,6 +292,10 @@ func (c *Client) CreateWorkbench(sessionID, spec string) (workbenchResponse, err
 		return workbenchResponse{}, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return workbenchResponse{}, fmt.Errorf("create workbench: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
 	var wb workbenchResponse
 	if err := json.NewDecoder(resp.Body).Decode(&wb); err != nil {
 		return workbenchResponse{}, fmt.Errorf("decode workbench: %w", err)
@@ -249,6 +329,20 @@ func (c *Client) DeleteWorkbenchBySession(sessionID string) error {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("delete workbench: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// RegisterTool registers a tool for a session.
+func (c *Client) RegisterTool(sessionID string, spec agent.ToolSpec) error {
+	resp, err := c.do("POST", "/sessions/"+url.PathEscape(sessionID)+"/tools", spec)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("register tool: status %d: %s", resp.StatusCode, string(body))
 	}
 	return nil
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -234,7 +234,16 @@ func (c *Client) WatchSessions(ctx context.Context, sessionIDs []string, afterID
 	if err != nil {
 		return err
 	}
-	resp, err := c.http.Do(req)
+	// Use a streaming-specific HTTP client without a timeout so the SSE
+	// connection is not killed by the default 10s client timeout.
+	streamClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", c.socketPath)
+			},
+		},
+	}
+	resp, err := streamClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -245,22 +254,36 @@ func (c *Client) WatchSessions(ctx context.Context, sessionIDs []string, afterID
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	var payload strings.Builder
+	var eventType string
 	for scanner.Scan() {
 		line := scanner.Text()
+		if strings.HasPrefix(line, "event: ") {
+			eventType = strings.TrimPrefix(line, "event: ")
+			continue
+		}
 		if strings.HasPrefix(line, "data: ") {
 			payload.WriteString(strings.TrimPrefix(line, "data: "))
 			continue
 		}
 		if line == "" && payload.Len() > 0 {
+			if eventType == "error" {
+				payload.Reset()
+				eventType = ""
+				continue
+			}
 			var evt eventResponse
 			if err := json.Unmarshal([]byte(payload.String()), &evt); err != nil {
-				return fmt.Errorf("watch sessions: decode event: %w", err)
+				payload.Reset()
+				eventType = ""
+				continue
 			}
 			if err := onEvent(evt); err != nil {
 				return err
 			}
 			payload.Reset()
+			eventType = ""
 		}
 	}
 	if err := scanner.Err(); err != nil && !errors.Is(err, context.Canceled) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,6 +23,7 @@ Commands:
   setup       Bootstrap a .belayer/ workspace
   status      Show running sessions
   logs        Show session events
+  watch       Stream events from one or more sessions
   recall      Search events via FTS5`,
 	}
 
@@ -33,6 +34,7 @@ Commands:
 		newSessionCmd(),
 		newAttachCmd(),
 		newLogsCmd(),
+		newWatchCmd(),
 		newStatusCmd(),
 		newDebugCmd(),
 		newRecallCmd(),

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestRootCmdRegistersV6ScaffoldCommands(t *testing.T) {
 	cmd := NewRootCmd()
 
-	want := []string{"attach", "context", "daemon", "debug", "logs", "message", "note", "recall", "session", "setup", "status", "submit"}
+	want := []string{"attach", "context", "daemon", "debug", "logs", "message", "note", "recall", "session", "setup", "status", "submit", "watch"}
 	seen := map[string]bool{}
 	for _, child := range cmd.Commands() {
 		seen[child.Name()] = true

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -389,8 +389,10 @@ func newSessionAddAgentCmd() *cobra.Command {
 				SessionID: sessionID,
 			})
 
-			sysPromptFile := filepath.Join(os.TempDir(), fmt.Sprintf("belayer-sysprompt-%s-%s.txt", sess.Name, spec.Name))
-			taskFile := filepath.Join(os.TempDir(), fmt.Sprintf("belayer-task-%s-%s.txt", sess.Name, spec.Name))
+			safeSessName := sanitizeName(sess.Name)
+			safeSpecName := sanitizeName(spec.Name)
+			sysPromptFile := filepath.Join(os.TempDir(), fmt.Sprintf("belayer-sysprompt-%s-%s.txt", safeSessName, safeSpecName))
+			taskFile := filepath.Join(os.TempDir(), fmt.Sprintf("belayer-task-%s-%s.txt", safeSessName, safeSpecName))
 			if err := os.WriteFile(sysPromptFile, []byte(compiled), 0o600); err != nil {
 				return fmt.Errorf("write system prompt: %w", err)
 			}
@@ -399,7 +401,7 @@ func newSessionAddAgentCmd() *cobra.Command {
 			}
 
 			runner := tmux.NewLocalRunner()
-			if err := runner.CreateSession(fmt.Sprintf("%s-%s", sess.Name, spec.Name), buildLaunchCmd(spec, sessionID, sysPromptFile, taskFile, workDir)); err != nil {
+			if err := runner.CreateSession(fmt.Sprintf("%s-%s", safeSessName, safeSpecName), buildLaunchCmd(spec, sessionID, sysPromptFile, taskFile, workDir)); err != nil {
 				return fmt.Errorf("launch agent: %w", err)
 			}
 
@@ -953,6 +955,13 @@ func newRecallCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
 	return cmd
+}
+
+// sanitizeName replaces path separators and other unsafe characters in a name
+// so it can be used safely in file paths and tmux session names.
+func sanitizeName(name string) string {
+	r := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-")
+	return r.Replace(name)
 }
 
 func resolveSocket(override string) string {

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -8,11 +9,16 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"text/tabwriter"
 	"time"
 
+	"github.com/donovan-yohan/belayer/internal/agent"
+	"github.com/donovan-yohan/belayer/internal/docker"
+	"github.com/donovan-yohan/belayer/internal/tmux"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +28,9 @@ func newSessionCmd() *cobra.Command {
 		Short: "Manage belayer sessions",
 	}
 	cmd.AddCommand(
+		newSessionCreateCmd(),
 		newSessionStartCmd(),
+		newSessionAddAgentCmd(),
 		newSessionListCmd(),
 		newSessionStopCmd(),
 		newSessionWakeCmd(),
@@ -32,27 +40,9 @@ func newSessionCmd() *cobra.Command {
 }
 
 func newSessionCreateCmd() *cobra.Command {
-	var name, template, socket string
-
-	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create a new session",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if name == "" {
-				return fmt.Errorf("--name is required")
-			}
-			c := NewClient(resolveSocket(socket))
-			sess, err := c.CreateSession(name, template)
-			if err != nil {
-				return fmt.Errorf("create session: %w", err)
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Created session %s (%s)\n", sess.ID, sess.Name)
-			return nil
-		},
-	}
-	cmd.Flags().StringVar(&name, "name", "", "Session name (required)")
-	cmd.Flags().StringVar(&template, "template", "", "Session template (intake, implement, deliver)")
-	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	cmd := newSessionStartCmd()
+	cmd.Use = "create"
+	cmd.Short = "Create and start a session"
 	return cmd
 }
 
@@ -328,6 +318,128 @@ that context prepended to its prompt.`,
 	cmd.Flags().StringVar(&agentName, "agent", "", "Agent to wake (required)")
 	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
 	return cmd
+}
+
+func newSessionAddAgentCmd() *cobra.Command {
+	var (
+		template  string
+		socket    string
+		repo      string
+		input     string
+		command   string
+		tier      string
+		ephemeral bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "add-agent <session-id-or-name> <agent-name>",
+		Short: "Add an agent to a running local session",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if template == "" {
+				return fmt.Errorf("--template is required")
+			}
+			if input == "" {
+				input = command
+			}
+			if input == "" {
+				return fmt.Errorf("--input or --command is required")
+			}
+
+			c := NewClient(resolveSocket(socket))
+			sessionID, err := lookupSessionID(c, args[0])
+			if err != nil {
+				return fmt.Errorf("add agent: %w", err)
+			}
+			sess, err := c.GetSession(sessionID)
+			if err != nil {
+				return fmt.Errorf("add agent: %w", err)
+			}
+
+			home, _ := os.UserHomeDir()
+			sandboxDir := filepath.Join(home, ".belayer", "sandboxes", sessionID)
+			if meta, err := docker.LoadRuntimeMetadata(sandboxDir); err == nil && meta.SandboxComposeFile != "" {
+				return fmt.Errorf("session add-agent currently supports local tmux sessions only")
+			}
+
+			spec, err := loadAgentTemplateSpec(resolveBelayerDir(), template, repo)
+			if err != nil {
+				return err
+			}
+			spec.Name = args[1]
+			switch {
+			case tier != "":
+				spec.Tier = tier
+			case ephemeral:
+				spec.Tier = "ephemeral"
+			case spec.Tier == "":
+				spec.Tier = "main"
+			}
+
+			workDir := resolveAddAgentWorkDir(repo)
+			cfg := agent.AgentConfig{
+				Name:         spec.Name,
+				Vendor:       spec.Vendor,
+				Model:        spec.Model,
+				SystemPrompt: spec.SystemPrompt,
+			}
+			compiled := agent.CompilePrompt(agent.PromptContext{
+				Config:    cfg,
+				TaskInput: input,
+				SessionID: sessionID,
+			})
+
+			sysPromptFile := filepath.Join(os.TempDir(), fmt.Sprintf("belayer-sysprompt-%s-%s.txt", sess.Name, spec.Name))
+			taskFile := filepath.Join(os.TempDir(), fmt.Sprintf("belayer-task-%s-%s.txt", sess.Name, spec.Name))
+			if err := os.WriteFile(sysPromptFile, []byte(compiled), 0o600); err != nil {
+				return fmt.Errorf("write system prompt: %w", err)
+			}
+			if err := os.WriteFile(taskFile, []byte(input), 0o600); err != nil {
+				return fmt.Errorf("write task file: %w", err)
+			}
+
+			runner := tmux.NewLocalRunner()
+			if err := runner.CreateSession(fmt.Sprintf("%s-%s", sess.Name, spec.Name), buildLaunchCmd(spec, sessionID, sysPromptFile, taskFile, workDir)); err != nil {
+				return fmt.Errorf("launch agent: %w", err)
+			}
+
+			payload := mustJSON(map[string]string{
+				"agent":    spec.Name,
+				"template": template,
+				"tier":     spec.Tier,
+			})
+			_ = c.LogEvent(sessionID, "agent_added", payload)
+			_ = c.LogEvent(sessionID, "agent_launched", mustJSON(map[string]string{
+				"agent":  spec.Name,
+				"vendor": spec.Vendor,
+				"model":  spec.Model,
+				"tier":   spec.Tier,
+			}))
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Added agent %s to session %s (%s/%s, tier=%s)\n", spec.Name, sessionID, spec.Vendor, spec.Model, spec.Tier)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&template, "template", "", "Agent template name from .belayer/templates/<name>")
+	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	cmd.Flags().StringVar(&repo, "repo", "", "Optional repo name or workdir path for the agent")
+	cmd.Flags().StringVar(&input, "input", "", "Task input for the added agent")
+	cmd.Flags().StringVar(&command, "command", "", "Alias for --input")
+	cmd.Flags().StringVar(&tier, "tier", "", "Explicit tier override (main, peripheral, ephemeral)")
+	cmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "Mark the added agent as ephemeral")
+	return cmd
+}
+
+func resolveAddAgentWorkDir(repo string) string {
+	if repo != "" {
+		if filepath.IsAbs(repo) || strings.HasPrefix(repo, ".") {
+			return repo
+		}
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		return cwd
+	}
+	return "."
 }
 
 func newSessionCleanCmd() *cobra.Command {
@@ -650,6 +762,7 @@ func newLogsCmd() *cobra.Command {
 
 			// Print existing events.
 			lastSeen := time.Time{}
+			var lastSeenID int64
 			for _, e := range events {
 				if !cutoff.IsZero() && e.Timestamp.Before(cutoff) {
 					continue
@@ -658,29 +771,30 @@ func newLogsCmd() *cobra.Command {
 				if e.Timestamp.After(lastSeen) {
 					lastSeen = e.Timestamp
 				}
+				if e.ID > lastSeenID {
+					lastSeenID = e.ID
+				}
 			}
 
 			if !follow {
 				return nil
 			}
 
-			// Polling loop for --follow.
+			// Long-poll loop for --follow.
 			fmt.Fprintln(cmd.OutOrStdout(), "--- following (Ctrl+C to stop) ---")
 			for {
-				time.Sleep(2 * time.Second)
-
-				events, err := c.GetEvents(sessionID)
+				events, err := c.GetEventsAfter(sessionID, lastSeenID, 30*time.Second)
 				if err != nil {
 					continue // transient error, keep polling
 				}
 
 				for _, e := range events {
-					if !lastSeen.IsZero() && !e.Timestamp.After(lastSeen) {
-						continue
-					}
 					printEvent(cmd, e)
 					if e.Timestamp.After(lastSeen) {
 						lastSeen = e.Timestamp
+					}
+					if e.ID > lastSeenID {
+						lastSeenID = e.ID
 					}
 				}
 			}
@@ -689,6 +803,67 @@ func newLogsCmd() *cobra.Command {
 	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow events in real-time")
 	cmd.Flags().IntVar(&since, "since", 0, "Show events from the last N minutes")
+	return cmd
+}
+
+func newWatchCmd() *cobra.Command {
+	var (
+		socket       string
+		sessionsFlag string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Stream events from one or more sessions as they happen",
+		Long:  "Stream events from one or more sessions via the daemon SSE endpoint.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessionArgs := strings.TrimSpace(sessionsFlag)
+			if sessionArgs == "" {
+				sessionArgs = strings.Join(args, ",")
+			}
+			if sessionArgs == "" {
+				return fmt.Errorf("--sessions is required")
+			}
+
+			c := NewClient(resolveSocket(socket))
+			rawSessions := strings.Split(sessionArgs, ",")
+			sessionIDs := make([]string, 0, len(rawSessions))
+			var afterID int64
+			for _, raw := range rawSessions {
+				raw = strings.TrimSpace(raw)
+				if raw == "" {
+					continue
+				}
+				sessionID, err := lookupSessionID(c, raw)
+				if err != nil {
+					return err
+				}
+				sessionIDs = append(sessionIDs, sessionID)
+				events, err := c.GetEvents(sessionID)
+				if err == nil {
+					for _, evt := range events {
+						if evt.ID > afterID {
+							afterID = evt.ID
+						}
+					}
+				}
+			}
+			if len(sessionIDs) == 0 {
+				return fmt.Errorf("no sessions resolved")
+			}
+
+			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Watching sessions: %s\n", strings.Join(sessionIDs, ", "))
+			return c.WatchSessions(ctx, sessionIDs, afterID, func(evt eventResponse) error {
+				printEvent(cmd, evt)
+				return nil
+			})
+		},
+	}
+	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	cmd.Flags().StringVar(&sessionsFlag, "sessions", "", "Comma-separated session IDs or names")
 	return cmd
 }
 

--- a/internal/cli/session_commands_test.go
+++ b/internal/cli/session_commands_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import "testing"
+
+func TestSessionCmdRegistersLifecycleAndAgentCommands(t *testing.T) {
+	cmd := newSessionCmd()
+
+	want := []string{"add-agent", "clean", "create", "list", "start", "stop", "wake"}
+	seen := map[string]bool{}
+	for _, child := range cmd.Commands() {
+		seen[child.Name()] = true
+	}
+
+	for _, name := range want {
+		if !seen[name] {
+			t.Fatalf("missing session subcommand %q", name)
+		}
+	}
+}

--- a/internal/cli/session_smoke_test.go
+++ b/internal/cli/session_smoke_test.go
@@ -1,0 +1,280 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	daemonpkg "github.com/donovan-yohan/belayer/internal/daemon"
+)
+
+func installFakeTmux(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	logDir := t.TempDir()
+	script := filepath.Join(binDir, "tmux")
+	body := `#!/bin/sh
+set -eu
+log_dir="${BELAYER_FAKE_TMUX_DIR:-/tmp}"
+mkdir -p "$log_dir"
+printf '%s\n' "$*" >> "$log_dir/tmux.log"
+case "$1" in
+  new-session|kill-session|send-keys|pipe-pane)
+    exit 0
+    ;;
+  list-sessions)
+    exit 0
+    ;;
+  has-session)
+    exit 1
+    ;;
+  display-message)
+    printf '%s\n' "$PWD"
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("BELAYER_FAKE_TMUX_DIR", logDir)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return filepath.Join(logDir, "tmux.log")
+}
+
+func startTestDaemon(t *testing.T) (context.CancelFunc, string) {
+	t.Helper()
+	baseDir, err := os.MkdirTemp("/tmp", "belayer-cli-daemon-")
+	if err != nil {
+		t.Fatalf("mktemp daemon dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(baseDir) })
+	socketPath := filepath.Join(baseDir, "daemon.sock")
+	dbPath := filepath.Join(baseDir, "belayer.db")
+	d, err := daemonpkg.New(daemonpkg.Config{SocketPath: socketPath, DBPath: dbPath})
+	if err != nil {
+		t.Fatalf("new daemon: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- d.Start(ctx) }()
+
+	client := NewClient(socketPath)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if err := client.Health(); err == nil {
+			return cancel, socketPath
+		}
+		select {
+		case err := <-errCh:
+			cancel()
+			t.Fatalf("daemon exited before becoming healthy: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("daemon did not become healthy in time")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func runRootCmd(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := NewRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute %v: %v\noutput:\n%s", args, err, out.String())
+	}
+	return out.String()
+}
+
+func initGitRepo(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	mustRun := func(args ...string) {
+		t.Helper()
+		if out, err := execCombined(dir, args...); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	mustRun("git", "init", "-q")
+	mustRun("git", "config", "user.email", "smoke@example.com")
+	mustRun("git", "config", "user.name", "smoke")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# "+name+"\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	mustRun("git", "add", "README.md")
+	mustRun("git", "commit", "-qm", "init")
+}
+
+func execCombined(dir string, args ...string) (string, error) {
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(dst), err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", dst, err)
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(cwd, "..", ".."))
+}
+
+func TestSessionCreateClimbAliasStartsImplementRoster(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logPath := installFakeTmux(t)
+	cancel, socketPath := startTestDaemon(t)
+	defer cancel()
+
+	repoDir := filepath.Join(t.TempDir(), "extend-api")
+	initGitRepo(t, repoDir, "extend-api")
+
+	out := runRootCmd(t,
+		"session", "create",
+		"--socket", socketPath,
+		"--template", "climb",
+		"--input", "Add a test workflow",
+		"--name", "smoke-climb",
+		"--repo", repoDir,
+	)
+	for _, want := range []string{"pilot:", "implementer:", "reviewer:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+	client := NewClient(socketPath)
+	sessions, err := client.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Template != "climb" || sessions[0].Status != "running" {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read tmux log: %v", err)
+	}
+	for _, want := range []string{"belayer-smoke-climb-pilot", "belayer-smoke-climb-implementer", "belayer-smoke-climb-reviewer"} {
+		if !strings.Contains(string(logData), want) {
+			t.Fatalf("expected tmux log to contain %q, got:\n%s", want, string(logData))
+		}
+	}
+}
+
+func TestSessionCreateClimbFullstackStartsEnvironmentRoster(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logPath := installFakeTmux(t)
+	cancel, socketPath := startTestDaemon(t)
+	defer cancel()
+
+	root := repoRoot(t)
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	copyFile(t, filepath.Join(root, ".belayer", "environments", "extend-fullstack", "environment.yaml"), filepath.Join(workspace, ".belayer", "environments", "extend-fullstack", "environment.yaml"))
+	copyFile(t, filepath.Join(root, ".belayer", "environments", "extend-fullstack", "workbench.yaml"), filepath.Join(workspace, ".belayer", "environments", "extend-fullstack", "workbench.yaml"))
+	for _, name := range []string{"pilot", "api-implementer", "app-implementer", "reviewer", "sprite"} {
+		copyFile(t, filepath.Join(root, ".belayer", "templates", name, "agent.yaml"), filepath.Join(workspace, ".belayer", "templates", name, "agent.yaml"))
+		copyFile(t, filepath.Join(root, ".belayer", "templates", name, "system-prompt.md"), filepath.Join(workspace, ".belayer", "templates", name, "system-prompt.md"))
+	}
+
+	apiRepo := filepath.Join(t.TempDir(), "extend-api")
+	appRepo := filepath.Join(t.TempDir(), "extend-app")
+	initGitRepo(t, apiRepo, "extend-api")
+	initGitRepo(t, appRepo, "extend-app")
+
+	envPath := filepath.Join(workspace, ".belayer", "environments", "extend-fullstack", "environment.yaml")
+	envData, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read environment: %v", err)
+	}
+	rewritten := strings.ReplaceAll(string(envData), "~/Documents/Programs/work/extend-api", apiRepo)
+	rewritten = strings.ReplaceAll(rewritten, "~/Documents/Programs/work/extend-app", appRepo)
+	if err := os.WriteFile(envPath, []byte(rewritten), 0o644); err != nil {
+		t.Fatalf("write environment: %v", err)
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(prevWD) }()
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatalf("chdir workspace: %v", err)
+	}
+
+	out := runRootCmd(t,
+		"session", "create",
+		"--socket", socketPath,
+		"--template", "climb-fullstack",
+		"--environment", "extend-fullstack",
+		"--input", "Ship the fullstack workflow",
+		"--name", "smoke-fullstack",
+	)
+	for _, want := range []string{"pilot:", "api-implementer:", "app-implementer:", "reviewer:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+
+	client := NewClient(socketPath)
+	sessions, err := client.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Template != "climb-fullstack" || sessions[0].Status != "running" {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read tmux log: %v", err)
+	}
+	for _, want := range []string{"belayer-smoke-fullstack-pilot", "belayer-smoke-fullstack-api-implementer", "belayer-smoke-fullstack-app-implementer", "belayer-smoke-fullstack-reviewer"} {
+		if !strings.Contains(string(logData), want) {
+			t.Fatalf("expected tmux log to contain %q, got:\n%s", want, string(logData))
+		}
+	}
+
+	metaPath := filepath.Join(home, ".belayer", "sandboxes", sessions[0].ID, "runtime.json")
+	metaData, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read runtime metadata: %v", err)
+	}
+	for _, want := range []string{"\"environment\": \"extend-fullstack\"", apiRepo, appRepo} {
+		if !strings.Contains(string(metaData), want) {
+			t.Fatalf("expected runtime metadata to contain %q, got:\n%s", want, string(metaData))
+		}
+	}
+}

--- a/internal/cli/session_start.go
+++ b/internal/cli/session_start.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/donovan-yohan/belayer/internal/agent"
 	"github.com/donovan-yohan/belayer/internal/docker"
+	runtimepkg "github.com/donovan-yohan/belayer/internal/runtime"
 	"github.com/donovan-yohan/belayer/internal/session"
 	"github.com/donovan-yohan/belayer/internal/shell"
 	"github.com/donovan-yohan/belayer/internal/tmux"
@@ -41,9 +42,10 @@ config that controls network isolation, compose extensions, and repos.`,
 				return fmt.Errorf("--input is required (task description or path to spec file)")
 			}
 
-			// 1. Resolve workspace directory and templates.
-			wsDir := resolveWorkspaceDir()
-			templatesDir := filepath.Join(wsDir, "templates")
+			// 1. Resolve workspace directory, .belayer config dir, and templates.
+			workspaceRoot := resolveWorkspaceDir()
+			belayerDir := resolveBelayerDir()
+			templatesDir := filepath.Join(belayerDir, "templates")
 
 			// 2. Require daemon is running.
 			c := NewClient(resolveSocket(socket))
@@ -66,8 +68,21 @@ config that controls network isolation, compose extensions, and repos.`,
 				name = fmt.Sprintf("%s-%d", template, time.Now().Unix())
 			}
 
-			// 5. Load template from workspace, falling back to built-in.
-			tmpl, err := session.LoadTemplateFromDir(templatesDir, template)
+			// 5. Load environment config early when template resolution depends on it.
+			var envCfg *docker.EnvironmentConfig
+			if environment != "" {
+				var err error
+				envCfg, err = docker.LoadEnvironmentByName(belayerDir, environment)
+				if err != nil {
+					return fmt.Errorf("load environment %q: %w", environment, err)
+				}
+				if err := docker.ValidateEnvironment(envCfg); err != nil {
+					return fmt.Errorf("validate environment: %w", err)
+				}
+			}
+
+			// 6. Load template from workspace, falling back to built-in or environment-defined rosters.
+			tmpl, err := loadLaunchTemplate(templatesDir, belayerDir, envCfg, template, repo)
 			if err != nil {
 				return fmt.Errorf("load template: %w", err)
 			}
@@ -75,27 +90,28 @@ config that controls network isolation, compose extensions, and repos.`,
 				return fmt.Errorf("validate template: %w", err)
 			}
 
-			// 6. Create session via daemon.
+			// 7. Create session via daemon.
 			sess, err := c.CreateSession(name, template)
 			if err != nil {
 				return fmt.Errorf("create session: %w", err)
 			}
 
-			// 7. Build list of agent names.
+			// 8. Build list of agent names.
 			agentNames := make([]string, len(tmpl.Agents))
 			for i, a := range tmpl.Agents {
 				agentNames[i] = a.Name
 			}
 
-			// 8. Resolve working directory.
+			// 9. Resolve working directory.
 			workDir := repo
 			if workDir == "" {
 				workDir, _ = os.Getwd()
 			}
 
-			// 9. Launch agents.
-			if dockerMode {
-				if err := launchDocker(cmd, c, tmpl, sess, agentNames, taskInput, workDir, wsDir, environment, name); err != nil {
+			// 10. Launch agents using the selected runtime backend.
+			selectedRuntime := runtimepkg.Select(dockerMode)
+			if selectedRuntime.Mode() == runtimepkg.ModeDocker {
+				if err := launchDocker(cmd, c, tmpl, sess, agentNames, taskInput, workDir, workspaceRoot, belayerDir, environment, name, envCfg); err != nil {
 					return err
 				}
 			} else {
@@ -104,14 +120,14 @@ config that controls network isolation, compose extensions, and repos.`,
 				}
 			}
 
-			// 10. Log session_started event and update status.
+			// 11. Log session_started event and update status.
 			_ = c.LogEvent(sess.ID, "session_started", mustJSON(map[string]string{
 				"template": template,
 				"name":     name,
 			}))
 			_, _ = c.UpdateSession(sess.ID, "running")
 
-			// 11. Print summary.
+			// 12. Print summary.
 			fmt.Fprintf(cmd.OutOrStdout(), "Session started: %s (template: %s)\n", sess.ID, template)
 			if !dockerMode {
 				for _, spec := range tmpl.Agents {
@@ -130,7 +146,7 @@ config that controls network isolation, compose extensions, and repos.`,
 			fmt.Fprintln(cmd.OutOrStdout(), "  belayer status")
 			fmt.Fprintf(cmd.OutOrStdout(), "  belayer logs %s\n", sess.ID)
 
-			// 12. Auto-attach if requested (local tmux only).
+			// 13. Auto-attach if requested (local tmux only).
 			if attach && !dockerMode {
 				target := attachAgent
 				if target == "" && len(tmpl.Agents) > 0 {
@@ -162,19 +178,18 @@ config that controls network isolation, compose extensions, and repos.`,
 }
 
 // launchDocker starts agents in Docker containers with network isolation.
-func launchDocker(cmd *cobra.Command, c *Client, tmpl session.SessionTemplate, sess sessionResponse, agentNames []string, taskInput, workDir, wsDir, environment, sessionName string) error {
+func launchDocker(cmd *cobra.Command, c *Client, tmpl session.SessionTemplate, sess sessionResponse, agentNames []string, taskInput, workDir, workspaceRoot, belayerDir, environment, sessionName string, envCfg *docker.EnvironmentConfig) error {
 	// 1. Load and validate environment config.
-	var envCfg *docker.EnvironmentConfig
-	if environment != "" {
+	if envCfg == nil && environment != "" {
 		var err error
-		envCfg, err = docker.LoadEnvironmentByName(wsDir, environment)
+		envCfg, err = docker.LoadEnvironmentByName(belayerDir, environment)
 		if err != nil {
 			return fmt.Errorf("load environment %q: %w", environment, err)
 		}
 		if err := docker.ValidateEnvironment(envCfg); err != nil {
 			return fmt.Errorf("validate environment: %w", err)
 		}
-	} else {
+	} else if envCfg == nil {
 		envCfg = docker.DefaultEnvironment()
 	}
 
@@ -201,8 +216,31 @@ func launchDocker(cmd *cobra.Command, c *Client, tmpl session.SessionTemplate, s
 	}
 
 	// 5. Create per-agent worktrees for isolation.
+	repoWorkDirs := make(map[string]string)
+	for _, repoRef := range envCfg.Repos {
+		repoPath := expandHomePath(repoRef.Path)
+		if repoPath == "" {
+			continue
+		}
+		wt, err := createWorktree(repoPath, filepath.Join(sandboxDir, "repo-worktrees"), repoRef.Name, "")
+		if err != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "  warning: repo worktree for %s: %v (using source repo)\n", repoRef.Name, err)
+			repoWorkDirs[repoRef.Name] = repoPath
+			continue
+		}
+		repoWorkDirs[repoRef.Name] = wt
+	}
+
 	agentWorkDirs := make(map[string]string, len(tmpl.Agents))
+	agentMeta := make(map[string]docker.AgentRuntimeMetadata, len(tmpl.Agents))
 	for _, spec := range tmpl.Agents {
+		agentMeta[spec.Name] = docker.AgentRuntimeMetadata{Name: spec.Name, Repo: spec.Repo, Tier: spec.Tier}
+		if spec.Repo != "" {
+			if repoDir, ok := repoWorkDirs[spec.Repo]; ok {
+				agentWorkDirs[spec.Name] = repoDir
+				continue
+			}
+		}
 		wt, err := createWorktree(workDir, sandboxDir, spec.Name, "")
 		if err != nil {
 			// Log warning but continue — fallback to shared workDir.
@@ -295,6 +333,40 @@ func launchDocker(cmd *cobra.Command, c *Client, tmpl session.SessionTemplate, s
 		return fmt.Errorf("start sandbox: %w", err)
 	}
 
+	var workbenchSpec *docker.WorkbenchConfigSpec
+	if envCfg.Workbench != nil {
+		spec, err := envCfg.ResolveWorkbenchSpec()
+		if err != nil {
+			return fmt.Errorf("resolve workbench spec: %w", err)
+		}
+		workbenchSpec = &spec
+	}
+
+	if err := docker.WriteRuntimeMetadata(sandboxDir, docker.RuntimeMetadata{
+		SessionID:          sess.ID,
+		SessionName:        sessionName,
+		Template:           tmpl.Name,
+		Environment:        environment,
+		EnvironmentPath:    envCfg.SourcePath(),
+		BelayerDir:         belayerDir,
+		WorkspaceRoot:      workspaceRoot,
+		SandboxDir:         sandboxDir,
+		SandboxComposeFile: filepath.Join(sandbox.ComposeDir(), "docker-compose.yml"),
+		Workbench:          workbenchSpec,
+		Tools:              envCfg.Tools,
+		RepoWorktrees:      repoWorkDirs,
+		AgentWorktrees:     agentWorkDirs,
+		Agents:             agentMeta,
+	}); err != nil {
+		return fmt.Errorf("write runtime metadata: %w", err)
+	}
+
+	for _, tool := range envCfg.Tools {
+		if err := c.RegisterTool(sess.ID, tool); err != nil {
+			return fmt.Errorf("register environment tool %q: %w", tool.Name, err)
+		}
+	}
+
 	_ = c.LogEvent(sess.ID, "sandbox_started", mustJSON(map[string]string{
 		"compose_dir": sandbox.ComposeDir(),
 		"network":     envCfg.Networking.Type,
@@ -370,6 +442,7 @@ func launchTmux(cmd *cobra.Command, c *Client, tmpl session.SessionTemplate, ses
 			"agent":  spec.Name,
 			"vendor": spec.Vendor,
 			"model":  spec.Model,
+			"tier":   spec.Tier,
 		}))
 	}
 
@@ -441,6 +514,17 @@ func createWorktree(repoDir, baseDir, agentName, branch string) (string, error) 
 	}
 
 	return worktreePath, nil
+}
+
+func expandHomePath(path string) string {
+	if path == "" || !strings.HasPrefix(path, "~/") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	return filepath.Join(home, path[2:])
 }
 
 // cleanupWorktrees removes git worktrees created for a session.

--- a/internal/cli/session_start.go
+++ b/internal/cli/session_start.go
@@ -447,16 +447,18 @@ func launchTmux(cmd *cobra.Command, c *Client, tmpl session.SessionTemplate, ses
 			Team:      team,
 		})
 
-		sysPromptFile := filepath.Join(os.TempDir(), fmt.Sprintf("belayer-sysprompt-%s-%s.txt", sessionName, spec.Name))
+		safeSessName := sanitizeName(sessionName)
+		safeSpecName := sanitizeName(spec.Name)
+		sysPromptFile := filepath.Join(os.TempDir(), fmt.Sprintf("belayer-sysprompt-%s-%s.txt", safeSessName, safeSpecName))
 		if err := os.WriteFile(sysPromptFile, []byte(compiled), 0600); err != nil {
 			return fmt.Errorf("write system prompt for %s: %w", spec.Name, err)
 		}
-		taskFile := filepath.Join(os.TempDir(), fmt.Sprintf("belayer-task-%s-%s.txt", sessionName, spec.Name))
+		taskFile := filepath.Join(os.TempDir(), fmt.Sprintf("belayer-task-%s-%s.txt", safeSessName, safeSpecName))
 		if err := os.WriteFile(taskFile, []byte(taskInput), 0600); err != nil {
 			return fmt.Errorf("write task file for %s: %w", spec.Name, err)
 		}
 
-		tmuxSessionName := fmt.Sprintf("%s-%s", sessionName, spec.Name)
+		tmuxSessionName := fmt.Sprintf("%s-%s", safeSessName, safeSpecName)
 		launchCmd := buildLaunchCmd(spec, sess.ID, sysPromptFile, taskFile, agentWorkDirs[spec.Name])
 
 		if err := runner.CreateSession(tmuxSessionName, launchCmd); err != nil {

--- a/internal/cli/session_start.go
+++ b/internal/cli/session_start.go
@@ -115,7 +115,7 @@ config that controls network isolation, compose extensions, and repos.`,
 					return err
 				}
 			} else {
-				if err := launchTmux(cmd, c, tmpl, sess, agentNames, taskInput, workDir, name); err != nil {
+				if err := launchTmux(cmd, c, tmpl, sess, agentNames, taskInput, workDir, workspaceRoot, belayerDir, environment, name, envCfg); err != nil {
 					return err
 				}
 			}
@@ -378,13 +378,38 @@ func launchDocker(cmd *cobra.Command, c *Client, tmpl session.SessionTemplate, s
 }
 
 // launchTmux starts agents in local tmux sessions.
-func launchTmux(cmd *cobra.Command, c *Client, tmpl session.SessionTemplate, sess sessionResponse, agentNames []string, taskInput, workDir, sessionName string) error {
+func launchTmux(cmd *cobra.Command, c *Client, tmpl session.SessionTemplate, sess sessionResponse, agentNames []string, taskInput, workDir, workspaceRoot, belayerDir, environment, sessionName string, envCfg *docker.EnvironmentConfig) error {
 	runner := tmux.NewLocalRunner()
 
 	// Create per-agent worktrees for isolation.
 	wtBaseDir := filepath.Join(os.TempDir(), "belayer-worktrees", sessionName)
+	repoWorkDirs := make(map[string]string)
+	if envCfg != nil {
+		for _, repoRef := range envCfg.Repos {
+			repoPath := expandHomePath(repoRef.Path)
+			if repoPath == "" {
+				continue
+			}
+			wt, err := createWorktree(repoPath, filepath.Join(wtBaseDir, "repos"), repoRef.Name, "")
+			if err != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "  warning: repo worktree for %s: %v (using source repo)\n", repoRef.Name, err)
+				repoWorkDirs[repoRef.Name] = repoPath
+				continue
+			}
+			repoWorkDirs[repoRef.Name] = wt
+		}
+	}
+
 	agentWorkDirs := make(map[string]string, len(tmpl.Agents))
+	agentMeta := make(map[string]docker.AgentRuntimeMetadata, len(tmpl.Agents))
 	for _, spec := range tmpl.Agents {
+		agentMeta[spec.Name] = docker.AgentRuntimeMetadata{Name: spec.Name, Repo: spec.Repo, Tier: spec.Tier}
+		if spec.Repo != "" {
+			if repoDir, ok := repoWorkDirs[spec.Repo]; ok {
+				agentWorkDirs[spec.Name] = repoDir
+				continue
+			}
+		}
 		wt, err := createWorktree(workDir, wtBaseDir, spec.Name, "")
 		if err != nil {
 			// Log warning but continue — fallback to shared workDir.
@@ -444,6 +469,53 @@ func launchTmux(cmd *cobra.Command, c *Client, tmpl session.SessionTemplate, ses
 			"model":  spec.Model,
 			"tier":   spec.Tier,
 		}))
+	}
+
+	home, err := os.UserHomeDir()
+	if err == nil {
+		sandboxDir := filepath.Join(home, ".belayer", "sandboxes", sess.ID)
+		var workbenchSpec *docker.WorkbenchConfigSpec
+		if envCfg != nil && envCfg.Workbench != nil {
+			spec, err := envCfg.ResolveWorkbenchSpec()
+			if err != nil {
+				return fmt.Errorf("resolve workbench spec: %w", err)
+			}
+			workbenchSpec = &spec
+		}
+		if err := docker.WriteRuntimeMetadata(sandboxDir, docker.RuntimeMetadata{
+			SessionID:   sess.ID,
+			SessionName: sessionName,
+			Template:    tmpl.Name,
+			Environment: environment,
+			EnvironmentPath: func() string {
+				if envCfg == nil {
+					return ""
+				}
+				return envCfg.SourcePath()
+			}(),
+			BelayerDir:    belayerDir,
+			WorkspaceRoot: workspaceRoot,
+			Workbench:     workbenchSpec,
+			Tools: func() []agent.ToolSpec {
+				if envCfg == nil {
+					return nil
+				}
+				return envCfg.Tools
+			}(),
+			RepoWorktrees:  repoWorkDirs,
+			AgentWorktrees: agentWorkDirs,
+			Agents:         agentMeta,
+		}); err != nil {
+			return fmt.Errorf("write runtime metadata: %w", err)
+		}
+	}
+
+	if envCfg != nil {
+		for _, tool := range envCfg.Tools {
+			if err := c.RegisterTool(sess.ID, tool); err != nil {
+				return fmt.Errorf("register environment tool %q: %w", tool.Name, err)
+			}
+		}
 	}
 
 	return nil

--- a/internal/cli/session_templates.go
+++ b/internal/cli/session_templates.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/donovan-yohan/belayer/internal/docker"
+	"github.com/donovan-yohan/belayer/internal/session"
+	"gopkg.in/yaml.v3"
+)
+
+type agentTemplateManifest struct {
+	Description string `yaml:"description"`
+	Vendor      string `yaml:"vendor"`
+	Model       string `yaml:"model"`
+	Ephemeral   bool   `yaml:"ephemeral"`
+	Workspace   string `yaml:"workspace"`
+	Tier        string `yaml:"tier,omitempty"`
+}
+
+func loadLaunchTemplate(templatesDir, belayerDir string, envCfg *docker.EnvironmentConfig, template, repo string) (session.SessionTemplate, error) {
+	switch template {
+	case "climb":
+		if envCfg == nil {
+			template = "implement"
+			break
+		}
+		return buildEnvironmentSessionTemplate(belayerDir, envCfg, template, repo)
+	case "climb-fullstack":
+		if envCfg == nil {
+			return session.SessionTemplate{}, fmt.Errorf("--environment is required for template %q", template)
+		}
+		return buildEnvironmentSessionTemplate(belayerDir, envCfg, template, repo)
+	}
+	return session.LoadTemplateFromDir(templatesDir, template)
+}
+
+func buildEnvironmentSessionTemplate(belayerDir string, envCfg *docker.EnvironmentConfig, template, repo string) (session.SessionTemplate, error) {
+	if envCfg == nil {
+		return session.SessionTemplate{}, fmt.Errorf("environment config is required")
+	}
+
+	agents := make([]session.AgentSpec, 0, len(envCfg.Agents)+1)
+	added := map[string]bool{}
+
+	addTemplate := func(templateName, repoName string) error {
+		spec, err := loadAgentTemplateSpec(belayerDir, templateName, repoName)
+		if err != nil {
+			return err
+		}
+		if !added[spec.Name] {
+			agents = append(agents, spec)
+			added[spec.Name] = true
+		}
+		return nil
+	}
+
+	if err := addTemplate("pilot", ""); err != nil {
+		return session.SessionTemplate{}, err
+	}
+
+	switch template {
+	case "climb":
+		selectedRepo := strings.TrimSpace(repo)
+		for _, envAgent := range envCfg.Agents {
+			if envAgent.Repo == "" {
+				continue
+			}
+			if selectedRepo != "" && envAgent.Repo != selectedRepo {
+				continue
+			}
+			if err := addTemplate(envAgent.Template, envAgent.Repo); err != nil {
+				return session.SessionTemplate{}, err
+			}
+			selectedRepo = envAgent.Repo
+			break
+		}
+		if selectedRepo == "" {
+			return session.SessionTemplate{}, fmt.Errorf("no environment agent matched repo %q", repo)
+		}
+	case "climb-fullstack":
+		for _, envAgent := range envCfg.Agents {
+			if envAgent.Template == "pilot" {
+				continue
+			}
+			if err := addTemplate(envAgent.Template, envAgent.Repo); err != nil {
+				return session.SessionTemplate{}, err
+			}
+		}
+	default:
+		return session.SessionTemplate{}, fmt.Errorf("unsupported environment template %q", template)
+	}
+
+	if err := addTemplate("reviewer", ""); err != nil {
+		return session.SessionTemplate{}, err
+	}
+
+	return session.SessionTemplate{
+		Name:        template,
+		Phase:       session.PhaseImplement,
+		Description: fmt.Sprintf("%s session built from environment %s", template, envCfg.Name),
+		Agents:      agents,
+	}, nil
+}
+
+func loadAgentTemplateSpec(belayerDir, templateName, repoName string) (session.AgentSpec, error) {
+	dir := filepath.Join(belayerDir, "templates", templateName)
+	manifestPath := filepath.Join(dir, "agent.yaml")
+	promptPath := filepath.Join(dir, "system-prompt.md")
+
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return session.AgentSpec{}, fmt.Errorf("read agent template manifest %q: %w", manifestPath, err)
+	}
+	var manifest agentTemplateManifest
+	if err := yaml.Unmarshal(manifestData, &manifest); err != nil {
+		return session.AgentSpec{}, fmt.Errorf("parse agent template manifest %q: %w", manifestPath, err)
+	}
+
+	systemPrompt, err := os.ReadFile(promptPath)
+	if err != nil {
+		return session.AgentSpec{}, fmt.Errorf("read system prompt %q: %w", promptPath, err)
+	}
+
+	tier := manifest.Tier
+	if tier == "" {
+		if manifest.Ephemeral {
+			tier = "ephemeral"
+		} else {
+			tier = "main"
+		}
+	}
+
+	if repoName == "" && manifest.Workspace != "" && manifest.Workspace != "none" && manifest.Workspace != "inherit" {
+		repoName = manifest.Workspace
+	}
+
+	return session.AgentSpec{
+		Name:         templateName,
+		Vendor:       manifest.Vendor,
+		Model:        manifest.Model,
+		Repo:         repoName,
+		Tier:         tier,
+		Role:         manifest.Description,
+		SystemPrompt: string(systemPrompt),
+	}, nil
+}

--- a/internal/cli/session_templates_test.go
+++ b/internal/cli/session_templates_test.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/donovan-yohan/belayer/internal/docker"
+	"github.com/donovan-yohan/belayer/internal/session"
+)
+
+func writeAgentTemplate(t *testing.T, belayerDir, name, vendor, model, workspace string, ephemeral bool) {
+	t.Helper()
+	dir := filepath.Join(belayerDir, "templates", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir template dir: %v", err)
+	}
+	manifest := "description: \"" + name + "\"\n" +
+		"vendor: " + vendor + "\n" +
+		"model: " + model + "\n" +
+		"ephemeral: " + map[bool]string{true: "true", false: "false"}[ephemeral] + "\n" +
+		"workspace: " + workspace + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "agent.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write agent manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "system-prompt.md"), []byte("prompt for "+name), 0o644); err != nil {
+		t.Fatalf("write system prompt: %v", err)
+	}
+}
+
+func testEnvironmentConfig() *docker.EnvironmentConfig {
+	return &docker.EnvironmentConfig{
+		Name: "extend-fullstack",
+		Agents: []docker.EnvironmentAgent{
+			{Template: "pilot"},
+			{Template: "api-implementer", Repo: "extend-api"},
+			{Template: "app-implementer", Repo: "extend-app"},
+		},
+	}
+}
+
+func TestLoadLaunchTemplate_ClimbFullstackFromEnvironment(t *testing.T) {
+	belayerDir := t.TempDir()
+	writeAgentTemplate(t, belayerDir, "pilot", "claude", "opus", "none", false)
+	writeAgentTemplate(t, belayerDir, "api-implementer", "claude", "sonnet", "extend-api", false)
+	writeAgentTemplate(t, belayerDir, "app-implementer", "claude", "sonnet", "extend-app", false)
+	writeAgentTemplate(t, belayerDir, "reviewer", "codex", "gpt-5", "none", true)
+
+	tmpl, err := loadLaunchTemplate("", belayerDir, testEnvironmentConfig(), "climb-fullstack", "")
+	if err != nil {
+		t.Fatalf("loadLaunchTemplate returned error: %v", err)
+	}
+	if tmpl.Phase != session.PhaseImplement {
+		t.Fatalf("Phase = %q, want %q", tmpl.Phase, session.PhaseImplement)
+	}
+	if len(tmpl.Agents) != 4 {
+		t.Fatalf("Agents = %d, want 4", len(tmpl.Agents))
+	}
+	if tmpl.Agents[1].Repo != "extend-api" {
+		t.Fatalf("api implementer repo = %q", tmpl.Agents[1].Repo)
+	}
+	if tmpl.Agents[3].Tier != "ephemeral" {
+		t.Fatalf("reviewer tier = %q, want ephemeral", tmpl.Agents[3].Tier)
+	}
+}
+
+func TestLoadLaunchTemplate_ClimbSingleRepoSelectsMatchingImplementer(t *testing.T) {
+	belayerDir := t.TempDir()
+	writeAgentTemplate(t, belayerDir, "pilot", "claude", "opus", "none", false)
+	writeAgentTemplate(t, belayerDir, "api-implementer", "claude", "sonnet", "extend-api", false)
+	writeAgentTemplate(t, belayerDir, "app-implementer", "claude", "sonnet", "extend-app", false)
+	writeAgentTemplate(t, belayerDir, "reviewer", "codex", "gpt-5", "none", true)
+
+	tmpl, err := loadLaunchTemplate("", belayerDir, testEnvironmentConfig(), "climb", "extend-api")
+	if err != nil {
+		t.Fatalf("loadLaunchTemplate returned error: %v", err)
+	}
+	if len(tmpl.Agents) != 3 {
+		t.Fatalf("Agents = %d, want 3", len(tmpl.Agents))
+	}
+	if tmpl.Agents[1].Name != "api-implementer" {
+		t.Fatalf("implementer name = %q, want api-implementer", tmpl.Agents[1].Name)
+	}
+}

--- a/internal/cli/tool.go
+++ b/internal/cli/tool.go
@@ -56,6 +56,12 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			toolName := args[0]
 			if sessionFlag == "" {
+				sessionFlag = os.Getenv("BELAYER_SESSION_ID")
+			}
+			if agentFlag == "" {
+				agentFlag = os.Getenv("BELAYER_AGENT_ID")
+			}
+			if sessionFlag == "" {
 				return fmt.Errorf("--session is required")
 			}
 
@@ -118,6 +124,9 @@ func newToolListCmd() *cobra.Command {
 Examples:
   belayer tool list --session abc123`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if sessionFlag == "" {
+				sessionFlag = os.Getenv("BELAYER_SESSION_ID")
+			}
 			if sessionFlag == "" {
 				return fmt.Errorf("--session is required")
 			}

--- a/internal/cli/workbench.go
+++ b/internal/cli/workbench.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -26,6 +27,9 @@ func newWorkbenchUpCmd() *cobra.Command {
 		Use:   "up",
 		Short: "Provision the workbench for the current session",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if sessionID == "" {
+				sessionID = os.Getenv("BELAYER_SESSION_ID")
+			}
 			if sessionID == "" {
 				return fmt.Errorf("--session is required")
 			}
@@ -52,6 +56,9 @@ func newWorkbenchStatusCmd() *cobra.Command {
 		Short: "Check workbench readiness and endpoints",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if sessionID == "" {
+				sessionID = os.Getenv("BELAYER_SESSION_ID")
+			}
+			if sessionID == "" {
 				return fmt.Errorf("--session is required")
 			}
 			c := NewClient(resolveSocket(socket))
@@ -77,6 +84,9 @@ func newWorkbenchDownCmd() *cobra.Command {
 		Use:   "down",
 		Short: "Tear down the workbench",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if sessionID == "" {
+				sessionID = os.Getenv("BELAYER_SESSION_ID")
+			}
 			if sessionID == "" {
 				return fmt.Errorf("--session is required")
 			}

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -6,16 +6,17 @@ import (
 )
 
 // resolveWorkspaceDir walks up from cwd looking for a .belayer/ directory.
-// Falls back to ~/.belayer/ if none found.
+// It returns the workspace root directory that contains .belayer.
+// Falls back to the user's home directory when no workspace marker is found.
 func resolveWorkspaceDir() string {
 	dir, err := os.Getwd()
 	if err != nil {
-		return defaultWorkspaceDir()
+		return defaultWorkspaceRoot()
 	}
 	for {
 		candidate := filepath.Join(dir, ".belayer")
 		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-			return candidate
+			return dir
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -23,11 +24,25 @@ func resolveWorkspaceDir() string {
 		}
 		dir = parent
 	}
-	return defaultWorkspaceDir()
+	return defaultWorkspaceRoot()
+}
+
+// resolveBelayerDir returns the active .belayer directory path.
+func resolveBelayerDir() string {
+	workspaceRoot := resolveWorkspaceDir()
+	candidate := filepath.Join(workspaceRoot, ".belayer")
+	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+		return candidate
+	}
+	return filepath.Join(defaultWorkspaceRoot(), ".belayer")
+}
+
+func defaultWorkspaceRoot() string {
+	home, _ := os.UserHomeDir()
+	return home
 }
 
 // defaultWorkspaceDir returns ~/.belayer/
 func defaultWorkspaceDir() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".belayer")
+	return filepath.Join(defaultWorkspaceRoot(), ".belayer")
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -304,9 +304,9 @@ func (d *Daemon) handleStreamEvents(w http.ResponseWriter, r *http.Request) {
 			afterID = existing[len(existing)-1].ID
 		}
 	}
-	if waitFor <= 0 {
-		waitFor = 30 * time.Second
-	}
+	// When the client omits 'wait', keep streaming until the client
+	// disconnects instead of forcing a 30s deadline.  This makes the
+	// endpoint suitable for long-running "watch" commands.
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -333,7 +333,8 @@ func (d *Daemon) handleStreamEvents(w http.ResponseWriter, r *http.Request) {
 	for {
 		events, err := d.store.QueryEventsForSessionsAfter(filtered, lastID)
 		if err != nil {
-			fmt.Fprintf(w, "event: error\ndata: %q\n\n", err.Error())
+			errJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
+			fmt.Fprintf(w, "event: error\ndata: %s\n\n", errJSON)
 			flusher.Flush()
 			return
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -320,16 +320,6 @@ func (d *Daemon) handleStreamEvents(w http.ResponseWriter, r *http.Request) {
 
 	enc := json.NewEncoder(w)
 	lastID := afterID
-	if lastID == 0 {
-		existing, err := d.store.QueryEventsForSessionsAfter(filtered, 0)
-		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-			return
-		}
-		if len(existing) > 0 {
-			lastID = existing[len(existing)-1].ID
-		}
-	}
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 	keepalive := time.NewTicker(15 * time.Second)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -9,12 +9,17 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/donovan-yohan/belayer/internal/agent"
+	"github.com/donovan-yohan/belayer/internal/docker"
 	"github.com/donovan-yohan/belayer/internal/store"
+	"gopkg.in/yaml.v3"
 )
 
 // Config holds daemon startup configuration.
@@ -65,6 +70,7 @@ func New(cfg Config) (*Daemon, error) {
 	mux.HandleFunc("PATCH /sessions/{id}", d.handleUpdateSession)
 	mux.HandleFunc("GET /sessions/{id}/events", d.handleGetEvents)
 	mux.HandleFunc("POST /sessions/{id}/events", d.handleLogEvent)
+	mux.HandleFunc("GET /events/stream", d.handleStreamEvents)
 	mux.HandleFunc("POST /sessions/{id}/messages", d.handleSendMessage)
 	mux.HandleFunc("POST /sessions/{id}/messages/broadcast", d.handleBroadcastMessage)
 	mux.HandleFunc("GET /sessions/{id}/messages", d.handleListMessages)
@@ -226,7 +232,13 @@ func (d *Daemon) handleUpdateSession(w http.ResponseWriter, r *http.Request) {
 
 func (d *Daemon) handleGetEvents(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	events, err := d.store.QueryEvents(id)
+	afterID, waitFor, err := parseEventCursor(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	events, err := d.querySessionEvents(r.Context(), id, afterID, waitFor)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -261,6 +273,172 @@ func (d *Daemon) handleLogEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]string{"status": "logged"})
+}
+
+func (d *Daemon) handleStreamEvents(w http.ResponseWriter, r *http.Request) {
+	sessionIDs := strings.Split(strings.TrimSpace(r.URL.Query().Get("sessions")), ",")
+	filtered := make([]string, 0, len(sessionIDs))
+	for _, sessionID := range sessionIDs {
+		sessionID = strings.TrimSpace(sessionID)
+		if sessionID != "" {
+			filtered = append(filtered, sessionID)
+		}
+	}
+	if len(filtered) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "sessions is required"})
+		return
+	}
+
+	afterID, waitFor, err := parseEventCursor(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if strings.TrimSpace(r.URL.Query().Get("after")) == "" {
+		existing, err := d.store.QueryEventsForSessionsAfter(filtered, 0)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		if len(existing) > 0 {
+			afterID = existing[len(existing)-1].ID
+		}
+	}
+	if waitFor <= 0 {
+		waitFor = 30 * time.Second
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "streaming unsupported"})
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	enc := json.NewEncoder(w)
+	lastID := afterID
+	if lastID == 0 {
+		existing, err := d.store.QueryEventsForSessionsAfter(filtered, 0)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		if len(existing) > 0 {
+			lastID = existing[len(existing)-1].ID
+		}
+	}
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	keepalive := time.NewTicker(15 * time.Second)
+	defer keepalive.Stop()
+
+	deadline := time.Time{}
+	if waitFor > 0 {
+		deadline = time.Now().Add(waitFor)
+	}
+
+	for {
+		events, err := d.store.QueryEventsForSessionsAfter(filtered, lastID)
+		if err != nil {
+			fmt.Fprintf(w, "event: error\ndata: %q\n\n", err.Error())
+			flusher.Flush()
+			return
+		}
+		if len(events) > 0 {
+			for _, evt := range events {
+				fmt.Fprint(w, "event: session_event\ndata: ")
+				if err := enc.Encode(evt); err != nil {
+					return
+				}
+				fmt.Fprint(w, "\n")
+				lastID = evt.ID
+			}
+			flusher.Flush()
+		}
+
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			fmt.Fprint(w, ": timeout\n\n")
+			flusher.Flush()
+			return
+		}
+
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+		case <-keepalive.C:
+			fmt.Fprint(w, ": keep-alive\n\n")
+			flusher.Flush()
+		}
+	}
+}
+
+func parseEventCursor(r *http.Request) (int64, time.Duration, error) {
+	afterRaw := strings.TrimSpace(r.URL.Query().Get("after"))
+	waitRaw := strings.TrimSpace(r.URL.Query().Get("wait"))
+
+	var afterID int64
+	if afterRaw != "" {
+		parsed, err := strconv.ParseInt(afterRaw, 10, 64)
+		if err != nil || parsed < 0 {
+			return 0, 0, fmt.Errorf("after must be a non-negative integer")
+		}
+		afterID = parsed
+	}
+
+	var waitFor time.Duration
+	if waitRaw != "" {
+		parsed, err := time.ParseDuration(waitRaw)
+		if err != nil || parsed < 0 {
+			return 0, 0, fmt.Errorf("wait must be a valid non-negative duration")
+		}
+		waitFor = parsed
+	}
+
+	return afterID, waitFor, nil
+}
+
+func (d *Daemon) querySessionEvents(ctx context.Context, sessionID string, afterID int64, waitFor time.Duration) ([]store.SessionEvent, error) {
+	if waitFor <= 0 {
+		if afterID > 0 {
+			return d.store.QueryEventsAfter(sessionID, afterID)
+		}
+		return d.store.QueryEvents(sessionID)
+	}
+
+	deadline := time.Now().Add(waitFor)
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		var (
+			events []store.SessionEvent
+			err    error
+		)
+		if afterID > 0 {
+			events, err = d.store.QueryEventsAfter(sessionID, afterID)
+		} else {
+			events, err = d.store.QueryEvents(sessionID)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(events) > 0 {
+			return events, nil
+		}
+		if time.Now().After(deadline) {
+			return []store.SessionEvent{}, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func (d *Daemon) handleSearch(w http.ResponseWriter, r *http.Request) {
@@ -301,16 +479,112 @@ func (d *Daemon) handleCreateWorkbench(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// NOTE: This endpoint currently creates a state record only.
-	// Actual Docker compose provisioning (generate, up, wait-for-healthy)
-	// will be wired in when the workbench runtime is integrated.
-	wb := store.WorkbenchState{
-		SessionID: id,
-		Spec:      req.Spec,
-		Endpoints: req.Endpoints,
+	if existing, err := d.store.GetWorkbenchBySession(id); err == nil && existing.Status == "ready" {
+		writeJSON(w, http.StatusOK, existing)
+		return
 	}
-	wbID, err := d.store.CreateWorkbench(wb)
+
+	sandboxPath, err := sandboxDir(id)
 	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	meta, err := docker.LoadRuntimeMetadata(sandboxPath)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("load runtime metadata: %v", err)})
+		return
+	}
+
+	spec := docker.WorkbenchConfigSpec{}
+	if meta.Workbench != nil {
+		spec = *meta.Workbench
+	}
+	if req.Spec != "" && req.Spec != "{}" {
+		if err := yaml.Unmarshal([]byte(req.Spec), &spec); err != nil {
+			if err := json.Unmarshal([]byte(req.Spec), &spec); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid workbench spec: %v", err)})
+				return
+			}
+		}
+	}
+	if len(spec.Services) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "no workbench services configured for this session"})
+		return
+	}
+
+	specJSON, err := json.Marshal(spec)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("marshal workbench spec: %v", err)})
+		return
+	}
+
+	workbenchState, err := d.store.GetWorkbenchBySession(id)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		workbenchState = store.WorkbenchState{
+			SessionID: id,
+			Status:    "provisioning",
+			Spec:      string(specJSON),
+			Endpoints: "{}",
+		}
+		if _, err := d.store.CreateWorkbench(workbenchState); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		workbenchState, err = d.store.GetWorkbenchBySession(id)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+	} else {
+		_ = d.store.UpdateWorkbenchStatus(workbenchState.ID, "provisioning")
+	}
+
+	workbench, err := docker.NewWorkbench(docker.WorkbenchConfig{
+		SessionID:     id,
+		Spec:          spec,
+		WorktreePaths: meta.RepoWorktrees,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := workbench.Create(); err != nil {
+		_ = d.store.UpdateWorkbenchStatus(workbenchState.ID, "failed")
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := workbench.Start(); err != nil {
+		_ = d.store.UpdateWorkbenchStatus(workbenchState.ID, "failed")
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	timeout, err := time.ParseDuration(spec.Timeout)
+	if err != nil || timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	if err := workbench.WaitForHealthy(timeout); err != nil {
+		_ = d.store.UpdateWorkbenchStatus(workbenchState.ID, "failed")
+		writeJSON(w, http.StatusGatewayTimeout, map[string]string{"error": err.Error()})
+		return
+	}
+
+	endpointsJSON, err := json.Marshal(workbench.Endpoints())
+	if err != nil {
+		_ = d.store.UpdateWorkbenchStatus(workbenchState.ID, "failed")
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("marshal workbench endpoints: %v", err)})
+		return
+	}
+	if err := d.store.UpdateWorkbenchStatus(workbenchState.ID, "ready"); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := d.store.UpdateWorkbenchEndpoints(workbenchState.ID, string(endpointsJSON)); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
@@ -324,7 +598,7 @@ func (d *Daemon) handleCreateWorkbench(w http.ResponseWriter, r *http.Request) {
 	d.store.LogEvent(store.SessionEvent{
 		SessionID: id,
 		Type:      "workbench_created",
-		Data:      mustJSON(map[string]string{"workbench_id": wbID}),
+		Data:      mustJSON(map[string]string{"workbench_id": created.ID, "status": created.Status}),
 	})
 
 	writeJSON(w, http.StatusCreated, created)
@@ -346,6 +620,14 @@ func (d *Daemon) handleGetWorkbench(w http.ResponseWriter, r *http.Request) {
 
 func (d *Daemon) handleDeleteWorkbench(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if home, err := os.UserHomeDir(); err == nil {
+		workbenchDir := filepath.Join(home, ".belayer", "workbenches", id)
+		composePath := filepath.Join(workbenchDir, "docker-compose.yml")
+		if _, err := os.Stat(composePath); err == nil {
+			_ = exec.Command("docker", "compose", "-f", composePath, "down").Run()
+		}
+		_ = os.RemoveAll(workbenchDir)
+	}
 	if err := d.store.DeleteWorkbenchBySession(id); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3,12 +3,20 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/donovan-yohan/belayer/internal/agent"
+	"github.com/donovan-yohan/belayer/internal/docker"
 	"github.com/donovan-yohan/belayer/internal/store"
 )
 
@@ -30,7 +38,11 @@ func testDaemon(t *testing.T) *Daemon {
 	mux.HandleFunc("PATCH /sessions/{id}", d.handleUpdateSession)
 	mux.HandleFunc("GET /sessions/{id}/events", d.handleGetEvents)
 	mux.HandleFunc("POST /sessions/{id}/events", d.handleLogEvent)
+	mux.HandleFunc("GET /events/stream", d.handleStreamEvents)
 	mux.HandleFunc("GET /search", d.handleSearch)
+	mux.HandleFunc("POST /sessions/{id}/workbench", d.handleCreateWorkbench)
+	mux.HandleFunc("GET /sessions/{id}/workbench", d.handleGetWorkbench)
+	mux.HandleFunc("DELETE /sessions/{id}/workbench", d.handleDeleteWorkbench)
 	mux.HandleFunc("POST /sessions/{id}/tools", d.handleRegisterTool)
 	mux.HandleFunc("GET /sessions/{id}/tools", d.handleListTools)
 	mux.HandleFunc("POST /sessions/{id}/tools/{name}", d.handleExecuteTool)
@@ -186,6 +198,115 @@ func TestGetEvents(t *testing.T) {
 	}
 }
 
+func TestGetEventsAfter(t *testing.T) {
+	d := testDaemon(t)
+
+	createRR := doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "events-after"})
+	created := decodeJSON[store.Session](t, createRR)
+	doRequest(t, d, "POST", "/sessions/"+created.ID+"/events", logEventRequest{Type: "first"})
+
+	allEventsRR := doRequest(t, d, "GET", "/sessions/"+created.ID+"/events", nil)
+	allEvents := decodeJSON[[]store.SessionEvent](t, allEventsRR)
+	lastID := allEvents[len(allEvents)-1].ID
+
+	doRequest(t, d, "POST", "/sessions/"+created.ID+"/events", logEventRequest{Type: "second"})
+	doRequest(t, d, "POST", "/sessions/"+created.ID+"/events", logEventRequest{Type: "third"})
+
+	rr := doRequest(t, d, "GET", "/sessions/"+created.ID+"/events?after="+fmt.Sprint(lastID), nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	events := decodeJSON[[]store.SessionEvent](t, rr)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Type != "second" || events[1].Type != "third" {
+		t.Fatalf("unexpected events: %#v", events)
+	}
+}
+
+func TestGetEventsWait_LongPollsUntilEventArrives(t *testing.T) {
+	d := testDaemon(t)
+
+	createRR := doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "events-wait"})
+	created := decodeJSON[store.Session](t, createRR)
+	initialEventsRR := doRequest(t, d, "GET", "/sessions/"+created.ID+"/events", nil)
+	initialEvents := decodeJSON[[]store.SessionEvent](t, initialEventsRR)
+	lastID := initialEvents[len(initialEvents)-1].ID
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		doRequest(t, d, "POST", "/sessions/"+created.ID+"/events", logEventRequest{Type: "delayed"})
+	}()
+
+	req := httptest.NewRequest("GET", "/sessions/"+created.ID+"/events?after="+fmt.Sprint(lastID)+"&wait=1s", nil)
+	rr := httptest.NewRecorder()
+	d.server.Handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	events := decodeJSON[[]store.SessionEvent](t, rr)
+	if len(events) != 1 || events[0].Type != "delayed" {
+		t.Fatalf("unexpected long-poll events: %#v", events)
+	}
+}
+
+func TestStreamEventsSSE_EmitsMultiplexedEvents(t *testing.T) {
+	d := testDaemon(t)
+	server := httptest.NewServer(d.server.Handler)
+	defer server.Close()
+
+	sess1 := decodeJSON[store.Session](t, doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "watch-1"}))
+	sess2 := decodeJSON[store.Session](t, doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "watch-2"}))
+	initial1 := decodeJSON[[]store.SessionEvent](t, doRequest(t, d, "GET", "/sessions/"+sess1.ID+"/events", nil))
+	initial2 := decodeJSON[[]store.SessionEvent](t, doRequest(t, d, "GET", "/sessions/"+sess2.ID+"/events", nil))
+	afterID := initial1[len(initial1)-1].ID
+	if last := initial2[len(initial2)-1].ID; last > afterID {
+		afterID = last
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resultCh := make(chan string, 1)
+	go func() {
+		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/events/stream?sessions=%s,%s&after=%d&wait=1s", server.URL, sess1.ID, sess2.ID, afterID), nil)
+		if err != nil {
+			resultCh <- "request-error:" + err.Error()
+			return
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			resultCh <- "do-error:" + err.Error()
+			return
+		}
+		defer resp.Body.Close()
+
+		buf := make([]byte, 2048)
+		n, _ := resp.Body.Read(buf)
+		resultCh <- string(buf[:n])
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	doRequest(t, d, "POST", "/sessions/"+sess2.ID+"/events", logEventRequest{Type: "streamed"})
+
+	select {
+	case payload := <-resultCh:
+		if !strings.Contains(payload, "event: session_event") {
+			t.Fatalf("expected SSE event header, got %q", payload)
+		}
+		if !strings.Contains(payload, `"Type":"streamed"`) {
+			t.Fatalf("expected streamed event payload, got %q", payload)
+		}
+		if !strings.Contains(payload, sess2.ID) {
+			t.Fatalf("expected session ID %s in payload, got %q", sess2.ID, payload)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for SSE payload")
+	}
+}
+
 func TestLogEvent(t *testing.T) {
 	d := testDaemon(t)
 
@@ -260,5 +381,109 @@ func TestSearchEventsMissingQuery(t *testing.T) {
 	rr := doRequest(t, d, "GET", "/search", nil)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func installFakeDocker(t *testing.T, statusesJSON string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "docker")
+	body := fmt.Sprintf(`#!/bin/sh
+set -eu
+printf "%%s\n" "$@" >> "%s"
+if [ "$1" = "compose" ] && [ "$4" = "up" ]; then
+  exit 0
+fi
+if [ "$1" = "compose" ] && [ "$4" = "ps" ]; then
+  printf '%%s' '%s'
+  exit 0
+fi
+if [ "$1" = "compose" ] && [ "$4" = "down" ]; then
+  exit 0
+fi
+exit 0
+`, filepath.Join(dir, "docker.log"), statusesJSON)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestCreateWorkbench_ProvisionsAndWaitsForHealthy(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	installFakeDocker(t, `[{"name":"extend-api","state":"running","health":"healthy"}]`)
+
+	d := testDaemon(t)
+	sessID := createTestSession(t, d)
+
+	sandboxPath, err := sandboxDir(sessID)
+	if err != nil {
+		t.Fatalf("sandboxDir: %v", err)
+	}
+	if err := os.MkdirAll(sandboxPath, 0o700); err != nil {
+		t.Fatalf("mkdir sandbox: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sandboxPath, "docker-compose.yml"), []byte("version: '3.9'"), 0o600); err != nil {
+		t.Fatalf("write sandbox compose: %v", err)
+	}
+	err = docker.WriteRuntimeMetadata(sandboxPath, docker.RuntimeMetadata{
+		SessionID: sessID,
+		Workbench: &docker.WorkbenchConfigSpec{
+			Timeout: "1s",
+			Services: []docker.ServiceDecl{
+				{Name: "extend-api", Image: "example/api:latest", Ports: []string{"8080"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteRuntimeMetadata: %v", err)
+	}
+
+	rr := doRequest(t, d, "POST", "/sessions/"+sessID+"/workbench", createWorkbenchRequest{})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	wb := decodeJSON[store.WorkbenchState](t, rr)
+	if wb.Status != "ready" {
+		t.Fatalf("expected ready status, got %q", wb.Status)
+	}
+	if !strings.Contains(wb.Endpoints, "extend-api") || !strings.Contains(wb.Endpoints, "http://extend-api:8080") {
+		t.Fatalf("unexpected endpoints: %s", wb.Endpoints)
+	}
+}
+
+func TestDeleteWorkbench_TearsDownComposeArtifacts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	installFakeDocker(t, `[]`)
+
+	d := testDaemon(t)
+	sessID := createTestSession(t, d)
+
+	workbenchDir := filepath.Join(home, ".belayer", "workbenches", sessID)
+	if err := os.MkdirAll(workbenchDir, 0o700); err != nil {
+		t.Fatalf("mkdir workbench dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workbenchDir, "docker-compose.yml"), []byte("version: '3.9'"), 0o600); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	if _, err := d.store.CreateWorkbench(store.WorkbenchState{
+		SessionID: sessID,
+		Status:    "ready",
+		Spec:      "{}",
+		Endpoints: "{}",
+	}); err != nil {
+		t.Fatalf("CreateWorkbench: %v", err)
+	}
+
+	rr := doRequest(t, d, "DELETE", "/sessions/"+sessID+"/workbench", nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rr.Code)
+	}
+	if _, err := os.Stat(workbenchDir); !os.IsNotExist(err) {
+		t.Fatalf("expected workbench dir to be removed, stat err=%v", err)
+	}
+	if _, err := d.store.GetWorkbenchBySession(sessID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected workbench row to be deleted, got err=%v", err)
 	}
 }

--- a/internal/docker/environment.go
+++ b/internal/docker/environment.go
@@ -7,31 +7,38 @@ import (
 	"strings"
 	"time"
 
+	"github.com/donovan-yohan/belayer/internal/agent"
 	"gopkg.in/yaml.v3"
 )
 
 // EnvironmentConfig describes the Docker infrastructure for a session.
 type EnvironmentConfig struct {
-	Name       string               `yaml:"name"`
-	Type       string               `yaml:"type"` // "docker-compose"
-	Compose    ComposeExtend        `yaml:"compose"`
-	Networking NetworkingRule       `yaml:"networking"`
-	Repos      []RepoRef            `yaml:"repos"`
-	Workbench  *WorkbenchConfigSpec `yaml:"workbench"` // nil means no workbench configured
+	Name        string               `yaml:"name"`
+	Description string               `yaml:"description,omitempty"`
+	Type        string               `yaml:"type"` // "docker-compose"
+	Compose     ComposeExtend        `yaml:"compose"`
+	Networking  NetworkingRule       `yaml:"networking"`
+	Repos       []RepoRef            `yaml:"repos"`
+	Workbench   *WorkbenchConfigSpec `yaml:"workbench"`
+	Clamshell   *ClamshellConfig     `yaml:"clamshell,omitempty"`
+	Agents      []EnvironmentAgent   `yaml:"agents,omitempty"`
+	Tools       []agent.ToolSpec     `yaml:"tools,omitempty"`
+
+	sourcePath string `yaml:"-"`
 }
 
 // ComposeExtend describes how to extend an existing Docker Compose setup.
 type ComposeExtend struct {
-	Include  string   `yaml:"include"`  // path to existing docker-compose.yml
-	Profiles []string `yaml:"profiles"` // compose profiles to activate
+	Include  string   `yaml:"include"`
+	Profiles []string `yaml:"profiles"`
 }
 
 // NetworkingRule describes the network access policy for a sandbox.
 type NetworkingRule struct {
-	Type                 string   `yaml:"type"` // "none", "limited", "full"
+	Type                 string   `yaml:"type"`
 	AllowedHosts         []string `yaml:"allowed_hosts"`
 	AllowPackageManagers bool     `yaml:"allow_package_managers"`
-	ConnectToWorkbench   bool     `yaml:"connect_to_workbench"` // allow connection to workbench services
+	ConnectToWorkbench   bool     `yaml:"connect_to_workbench"`
 }
 
 // RepoRef identifies a repository involved in the session.
@@ -40,30 +47,189 @@ type RepoRef struct {
 	Path string `yaml:"path"`
 }
 
-// WorkbenchConfigSpec describes the workbench configuration for provisioning services (YAML parsing).
+// ClamshellConfig points to the policy used by the environment.
+type ClamshellConfig struct {
+	Policy string `yaml:"policy"`
+}
+
+// EnvironmentAgent references a reusable agent template plus optional repo binding.
+type EnvironmentAgent struct {
+	Template string `yaml:"template"`
+	Repo     string `yaml:"repo,omitempty"`
+}
+
+// WorkbenchConfigSpec describes the parsed workbench configuration used for provisioning services.
 type WorkbenchConfigSpec struct {
-	Timeout  string        `yaml:"timeout"` // e.g., "5m"
+	Spec     string        `yaml:"spec,omitempty"`
+	Timeout  string        `yaml:"timeout,omitempty"`
 	Services []ServiceDecl `yaml:"services"`
 }
 
-// ServiceDecl describes a service to be provisioned in the workbench (YAML parsing).
-type ServiceDecl struct {
-	Name     string            `yaml:"name"`
-	Build    string            `yaml:"build"` // path or ${WORKTREE_*} template
-	Image    string            `yaml:"image"` // or use pre-built image
-	Ports    []string          `yaml:"ports"`
-	Env      map[string]string `yaml:"environment"`
-	Depends  []string          `yaml:"depends_on"`
-	Health   *HealthDecl       `yaml:"health_check"`
-	Networks []string          `yaml:"networks"` // e.g., ["infra-net"] for explicit network assignment
+// UnmarshalYAML supports both a sequence of services and a compose-style mapping keyed by service name.
+func (w *WorkbenchConfigSpec) UnmarshalYAML(node *yaml.Node) error {
+	type rawWorkbenchConfigSpec struct {
+		Spec     string    `yaml:"spec,omitempty"`
+		Timeout  string    `yaml:"timeout,omitempty"`
+		Services yaml.Node `yaml:"services"`
+	}
+
+	var raw rawWorkbenchConfigSpec
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+
+	w.Spec = raw.Spec
+	w.Timeout = raw.Timeout
+	w.Services = nil
+	if raw.Services.Kind == 0 {
+		return nil
+	}
+
+	switch raw.Services.Kind {
+	case yaml.SequenceNode:
+		var services []ServiceDecl
+		if err := raw.Services.Decode(&services); err != nil {
+			return err
+		}
+		w.Services = services
+		return nil
+	case yaml.MappingNode:
+		services := make([]ServiceDecl, 0, len(raw.Services.Content)/2)
+		for i := 0; i < len(raw.Services.Content); i += 2 {
+			nameNode := raw.Services.Content[i]
+			serviceNode := raw.Services.Content[i+1]
+
+			var service ServiceDecl
+			if err := serviceNode.Decode(&service); err != nil {
+				return err
+			}
+			if service.Name == "" {
+				service.Name = nameNode.Value
+			}
+			services = append(services, service)
+		}
+		w.Services = services
+		return nil
+	default:
+		return fmt.Errorf("docker: environment: services must be a sequence or mapping")
+	}
 }
 
-// HealthDecl describes a health check for a service (YAML parsing).
+// BuildDecl describes a service build context.
+type BuildDecl struct {
+	Context    string `yaml:"context,omitempty"`
+	Dockerfile string `yaml:"dockerfile,omitempty"`
+}
+
+func (b *BuildDecl) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return node.Decode(&b.Context)
+	case yaml.MappingNode:
+		type raw BuildDecl
+		return node.Decode((*raw)(b))
+	default:
+		return fmt.Errorf("docker: environment: invalid build declaration")
+	}
+}
+
+func (b BuildDecl) Empty() bool {
+	return b.Context == "" && b.Dockerfile == ""
+}
+
+// ServiceDependency describes an optional compose dependency condition.
+type ServiceDependency struct {
+	Condition string `yaml:"condition,omitempty"`
+}
+
+func (d *ServiceDependency) UnmarshalYAML(node *yaml.Node) error {
+	var aux struct {
+		Condition string `yaml:"condition,omitempty"`
+	}
+	if err := node.Decode(&aux); err != nil {
+		return err
+	}
+	d.Condition = aux.Condition
+	return nil
+}
+
+// ServiceDecl describes a service to be provisioned in the workbench.
+type ServiceDecl struct {
+	Name      string                       `yaml:"name"`
+	Build     BuildDecl                    `yaml:"build,omitempty"`
+	Image     string                       `yaml:"image,omitempty"`
+	Ports     []string                     `yaml:"ports,omitempty"`
+	Env       map[string]string            `yaml:"environment,omitempty"`
+	DependsOn map[string]ServiceDependency `yaml:"depends_on,omitempty"`
+	Health    *HealthDecl                  `yaml:"healthcheck,omitempty"`
+	Networks  []string                     `yaml:"networks,omitempty"`
+}
+
+// UnmarshalYAML supports both compact and structured forms for build/depends_on/healthcheck.
+func (s *ServiceDecl) UnmarshalYAML(node *yaml.Node) error {
+	type rawService struct {
+		Name      string            `yaml:"name"`
+		Build     BuildDecl         `yaml:"build"`
+		Image     string            `yaml:"image"`
+		Ports     []string          `yaml:"ports"`
+		Env       map[string]string `yaml:"environment"`
+		DependsOn yaml.Node         `yaml:"depends_on"`
+		HealthA   *HealthDecl       `yaml:"health_check"`
+		HealthB   *HealthDecl       `yaml:"healthcheck"`
+		Networks  []string          `yaml:"networks"`
+	}
+	var raw rawService
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+
+	s.Name = raw.Name
+	s.Build = raw.Build
+	s.Image = raw.Image
+	s.Ports = raw.Ports
+	s.Env = raw.Env
+	s.Networks = raw.Networks
+	if raw.HealthA != nil {
+		s.Health = raw.HealthA
+	} else {
+		s.Health = raw.HealthB
+	}
+
+	s.DependsOn = make(map[string]ServiceDependency)
+	switch raw.DependsOn.Kind {
+	case 0:
+	case yaml.SequenceNode:
+		var deps []string
+		if err := raw.DependsOn.Decode(&deps); err != nil {
+			return err
+		}
+		for _, dep := range deps {
+			s.DependsOn[dep] = ServiceDependency{}
+		}
+	case yaml.MappingNode:
+		var deps map[string]ServiceDependency
+		if err := raw.DependsOn.Decode(&deps); err != nil {
+			return err
+		}
+		for name, dep := range deps {
+			s.DependsOn[name] = dep
+		}
+	default:
+		return fmt.Errorf("docker: environment: invalid depends_on declaration")
+	}
+	if len(s.DependsOn) == 0 {
+		s.DependsOn = nil
+	}
+	return nil
+}
+
+// HealthDecl describes a health check for a service.
 type HealthDecl struct {
-	Test     []string `yaml:"test"`
-	Interval string   `yaml:"interval"`
-	Timeout  string   `yaml:"timeout"`
-	Retries  int      `yaml:"retries"`
+	Test        []string `yaml:"test"`
+	Interval    string   `yaml:"interval"`
+	Timeout     string   `yaml:"timeout"`
+	Retries     int      `yaml:"retries"`
+	StartPeriod string   `yaml:"start_period"`
 }
 
 // LoadEnvironment reads and parses an EnvironmentConfig from the given YAML file path.
@@ -77,24 +243,57 @@ func LoadEnvironment(path string) (*EnvironmentConfig, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("docker: environment: parse %q: %w", path, err)
 	}
+	if cfg.Type == "" {
+		cfg.Type = "docker-compose"
+	}
+	cfg.sourcePath = path
+
+	if cfg.Workbench != nil && cfg.Workbench.Spec != "" && len(cfg.Workbench.Services) == 0 {
+		spec, err := LoadWorkbenchSpec(cfg.ResolveWorkbenchSpecPath())
+		if err != nil {
+			return nil, err
+		}
+		if cfg.Workbench.Timeout != "" && spec.Timeout == "" {
+			spec.Timeout = cfg.Workbench.Timeout
+		}
+		cfg.Workbench = &spec
+	}
 
 	return &cfg, nil
 }
 
-// LoadEnvironmentByName loads an environment config from
-// <workspaceDir>/.belayer/environments/<name>.yaml.
-func LoadEnvironmentByName(workspaceDir, name string) (*EnvironmentConfig, error) {
-	path := filepath.Join(workspaceDir, ".belayer", "environments", name+".yaml")
-	return LoadEnvironment(path)
+// LoadEnvironmentByName loads an environment config from either:
+//
+//	<baseDir>/.belayer/environments/<name>.yaml
+//	<baseDir>/.belayer/environments/<name>/environment.yaml
+//	<baseDir>/environments/<name>.yaml
+//	<baseDir>/environments/<name>/environment.yaml
+func LoadEnvironmentByName(baseDir, name string) (*EnvironmentConfig, error) {
+	candidates := []string{
+		filepath.Join(baseDir, ".belayer", "environments", name+".yaml"),
+		filepath.Join(baseDir, ".belayer", "environments", name, "environment.yaml"),
+		filepath.Join(baseDir, "environments", name+".yaml"),
+		filepath.Join(baseDir, "environments", name, "environment.yaml"),
+	}
+	var lastErr error
+	for _, candidate := range candidates {
+		cfg, err := LoadEnvironment(candidate)
+		if err == nil {
+			return cfg, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("docker: environment: %q not found", name)
 }
 
 // DefaultEnvironment returns a minimal EnvironmentConfig with safe defaults.
 func DefaultEnvironment() *EnvironmentConfig {
 	return &EnvironmentConfig{
-		Type: "docker-compose",
-		Networking: NetworkingRule{
-			Type: "none",
-		},
+		Type:       "docker-compose",
+		Networking: NetworkingRule{Type: "none"},
 	}
 }
 
@@ -104,39 +303,37 @@ func ValidateEnvironment(cfg *EnvironmentConfig) error {
 	if cfg.Networking.Type != "" && !validTypes[cfg.Networking.Type] {
 		return fmt.Errorf("docker: environment: invalid network type %q (must be none, limited, or full)", cfg.Networking.Type)
 	}
-
 	for _, host := range cfg.Networking.AllowedHosts {
 		if err := validateHost(host); err != nil {
 			return fmt.Errorf("docker: environment: invalid allowed host %q: %w", host, err)
 		}
 	}
-
 	if cfg.Workbench != nil {
 		if cfg.Workbench.Timeout != "" {
 			if _, err := time.ParseDuration(cfg.Workbench.Timeout); err != nil {
 				return fmt.Errorf("docker: environment: invalid workbench timeout %q: %w", cfg.Workbench.Timeout, err)
 			}
 		}
+		if cfg.Workbench.Spec != "" {
+			if _, err := os.Stat(cfg.ResolveWorkbenchSpecPath()); err != nil {
+				return fmt.Errorf("docker: environment: read workbench spec %q: %w", cfg.ResolveWorkbenchSpecPath(), err)
+			}
+		}
 	}
-
 	return nil
 }
 
-// validateHost checks that a host entry looks like a valid hostname or wildcard pattern.
 func validateHost(host string) error {
 	if host == "" {
 		return fmt.Errorf("empty host")
 	}
-	// Reject obvious regex patterns that could bypass the proxy
 	if host == ".*" || host == "." || host == "*" {
 		return fmt.Errorf("overly broad pattern would bypass network isolation")
 	}
-	// Allow wildcard prefix (e.g., *.github.com)
 	h := host
 	if strings.HasPrefix(h, "*.") {
 		h = h[2:]
 	}
-	// Each label must be alphanumeric with hyphens, dots as separators
 	for _, label := range strings.Split(h, ".") {
 		if label == "" {
 			return fmt.Errorf("empty label in hostname")
@@ -150,23 +347,19 @@ func validateHost(host string) error {
 	return nil
 }
 
-// EscapeHostForRegex converts a hostname or wildcard pattern into a properly
-// anchored POSIX extended regex for tinyproxy's filter file.
+// EscapeHostForRegex converts a hostname or wildcard pattern into a properly anchored POSIX extended regex.
 func EscapeHostForRegex(host string) string {
-	// Handle wildcard prefix: *.github.com → [a-zA-Z0-9.-]+\.github\.com
 	prefix := ""
 	h := host
 	if strings.HasPrefix(h, "*.") {
 		prefix = "[a-zA-Z0-9.-]+\\."
 		h = h[2:]
 	}
-	// Escape dots in hostname
 	escaped := strings.ReplaceAll(h, ".", "\\.")
 	return prefix + escaped
 }
 
 // ResolveRepoPath finds the filesystem path for a named repo in the environment config.
-// Returns the path if found, or empty string if not found.
 func (cfg *EnvironmentConfig) ResolveRepoPath(repoName string) string {
 	for _, r := range cfg.Repos {
 		if r.Name == repoName {
@@ -176,8 +369,61 @@ func (cfg *EnvironmentConfig) ResolveRepoPath(repoName string) string {
 	return ""
 }
 
-// PackageManagerHosts returns common package manager domains that may be
-// added to AllowedHosts when AllowPackageManagers is true.
+// ResolveWorkbenchSpecPath resolves a relative nested workbench spec path.
+func (cfg *EnvironmentConfig) ResolveWorkbenchSpecPath() string {
+	if cfg == nil || cfg.Workbench == nil || cfg.Workbench.Spec == "" {
+		return ""
+	}
+	if filepath.IsAbs(cfg.Workbench.Spec) {
+		return cfg.Workbench.Spec
+	}
+	if cfg.sourcePath == "" {
+		return cfg.Workbench.Spec
+	}
+	return filepath.Join(filepath.Dir(cfg.sourcePath), cfg.Workbench.Spec)
+}
+
+// ResolveWorkbenchSpec returns the effective workbench spec, whether inline or split to a separate file.
+func (cfg *EnvironmentConfig) ResolveWorkbenchSpec() (WorkbenchConfigSpec, error) {
+	return cfg.LoadWorkbenchConfig()
+}
+
+// SourcePath returns the file path the environment was loaded from.
+func (cfg *EnvironmentConfig) SourcePath() string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.sourcePath
+}
+
+// LoadWorkbenchConfig returns the effective workbench configuration for the environment.
+func (cfg *EnvironmentConfig) LoadWorkbenchConfig() (WorkbenchConfigSpec, error) {
+	if cfg == nil || cfg.Workbench == nil {
+		return WorkbenchConfigSpec{}, fmt.Errorf("docker: environment: workbench is not configured")
+	}
+	if len(cfg.Workbench.Services) > 0 {
+		return *cfg.Workbench, nil
+	}
+	return LoadWorkbenchSpec(cfg.ResolveWorkbenchSpecPath())
+}
+
+// LoadWorkbenchSpec reads a standalone workbench spec YAML file.
+func LoadWorkbenchSpec(path string) (WorkbenchConfigSpec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return WorkbenchConfigSpec{}, fmt.Errorf("docker: environment: read workbench spec %q: %w", path, err)
+	}
+	var spec WorkbenchConfigSpec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return WorkbenchConfigSpec{}, fmt.Errorf("docker: environment: parse workbench spec %q: %w", path, err)
+	}
+	if spec.Timeout == "" {
+		spec.Timeout = "5m"
+	}
+	return spec, nil
+}
+
+// PackageManagerHosts returns common package manager domains that may be added to AllowedHosts.
 func PackageManagerHosts() []string {
 	return []string{
 		"registry.npmjs.org",

--- a/internal/docker/environment_test.go
+++ b/internal/docker/environment_test.go
@@ -25,6 +25,26 @@ repos:
     path: ~/Documents/Programs/work/extend-app
 `
 
+const splitWorkbenchEnvironmentYAML = `
+name: extend-fullstack
+workbench:
+  spec: workbench.yaml
+`
+
+const splitWorkbenchSpecYAML = `
+timeout: 5m
+services:
+  - name: extend-api
+    image: example/api:latest
+    ports: ["8080"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 30s
+`
+
 func TestLoadEnvironment_ValidYAML(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "env-*.yaml")
 	if err != nil {
@@ -101,6 +121,32 @@ func TestLoadEnvironmentByName_NonexistentName(t *testing.T) {
 	_, err := LoadEnvironmentByName(t.TempDir(), "does-not-exist")
 	if err == nil {
 		t.Fatal("expected error for nonexistent environment name, got nil")
+	}
+}
+
+func TestLoadEnvironment_LoadsSeparateWorkbenchSpec(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, "environment.yaml")
+	specPath := filepath.Join(dir, "workbench.yaml")
+	if err := os.WriteFile(envPath, []byte(splitWorkbenchEnvironmentYAML), 0o644); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+	if err := os.WriteFile(specPath, []byte(splitWorkbenchSpecYAML), 0o644); err != nil {
+		t.Fatalf("write workbench spec: %v", err)
+	}
+
+	cfg, err := LoadEnvironment(envPath)
+	if err != nil {
+		t.Fatalf("LoadEnvironment returned error: %v", err)
+	}
+	if cfg.Workbench == nil {
+		t.Fatal("expected Workbench to be loaded")
+	}
+	if len(cfg.Workbench.Services) != 1 {
+		t.Fatalf("expected 1 workbench service, got %d", len(cfg.Workbench.Services))
+	}
+	if cfg.Workbench.Services[0].Health == nil || cfg.Workbench.Services[0].Health.StartPeriod != "30s" {
+		t.Fatalf("expected health start period from split workbench spec, got %#v", cfg.Workbench.Services[0].Health)
 	}
 }
 

--- a/internal/docker/runtime_metadata.go
+++ b/internal/docker/runtime_metadata.go
@@ -1,0 +1,77 @@
+package docker
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/donovan-yohan/belayer/internal/agent"
+)
+
+// RuntimeMetadata captures session runtime configuration that later CLI/daemon
+// commands need after session start has finished.
+type RuntimeMetadata struct {
+	SessionID          string                          `json:"session_id"`
+	SessionName        string                          `json:"session_name,omitempty"`
+	Template           string                          `json:"template,omitempty"`
+	Environment        string                          `json:"environment,omitempty"`
+	EnvironmentPath    string                          `json:"environment_path,omitempty"`
+	BelayerDir         string                          `json:"belayer_dir,omitempty"`
+	WorkspaceRoot      string                          `json:"workspace_root,omitempty"`
+	SandboxDir         string                          `json:"sandbox_dir,omitempty"`
+	SandboxComposeFile string                          `json:"sandbox_compose_file,omitempty"`
+	Workbench          *WorkbenchConfigSpec            `json:"workbench,omitempty"`
+	WorkbenchDir       string                          `json:"workbench_dir,omitempty"`
+	WorkbenchCompose   string                          `json:"workbench_compose_file,omitempty"`
+	Tools              []agent.ToolSpec                `json:"tools,omitempty"`
+	RepoWorktrees      map[string]string               `json:"repo_worktrees,omitempty"`
+	AgentWorktrees     map[string]string               `json:"agent_worktrees,omitempty"`
+	Agents             map[string]AgentRuntimeMetadata `json:"agents,omitempty"`
+}
+
+// AgentRuntimeMetadata describes a configured agent in the runtime metadata.
+type AgentRuntimeMetadata struct {
+	Name string `json:"name"`
+	Repo string `json:"repo,omitempty"`
+	Tier string `json:"tier,omitempty"`
+}
+
+// MetadataPath returns the canonical metadata file path for a sandbox dir.
+func MetadataPath(sandboxDir string) string {
+	return filepath.Join(sandboxDir, "runtime.json")
+}
+
+// WriteRuntimeMetadata writes runtime metadata to the sandbox directory.
+func WriteRuntimeMetadata(sandboxDir string, meta RuntimeMetadata) error {
+	if err := os.MkdirAll(sandboxDir, 0o700); err != nil {
+		return fmt.Errorf("docker: create sandbox dir for metadata: %w", err)
+	}
+	if meta.SandboxDir == "" {
+		meta.SandboxDir = sandboxDir
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("docker: marshal runtime metadata: %w", err)
+	}
+	if err := os.WriteFile(MetadataPath(sandboxDir), data, 0o600); err != nil {
+		return fmt.Errorf("docker: write runtime metadata: %w", err)
+	}
+	return nil
+}
+
+// LoadRuntimeMetadata reads runtime metadata from the sandbox directory.
+func LoadRuntimeMetadata(sandboxDir string) (RuntimeMetadata, error) {
+	data, err := os.ReadFile(MetadataPath(sandboxDir))
+	if err != nil {
+		return RuntimeMetadata{}, fmt.Errorf("docker: read runtime metadata: %w", err)
+	}
+	var meta RuntimeMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return RuntimeMetadata{}, fmt.Errorf("docker: parse runtime metadata: %w", err)
+	}
+	if meta.SandboxDir == "" {
+		meta.SandboxDir = sandboxDir
+	}
+	return meta, nil
+}

--- a/internal/docker/runtime_metadata_test.go
+++ b/internal/docker/runtime_metadata_test.go
@@ -1,0 +1,58 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/donovan-yohan/belayer/internal/agent"
+)
+
+func TestRuntimeMetadata_RoundTrip(t *testing.T) {
+	sandboxDir := t.TempDir()
+	want := RuntimeMetadata{
+		SessionID:   "sess-123",
+		Environment: "extend-fullstack",
+		Workbench: &WorkbenchConfigSpec{
+			Timeout: "5m",
+			Services: []ServiceDecl{
+				{Name: "api", Image: "example/api:latest", Ports: []string{"8080"}},
+			},
+		},
+		Tools: []agent.ToolSpec{
+			{Name: "curl-api", Exec: agent.ToolExec{Target: "workbench", Command: "curl http://extend-api:8080"}},
+		},
+		RepoWorktrees: map[string]string{
+			"extend-api": "/tmp/extend-api",
+		},
+	}
+
+	if err := WriteRuntimeMetadata(sandboxDir, want); err != nil {
+		t.Fatalf("WriteRuntimeMetadata returned error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(sandboxDir, "runtime.json")); err != nil {
+		t.Fatalf("expected runtime.json to exist: %v", err)
+	}
+
+	got, err := LoadRuntimeMetadata(sandboxDir)
+	if err != nil {
+		t.Fatalf("LoadRuntimeMetadata returned error: %v", err)
+	}
+
+	if got.SessionID != want.SessionID {
+		t.Fatalf("SessionID = %q, want %q", got.SessionID, want.SessionID)
+	}
+	if got.Environment != want.Environment {
+		t.Fatalf("Environment = %q, want %q", got.Environment, want.Environment)
+	}
+	if got.Workbench == nil || len(got.Workbench.Services) != 1 {
+		t.Fatalf("expected workbench service in metadata, got %#v", got.Workbench)
+	}
+	if len(got.Tools) != 1 || got.Tools[0].Name != "curl-api" {
+		t.Fatalf("unexpected tools payload: %#v", got.Tools)
+	}
+	if got.RepoWorktrees["extend-api"] != "/tmp/extend-api" {
+		t.Fatalf("RepoWorktrees[extend-api] = %q", got.RepoWorktrees["extend-api"])
+	}
+}

--- a/internal/docker/workbench.go
+++ b/internal/docker/workbench.go
@@ -7,10 +7,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 	"text/template"
 	"time"
 )
+
+var execCommand = exec.Command
+var workbenchPollInterval = 5 * time.Second
 
 // WorkbenchConfig holds configuration for creating a workbench.
 type WorkbenchConfig struct {
@@ -26,6 +31,13 @@ type WorkbenchStatus struct {
 	Name   string `json:"name"`
 	State  string `json:"state"`
 	Health string `json:"health"`
+}
+
+// WorkbenchEndpoint is a structured endpoint returned to callers after
+// provisioning succeeds.
+type WorkbenchEndpoint struct {
+	Service string `json:"service"`
+	URL     string `json:"url"`
 }
 
 // Workbench manages the lifecycle of a Docker Compose-based workbench.
@@ -99,7 +111,7 @@ func (w *Workbench) Start() error {
 		return fmt.Errorf("docker: workbench: must call Create before Start")
 	}
 	composePath := filepath.Join(w.composeDir, "docker-compose.yml")
-	cmd := exec.Command("docker", "compose", "-f", composePath, "up", "-d")
+	cmd := execCommand("docker", "compose", "-f", composePath, "up", "-d")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -115,7 +127,7 @@ func (w *Workbench) Status() ([]WorkbenchStatus, error) {
 		return nil, fmt.Errorf("docker: workbench: must call Create before Status")
 	}
 	composePath := filepath.Join(w.composeDir, "docker-compose.yml")
-	cmd := exec.Command("docker", "compose", "-f", composePath, "ps", "--format", "json")
+	cmd := execCommand("docker", "compose", "-f", composePath, "ps", "--format", "json")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = os.Stderr
@@ -141,10 +153,10 @@ func (w *Workbench) WaitForHealthy(timeout time.Duration) error {
 	}
 
 	deadline := time.Now().Add(timeout)
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(workbenchPollInterval)
 	defer ticker.Stop()
 
-	for range ticker.C {
+	for {
 		statuses, err := w.Status()
 		if err != nil {
 			return fmt.Errorf("docker: workbench: wait for healthy: %w", err)
@@ -172,8 +184,9 @@ func (w *Workbench) WaitForHealthy(timeout time.Duration) error {
 		if time.Now().After(deadline) {
 			return fmt.Errorf("docker: workbench: wait for healthy: timeout exceeded")
 		}
+
+		<-ticker.C
 	}
-	return nil
 }
 
 // Stop runs `docker compose down` to tear down the workbench.
@@ -183,7 +196,7 @@ func (w *Workbench) Stop() error {
 		return fmt.Errorf("docker: workbench: must call Create before Stop")
 	}
 	composePath := filepath.Join(w.composeDir, "docker-compose.yml")
-	cmd := exec.Command("docker", "compose", "-f", composePath, "down")
+	cmd := execCommand("docker", "compose", "-f", composePath, "down")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -210,36 +223,54 @@ networks:
 services:
 {{ range .Services }}  {{ .Name }}:
 {{ if .Build }}    build:
-      context: {{ .Build }}
-{{ end }}{{ if .Image }}    image: {{ .Image }}
+      context: {{ .Build.Context }}
+{{ if .Build.Dockerfile }}      dockerfile: {{ .Build.Dockerfile }}
+{{ end }}{{ end }}{{ if .Image }}    image: {{ .Image }}
 {{ end }}{{ if .Environment }}    environment:
 {{ range $k, $v := .Environment }}      {{ $k }}: {{ $v }}
 {{ end }}{{ end }}{{ if .DependsOn }}    depends_on:
-{{ range .DependsOn }}      - {{ . }}
-{{ end }}{{ end }}{{ if .HealthCheck }}    healthcheck:
+{{ range .DependsOn }}      {{ .Name }}:
+{{ if .Condition }}        condition: {{ .Condition }}
+{{ else }}        condition: service_started
+{{ end }}{{ end }}{{ end }}{{ if .HealthCheck }}    healthcheck:
       test: {{ .HealthCheck.Test }}
-      interval: {{ .HealthCheck.Interval }}
-      timeout: {{ .HealthCheck.Timeout }}
-      retries: {{ .HealthCheck.Retries }}
-{{ end }}    networks:
+{{ if .HealthCheck.Interval }}      interval: {{ .HealthCheck.Interval }}
+{{ end }}{{ if .HealthCheck.Timeout }}      timeout: {{ .HealthCheck.Timeout }}
+{{ end }}{{ if .HealthCheck.Retries }}      retries: {{ .HealthCheck.Retries }}
+{{ end }}{{ if .HealthCheck.StartPeriod }}      start_period: {{ .HealthCheck.StartPeriod }}
+{{ end }}{{ end }}{{ if .Ports }}    ports:
+{{ range .Ports }}      - {{ . }}
+{{ end }}{{ end }}    networks:
       - workbench-net
 {{ range .ExtraNetworks }}      - {{ . }}
 {{ end }}
 {{ end }}`
 
 type healthCheckTemplateData struct {
-	Test     string // pre-formatted as JSON array
-	Interval string
-	Timeout  string
-	Retries  int
+	Test        string // pre-formatted as JSON array
+	Interval    string
+	Timeout     string
+	Retries     int
+	StartPeriod string
+}
+
+type serviceDependencyTemplateData struct {
+	Name      string
+	Condition string
+}
+
+type buildTemplateData struct {
+	Context    string
+	Dockerfile string
 }
 
 type workbenchServiceTemplateData struct {
 	Name          string
-	Build         string
+	Build         *buildTemplateData
 	Image         string
+	Ports         []string
 	Environment   map[string]string
-	DependsOn     []string
+	DependsOn     []serviceDependencyTemplateData
 	HealthCheck   *healthCheckTemplateData
 	ExtraNetworks []string
 }
@@ -251,45 +282,56 @@ type workbenchTemplateData struct {
 
 // generateWorkbenchCompose returns docker-compose.yml content for the given WorkbenchConfig.
 func generateWorkbenchCompose(cfg WorkbenchConfig) ([]byte, error) {
-	funcMap := template.FuncMap{}
-	tmpl, err := template.New("workbench").Funcs(funcMap).Parse(workbenchComposeTmpl)
+	tmpl, err := template.New("workbench").Parse(workbenchComposeTmpl)
 	if err != nil {
 		return nil, fmt.Errorf("docker: parse workbench template: %w", err)
 	}
 
 	services := make([]workbenchServiceTemplateData, 0, len(cfg.Spec.Services))
 	for _, svc := range cfg.Spec.Services {
-		// Substitute worktree paths in Build field
-		build := svc.Build
-		if build != "" {
-			for name, path := range cfg.WorktreePaths {
-				placeholder := fmt.Sprintf("${WORKTREE_%s}", name)
-				build = strings.ReplaceAll(build, placeholder, path)
+		var build *buildTemplateData
+		if !svc.Build.Empty() {
+			contextPath, err := renderWorkbenchString(svc.Build.Context, cfg)
+			if err != nil {
+				return nil, fmt.Errorf("docker: render build context for %s: %w", svc.Name, err)
 			}
+			dockerfilePath, err := renderWorkbenchString(svc.Build.Dockerfile, cfg)
+			if err != nil {
+				return nil, fmt.Errorf("docker: render dockerfile for %s: %w", svc.Name, err)
+			}
+			build = &buildTemplateData{Context: contextPath, Dockerfile: dockerfilePath}
 		}
 
-		// Safely quote environment values for YAML
 		safeEnv := make(map[string]string, len(svc.Env))
 		for k, v := range svc.Env {
-			safeEnv[k] = fmt.Sprintf("%q", v)
+			rendered, err := renderWorkbenchString(v, cfg)
+			if err != nil {
+				return nil, fmt.Errorf("docker: render env %s for %s: %w", k, svc.Name, err)
+			}
+			safeEnv[k] = fmt.Sprintf("%q", rendered)
 		}
 
-		// Convert healthcheck to template data with properly serialized test command
 		var hc *healthCheckTemplateData
 		if svc.Health != nil {
 			testJSON, _ := json.Marshal(svc.Health.Test)
 			hc = &healthCheckTemplateData{
-				Test:     string(testJSON),
-				Interval: svc.Health.Interval,
-				Timeout:  svc.Health.Timeout,
-				Retries:  svc.Health.Retries,
+				Test:        string(testJSON),
+				Interval:    svc.Health.Interval,
+				Timeout:     svc.Health.Timeout,
+				Retries:     svc.Health.Retries,
+				StartPeriod: svc.Health.StartPeriod,
 			}
 		}
 
-		// Use explicit Networks field from ServiceDecl for extra network assignment
+		dependsOn := make([]serviceDependencyTemplateData, 0, len(svc.DependsOn))
+		for name, dep := range svc.DependsOn {
+			dependsOn = append(dependsOn, serviceDependencyTemplateData{Name: name, Condition: dep.Condition})
+		}
+		sort.Slice(dependsOn, func(i, j int) bool { return dependsOn[i].Name < dependsOn[j].Name })
+
 		var extraNets []string
 		for _, net := range svc.Networks {
-			if net != "workbench-net" { // workbench-net is always included
+			if net != "workbench-net" {
 				extraNets = append(extraNets, net)
 			}
 		}
@@ -298,17 +340,15 @@ func generateWorkbenchCompose(cfg WorkbenchConfig) ([]byte, error) {
 			Name:          svc.Name,
 			Build:         build,
 			Image:         svc.Image,
+			Ports:         svc.Ports,
 			Environment:   safeEnv,
-			DependsOn:     svc.Depends,
+			DependsOn:     dependsOn,
 			HealthCheck:   hc,
 			ExtraNetworks: extraNets,
 		})
 	}
 
-	data := workbenchTemplateData{
-		SessionID: cfg.SessionID,
-		Services:  services,
-	}
+	data := workbenchTemplateData{SessionID: cfg.SessionID, Services: services}
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
@@ -316,4 +356,78 @@ func generateWorkbenchCompose(cfg WorkbenchConfig) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+func renderWorkbenchString(value string, cfg WorkbenchConfig) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	for name, path := range cfg.WorktreePaths {
+		value = strings.ReplaceAll(value, fmt.Sprintf("${WORKTREE_%s}", name), path)
+	}
+	worktreeRefPattern := regexp.MustCompile(`\{\{\s*\.Worktree\.([A-Za-z0-9._-]+)\s*\}\}`)
+	value = worktreeRefPattern.ReplaceAllStringFunc(value, func(match string) string {
+		submatches := worktreeRefPattern.FindStringSubmatch(match)
+		if len(submatches) != 2 {
+			return match
+		}
+		if path, ok := cfg.WorktreePaths[submatches[1]]; ok {
+			return path
+		}
+		return match
+	})
+	tmpl, err := template.New("workbench-string").Option("missingkey=error").Parse(value)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	data := struct {
+		SessionID string
+		Worktree  map[string]string
+	}{
+		SessionID: cfg.SessionID,
+		Worktree:  cfg.WorktreePaths,
+	}
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// OpenWorkbench re-opens an already-created workbench by session ID so callers can
+// query status or stop it without recreating the compose file.
+func OpenWorkbench(sessionID, baseDir string) *Workbench {
+	root := baseDir
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			root = filepath.Join(home, ".belayer", "workbenches")
+		}
+	}
+	return &Workbench{
+		config:     WorkbenchConfig{SessionID: sessionID, BaseDir: baseDir},
+		composeDir: filepath.Join(root, sessionID),
+	}
+}
+
+// Endpoints returns best-effort service endpoints for callers. For web-style
+// ports it emits http:// URLs; otherwise it emits service:port addresses.
+func (w *Workbench) Endpoints() map[string]WorkbenchEndpoint {
+	endpoints := make(map[string]WorkbenchEndpoint, len(w.config.Spec.Services))
+	for _, svc := range w.config.Spec.Services {
+		if len(svc.Ports) == 0 {
+			continue
+		}
+		port := svc.Ports[0]
+		serviceURL := fmt.Sprintf("%s:%s", svc.Name, port)
+		switch port {
+		case "80", "3000", "8080", "8081":
+			serviceURL = fmt.Sprintf("http://%s:%s", svc.Name, port)
+		}
+		endpoints[svc.Name] = WorkbenchEndpoint{
+			Service: svc.Name,
+			URL:     serviceURL,
+		}
+	}
+	return endpoints
 }

--- a/internal/docker/workbench_test.go
+++ b/internal/docker/workbench_test.go
@@ -117,7 +117,7 @@ func TestGenerateWorkbenchCompose_BuildContext(t *testing.T) {
 			Services: []ServiceDecl{
 				{
 					Name:  "api",
-					Build: "/path/to/api",
+					Build: BuildDecl{Context: "/path/to/api"},
 				},
 			},
 		},
@@ -219,9 +219,9 @@ func TestGenerateWorkbenchCompose_DependsOn(t *testing.T) {
 		Spec: WorkbenchConfigSpec{
 			Services: []ServiceDecl{
 				{
-					Name:    "api",
-					Image:   "extend/api:latest",
-					Depends: []string{"db"},
+					Name:      "api",
+					Image:     "extend/api:latest",
+					DependsOn: map[string]ServiceDependency{"db": {}},
 				},
 				{
 					Name:  "db",
@@ -238,8 +238,8 @@ func TestGenerateWorkbenchCompose_DependsOn(t *testing.T) {
 	if !strings.Contains(content, "depends_on:") {
 		t.Errorf("expected 'depends_on:' in compose output, got:\n%s", content)
 	}
-	if !strings.Contains(content, "- db") {
-		t.Errorf("expected '- db' dependency in compose output, got:\n%s", content)
+	if !strings.Contains(content, "db:") || !strings.Contains(content, "condition: service_started") {
+		t.Errorf("expected structured db dependency in compose output, got:\n%s", content)
 	}
 }
 
@@ -281,6 +281,35 @@ func TestGenerateWorkbenchCompose_HealthCheck(t *testing.T) {
 	}
 	if !strings.Contains(content, "retries: 5") {
 		t.Errorf("expected retries in compose output, got:\n%s", content)
+	}
+}
+
+func TestGenerateWorkbenchCompose_HealthCheckStartPeriod(t *testing.T) {
+	cfg := WorkbenchConfig{
+		SessionID: "test-session",
+		Spec: WorkbenchConfigSpec{
+			Services: []ServiceDecl{
+				{
+					Name:  "api",
+					Image: "extend/api:latest",
+					Health: &HealthDecl{
+						Test:        []string{"CMD", "curl", "-f", "http://localhost:8080/health"},
+						Interval:    "5s",
+						Timeout:     "3s",
+						Retries:     10,
+						StartPeriod: "30s",
+					},
+				},
+			},
+		},
+	}
+	out, err := generateWorkbenchCompose(cfg)
+	if err != nil {
+		t.Fatalf("generateWorkbenchCompose returned error: %v", err)
+	}
+	content := string(out)
+	if !strings.Contains(content, "start_period: 30s") {
+		t.Errorf("expected start_period in compose output, got:\n%s", content)
 	}
 }
 
@@ -337,7 +366,7 @@ func TestGenerateWorkbenchCompose_WorktreePathSubstitution(t *testing.T) {
 			Services: []ServiceDecl{
 				{
 					Name:  "api",
-					Build: "${WORKTREE_extend_api}",
+					Build: BuildDecl{Context: "${WORKTREE_extend_api}"},
 				},
 			},
 		},
@@ -355,6 +384,31 @@ func TestGenerateWorkbenchCompose_WorktreePathSubstitution(t *testing.T) {
 	}
 	if strings.Contains(content, "${WORKTREE_extend_api}") {
 		t.Errorf("expected placeholder to be substituted, got:\n%s", content)
+	}
+}
+
+func TestGenerateWorkbenchCompose_WorktreeDotTemplateSubstitution(t *testing.T) {
+	cfg := WorkbenchConfig{
+		SessionID: "test-session",
+		Spec: WorkbenchConfigSpec{
+			Services: []ServiceDecl{
+				{
+					Name:  "api",
+					Build: BuildDecl{Context: "{{.Worktree.extend-api}}"},
+				},
+			},
+		},
+		WorktreePaths: map[string]string{
+			"extend-api": "/Users/test/worktrees/extend-api",
+		},
+	}
+	out, err := generateWorkbenchCompose(cfg)
+	if err != nil {
+		t.Fatalf("generateWorkbenchCompose returned error: %v", err)
+	}
+	content := string(out)
+	if !strings.Contains(content, "/Users/test/worktrees/extend-api") {
+		t.Errorf("expected substituted path in compose output, got:\n%s", content)
 	}
 }
 
@@ -522,5 +576,28 @@ func TestWorkbench_Stop_RequiresCreate(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "must call Create before Stop") {
 		t.Errorf("expected error about Create, got: %v", err)
+	}
+}
+
+func TestWorkbench_Endpoints(t *testing.T) {
+	w, err := NewWorkbench(WorkbenchConfig{
+		SessionID: "test-session",
+		Spec: WorkbenchConfigSpec{
+			Services: []ServiceDecl{
+				{Name: "extend-api", Ports: []string{"8080"}},
+				{Name: "postgres", Ports: []string{"5432"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewWorkbench returned error: %v", err)
+	}
+
+	endpoints := w.Endpoints()
+	if endpoints["extend-api"].URL != "http://extend-api:8080" {
+		t.Fatalf("unexpected extend-api endpoint: %#v", endpoints["extend-api"])
+	}
+	if endpoints["postgres"].URL != "postgres:5432" {
+		t.Fatalf("unexpected postgres endpoint: %#v", endpoints["postgres"])
 	}
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,0 +1,45 @@
+package runtime
+
+// Mode identifies a runtime backend.
+type Mode string
+
+const (
+	ModeLocal      Mode = "local"
+	ModeDocker     Mode = "docker"
+	ModeKubernetes Mode = "kubernetes"
+)
+
+// Runtime captures the active backend selection for a session launch.
+// The higher-level CLI still owns concrete lifecycle plumbing, but launch
+// selection and capability checks now flow through this runtime layer.
+type Runtime interface {
+	Mode() Mode
+	Containerized() bool
+	SupportsDynamicAgents() bool
+}
+
+type LocalRuntime struct{}
+
+func (LocalRuntime) Mode() Mode                 { return ModeLocal }
+func (LocalRuntime) Containerized() bool        { return false }
+func (LocalRuntime) SupportsDynamicAgents() bool { return true }
+
+type DockerRuntime struct{}
+
+func (DockerRuntime) Mode() Mode                 { return ModeDocker }
+func (DockerRuntime) Containerized() bool        { return true }
+func (DockerRuntime) SupportsDynamicAgents() bool { return false }
+
+type KubernetesRuntime struct{}
+
+func (KubernetesRuntime) Mode() Mode                 { return ModeKubernetes }
+func (KubernetesRuntime) Containerized() bool        { return true }
+func (KubernetesRuntime) SupportsDynamicAgents() bool { return false }
+
+// Select chooses the current runtime backend from the launch mode flags.
+func Select(useDocker bool) Runtime {
+	if useDocker {
+		return DockerRuntime{}
+	}
+	return LocalRuntime{}
+}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1,0 +1,12 @@
+package runtime
+
+import "testing"
+
+func TestSelect(t *testing.T) {
+	if got := Select(false).Mode(); got != ModeLocal {
+		t.Fatalf("Select(false).Mode() = %q, want %q", got, ModeLocal)
+	}
+	if got := Select(true).Mode(); got != ModeDocker {
+		t.Fatalf("Select(true).Mode() = %q, want %q", got, ModeDocker)
+	}
+}

--- a/internal/session/template.go
+++ b/internal/session/template.go
@@ -27,6 +27,7 @@ type AgentSpec struct {
 	Vendor       string            `yaml:"vendor" json:"vendor"`
 	Model        string            `yaml:"model" json:"model"`
 	Repo         string            `yaml:"repo,omitempty" json:"repo,omitempty"` // optional repo name from environment config
+	Tier         string            `yaml:"tier,omitempty" json:"tier,omitempty"` // main, peripheral, ephemeral
 	Role         string            `yaml:"role,omitempty" json:"role,omitempty"` // human-readable description of what this agent does
 	SystemPrompt string            `yaml:"system_prompt" json:"system_prompt"`
 	MCPConfig    string            `yaml:"mcp_config,omitempty" json:"mcp_config,omitempty"`

--- a/internal/session/template_test.go
+++ b/internal/session/template_test.go
@@ -216,3 +216,30 @@ agents:
 		t.Errorf("app-impl should have repo 'extend-app', got %q", tmpl.Agents[2].Repo)
 	}
 }
+
+func TestAgentSpec_TierField(t *testing.T) {
+	yamlStr := `
+name: tiered
+phase: implement
+description: Tiered agents
+agents:
+  - name: pilot
+    vendor: claude
+    model: opus
+    tier: main
+  - name: reviewer
+    vendor: claude
+    model: sonnet
+    tier: ephemeral
+`
+	var tmpl SessionTemplate
+	if err := yamlPkg.Unmarshal([]byte(yamlStr), &tmpl); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if tmpl.Agents[0].Tier != "main" {
+		t.Fatalf("pilot tier = %q, want main", tmpl.Agents[0].Tier)
+	}
+	if tmpl.Agents[1].Tier != "ephemeral" {
+		t.Fatalf("reviewer tier = %q, want ephemeral", tmpl.Agents[1].Tier)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -273,6 +274,52 @@ func (s *Store) QueryEvents(sessionID string) ([]SessionEvent, error) {
 	)
 	if err != nil {
 		return nil, fmt.Errorf("store: query events: %w", err)
+	}
+	defer rows.Close()
+	return scanEvents(rows)
+}
+
+// QueryEventsAfter returns all events for a session with IDs greater than afterID,
+// ordered by ID ASC.
+func (s *Store) QueryEventsAfter(sessionID string, afterID int64) ([]SessionEvent, error) {
+	rows, err := s.db.Query(
+		`SELECT id, session_id, timestamp, type, data
+		 FROM events
+		 WHERE session_id = ? AND id > ?
+		 ORDER BY id ASC`,
+		sessionID, afterID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: query events after: %w", err)
+	}
+	defer rows.Close()
+	return scanEvents(rows)
+}
+
+// QueryEventsForSessionsAfter returns all events for the provided session IDs
+// with IDs greater than afterID, ordered by ID ASC.
+func (s *Store) QueryEventsForSessionsAfter(sessionIDs []string, afterID int64) ([]SessionEvent, error) {
+	if len(sessionIDs) == 0 {
+		return []SessionEvent{}, nil
+	}
+
+	placeholders := make([]string, len(sessionIDs))
+	args := make([]any, 0, len(sessionIDs)+1)
+	for i, sessionID := range sessionIDs {
+		placeholders[i] = "?"
+		args = append(args, sessionID)
+	}
+	args = append(args, afterID)
+
+	rows, err := s.db.Query(
+		fmt.Sprintf(`SELECT id, session_id, timestamp, type, data
+		 FROM events
+		 WHERE session_id IN (%s) AND id > ?
+		 ORDER BY id ASC`, strings.Join(placeholders, ",")),
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: query events for sessions after: %w", err)
 	}
 	defer rows.Close()
 	return scanEvents(rows)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -221,6 +221,77 @@ func TestQueryEvents_OrderedByTimestampASC(t *testing.T) {
 	}
 }
 
+func TestQueryEventsAfter_FiltersByEventID(t *testing.T) {
+	s := openMemory(t)
+
+	id, _ := s.CreateSession(Session{Name: "after-test"})
+	var eventIDs []int64
+	for _, typ := range []string{"alpha", "beta", "gamma"} {
+		if err := s.LogEvent(SessionEvent{SessionID: id, Type: typ}); err != nil {
+			t.Fatalf("LogEvent(%s): %v", typ, err)
+		}
+		events, err := s.QueryEvents(id)
+		if err != nil {
+			t.Fatalf("QueryEvents: %v", err)
+		}
+		eventIDs = append(eventIDs, events[len(events)-1].ID)
+	}
+
+	evts, err := s.QueryEventsAfter(id, eventIDs[0])
+	if err != nil {
+		t.Fatalf("QueryEventsAfter: %v", err)
+	}
+	if len(evts) != 2 {
+		t.Fatalf("expected 2 events after first ID, got %d", len(evts))
+	}
+	if evts[0].Type != "beta" || evts[1].Type != "gamma" {
+		t.Fatalf("unexpected events after first ID: %#v", evts)
+	}
+}
+
+func TestQueryEventsForSessionsAfter_FiltersSessionsAndEventID(t *testing.T) {
+	s := openMemory(t)
+
+	sessionA, _ := s.CreateSession(Session{Name: "sess-a"})
+	sessionB, _ := s.CreateSession(Session{Name: "sess-b"})
+	sessionC, _ := s.CreateSession(Session{Name: "sess-c"})
+
+	if err := s.LogEvent(SessionEvent{SessionID: sessionA, Type: "a-1"}); err != nil {
+		t.Fatalf("LogEvent(a-1): %v", err)
+	}
+	eventsA, err := s.QueryEvents(sessionA)
+	if err != nil {
+		t.Fatalf("QueryEvents(a): %v", err)
+	}
+	cutoffID := eventsA[len(eventsA)-1].ID
+
+	for _, evt := range []SessionEvent{
+		{SessionID: sessionB, Type: "b-1"},
+		{SessionID: sessionA, Type: "a-2"},
+		{SessionID: sessionC, Type: "c-1"},
+		{SessionID: sessionB, Type: "b-2"},
+	} {
+		if err := s.LogEvent(evt); err != nil {
+			t.Fatalf("LogEvent(%s): %v", evt.Type, err)
+		}
+	}
+
+	evts, err := s.QueryEventsForSessionsAfter([]string{sessionA, sessionB}, cutoffID)
+	if err != nil {
+		t.Fatalf("QueryEventsForSessionsAfter: %v", err)
+	}
+	if len(evts) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(evts))
+	}
+	got := []string{evts[0].Type, evts[1].Type, evts[2].Type}
+	want := []string{"b-1", "a-2", "b-2"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("event[%d] = %q, want %q (all=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 // TestSearchEvents_MatchesType verifies FTS5 search on the type field.
 func TestSearchEvents_MatchesType(t *testing.T) {
 	s := openMemory(t)


### PR DESCRIPTION
## Summary
- keep local tmux sessions aligned with the environment-backed climb/climb-fullstack launch path
- add end-to-end CLI smoke coverage for the climb acceptance surface using a real daemon plus fake tmux
- preserve issue #35 evidence for the single-repo and fullstack session-create flows

## What changed
- local tmux launches now persist runtime metadata and register environment tools the same way the docker path does
- environment-backed local sessions reuse repo-scoped worktrees for repo-bound agents instead of always falling back to the caller cwd
- new CLI smoke tests verify:
  - `belayer session create --template climb`
  - `belayer session create --template climb-fullstack --environment extend-fullstack`
  - daemon-visible running session state
  - expected agent roster creation and runtime metadata persistence

## Issue references
- References #35
- References #43
- References #44
- References #48
- References #49
- References #50
- References #51
- References #52
- References #53

## Verification
- `go test ./internal/cli -run 'TestSessionCreateClimbAliasStartsImplementRoster|TestSessionCreateClimbFullstackStartsEnvironmentRoster'`
- `go test ./...`
- `go build ./cmd/belayer`

## Notes
- This branch builds on the current `feature/v6-phase4-proof-out` stack, where most of the requested Phase 4 issue work is already present.
- This PR focuses on acceptance-path parity and regression evidence for the CLI surfaces tied to issue #35.
- #51 was already present in the base stack; it is referenced here so issue/PR automation sees the full linked phase-4 context.
