### PR TITLE
feat: add nightshift run-local control plane primitives

### DIFF
--- a/.hermes/plugins/belayer-support/__init__.py
+++ b/.hermes/plugins/belayer-support/__init__.py
@@ -1,0 +1,55 @@
+"""Belayer support plugin for project-local Nightshift runs."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _run_dir() -> Path | None:
+    value = os.getenv("BELAYER_RUN_DIR", "").strip()
+    return Path(value) if value else None
+
+
+def _finish_marker() -> Path | None:
+    rd = _run_dir()
+    if not rd:
+        return None
+    return rd / ".belayer-finished"
+
+
+def _extract_command(params: dict[str, Any] | None) -> str:
+    if not isinstance(params, dict):
+        return ""
+    for key in ("command", "input", "text", "data"):
+        value = params.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _post_tool_call(tool_name, params, result, task_id=None, **kwargs):
+    if tool_name not in {"terminal", "mcp_terminal", "bash", "shell"}:
+        return
+    command = _extract_command(params)
+    if "belayer finish" not in command:
+        return
+    marker = _finish_marker()
+    if not marker:
+        return
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("finished\n", encoding="utf-8")
+    logger.info("Belayer finish marker written: %s", marker)
+
+
+def register(ctx):
+    plugin_dir = Path(__file__).parent
+    ctx.register_skill(
+        "belayer-communication",
+        str(plugin_dir / "skills" / "belayer-communication" / "SKILL.md"),
+    )
+    ctx.register_hook("post_tool_call", _post_tool_call)

--- a/.hermes/plugins/belayer-support/plugin.yaml
+++ b/.hermes/plugins/belayer-support/plugin.yaml
@@ -1,0 +1,5 @@
+name: belayer-support
+version: "1.0"
+description: Belayer communication skill + finish guard hooks for Nightshift runs
+provides_hooks:
+  - post_tool_call

--- a/.hermes/plugins/belayer-support/skills/belayer-communication/SKILL.md
+++ b/.hermes/plugins/belayer-support/skills/belayer-communication/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: belayer-communication
+description: How to communicate with other agents and the Belayer control plane during a Nightshift run. Load this skill in every Nightshift specialist profile.
+version: 1.0.0
+author: Nightshift
+license: MIT
+metadata:
+  hermes:
+    tags: [nightshift, belayer, communication, multi-agent, coordination]
+---
+
+# Belayer Communication
+
+You are operating inside a **Belayer-managed Nightshift run**.
+
+Multiple specialist agents are working on the same ticket. You are one of them. A planner coordinates the work. Belayer is the session bus that connects everyone.
+
+## The rules
+
+1. **Never communicate with other agents directly.** No raw tmux. No writing to shared files as a messaging hack. No printing text hoping someone reads your terminal.
+2. **Always use `belayer` commands** to send messages, log observations, publish artifacts, and mark work complete.
+3. **Belayer is your only coordination interface.** If you need something from another agent, go through Belayer. If you learn something the run should know, tell Belayer.
+
+## Commands
+
+### Messaging
+```bash
+belayer message send --to planner "Blocked on API auth contract"
+belayer message broadcast "Shared contract updated in artifacts/shared-contract.md"
+```
+
+### Notes
+```bash
+belayer note "extend-api tests pass locally after migration change"
+```
+
+### Artifacts
+```bash
+belayer artifact create --kind specialist-report --path artifacts/api-specialist-report.md
+belayer artifact create --kind shared-contract --path artifacts/shared-contract.md
+belayer artifact list
+```
+
+### Completion
+You must call one of these before you are done:
+
+```bash
+belayer finish "Summary of work completed"
+belayer finish --blocked "Reason I cannot continue"
+```
+
+If you do not call `belayer finish`, a hook will mark your run blocked automatically when your Hermes session ends.
+
+## Planner-only commands
+
+### Spawn specialists
+```bash
+belayer spawn --profile default --name api --role api --workdir /path/to/repo
+belayer spawn --profile default --name reviewer --role reviewer --workdir /path/to/repo
+belayer roster
+```
+
+Use `belayer spawn` whenever you decide a new specialist is needed.
+
+## Communication etiquette
+
+- Use **messages** for direct questions/instructions
+- Use **notes** for progress and observations
+- Use **artifacts** for durable outputs others should read later
+- Use **finish** to explicitly signal completion or blockage
+
+Do not assume the planner can infer your state from silence.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,63 +1,108 @@
 # CLAUDE.md
 
-Belayer v6 — session runtime for autonomous coding agents.
+Belayer — Nightshift v1 / Extend-first redesign.
 
-## Architecture
+## Current architectural stance
 
-Daemon-based session runtime. One global daemon (`belayer daemon`) serves all workspaces via Unix socket. Sessions are the primitive — each session has a template (intake/implement/deliver), agents, events, and messages stored in SQLite.
+Belayer is no longer best thought of as a generic global orchestration platform.
 
-Three-phase model:
-- **intake** — single agent generates spec from idea
-- **implement** — pilot (opus) + implementer (sonnet) + reviewer (codex) trio
-- **deliver** — QA validation and merge
+For the current direction, Belayer is:
 
-## CLI Surface
+> the **run-local agent control plane** inside a single Nightshift worker run.
 
-```
-belayer daemon                     # Start supervisor
-belayer setup [--global]           # Bootstrap .belayer/ workspace (cwd or global)
-belayer session start --template implement --docker --environment extend-fullstack --input "task"
-belayer session list/stop          # Session CRUD
-belayer session wake <id> --agent  # Restart crashed agent with compiled context
-belayer attach <id> [--agent name] # Attach to agent tmux panes (local + Docker)
-belayer status                     # Daemon health + active sessions
-belayer logs <id> [-f] [--since N] # Session event stream (--follow for real-time)
-belayer debug <id>                 # Aggregated diagnostics (events + container health)
-belayer recall "query"             # FTS5 search across events
-belayer message send/broadcast     # Agent-to-agent messaging
-belayer context                    # Session info (messaging plane)
-belayer note "text"                # Log observation to session
-```
+Nightshift has two control planes:
 
-## Workspace Scoping
+1. **Worker control plane** — outer service that queues requests and assigns workers
+2. **Agent control plane** — Belayer, inside one worker run, coordinating planner + specialists
 
-Workspaces are cwd-derived: belayer walks up from the current directory looking for `.belayer/`. Falls back to `~/.belayer/` if none found. The daemon is global; workspaces are local.
+Belayer owns the second one.
 
-## Key Packages
+## Working assumptions right now
 
-- `internal/daemon/` — HTTP server on Unix socket, session/event CRUD
-- `internal/store/` — SQLite with WAL mode, FTS5 for event search
-- `internal/session/` — Template definitions (intake/implement/deliver)
-- `internal/agent/` — Config, prompt compilation, memory, tool registry
-- `internal/broker/` — Message send/broadcast with 2s debounce
-- `internal/tmux/` — Local tmux runner for agent execution
-- `internal/vendor/` — Claude, Codex, Generic adapters
-- `internal/memory/` — Three-tier: core (in-context), archival (FTS5), recall
-- `internal/workspace/` — repos.json loading and path resolution
-- `internal/docker/` — Compose generation, network isolation, environment configs, .env auth
-- `internal/shell/` — Safe shell quoting (prevents command injection from YAML templates)
+- one worker handles one request at a time
+- one Belayer session exists inside that worker
+- Hermes is the default harness
+- tmux is the default transport adapter
+- Belayer is the session bus for messages, events, artifacts, and roster state
+- Extend-localenv (`xt`) is the preferred Extend workbench interface
+- Clamshell remains the preferred sandbox boundary for production deployment
 
-## Development
+## Current implemented slice
 
-```bash
-go build ./cmd/belayer
-go test ./...
-go install ./cmd/belayer
-```
+Implemented in the repo now:
 
-## Guidance
+- `belayer run start`
+- `belayer spawn`
+- `belayer roster`
+- `belayer finish`
+- `belayer artifact create`
+- `belayer artifact list`
+- daemon-backed `agent_runs`
+- daemon-backed artifact registry
+- Hermes launch wrapper with Belayer env injection
+- project-local Hermes plugin + Belayer communication skill
+- exit-without-finish detection that marks runs blocked
 
-- The daemon handles plumbing. The pilot agent handles judgment.
-- Do not replace LLM judgment with deterministic heuristics.
-- Pilot is always present in implement sessions, even single-repo.
-- Keep the phase naming clear: intake/implement/deliver in code (explore/climb/summit is marketing only).
+## Key design rule
+
+Belayer should not be trying to be:
+
+- the cluster scheduler
+- the worker autoscaler
+- the hypervisor
+- the universal hosted identity service
+
+It should be trying to be excellent at:
+
+- run-local session management
+- planner/specialist coordination
+- messages / events / artifacts
+- observable progress and completion state
+
+## Coordination model
+
+Inside one run, agents coordinate through Belayer using:
+
+- **messages** — direct communication
+- **events** — orchestration state transitions
+- **artifacts** — durable outputs
+
+Agents should never rely on raw tmux for communication. tmux is only the transport adapter under Belayer.
+
+## Hermes-specific guidance
+
+Hermes is the preferred harness because:
+
+- profiles give us controlled behavior loading
+- skills/plugins/hooks are versionable and owned by us
+- the stack is git-traceable
+- we can iterate on behavior without depending on opaque upstream prompt changes
+
+Current MVP identity injection uses:
+
+- Hermes profile selection
+- Belayer env vars (`BELAYER_SESSION_ID`, `BELAYER_AGENT_ID`, `BELAYER_SOCKET`, `BELAYER_RUN_DIR`)
+- project-local Hermes plugin enablement
+- Belayer communication skill preload
+- workdir binding
+
+This is enough for the MVP; canonical git-backed identity materialization is still a later layer.
+
+## Relevant design docs
+
+When working on Belayer now, use these docs as the current truth:
+
+- `docs/PHILOSOPHY.md`
+- `docs/ARCHITECTURE.md`
+- `docs/DESIGN.md`
+- `docs/design-docs/2026-04-15-nightshift-v1-deployment-topology.md`
+- `docs/design-docs/2026-04-15-belayer-run-model-for-nightshift-v1.md`
+- `docs/design-docs/2026-04-15-nightshift-extend-first-implementation-delta.md`
+
+## Development guidance
+
+- Prefer deleting old generic code if it gets in the way of the new run-local model.
+- Backwards compatibility is not the priority right now.
+- New work should align with planner + api first, then expand.
+- Keep the system inspectable by humans; avoid magical hidden orchestration.
+- tmux is a pragmatic transport layer, not the architecture.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,661 +1,226 @@
-# Belayer v6 Architecture
+# Belayer Architecture
 
-Status: `implemented` — v6 session runtime (2026-04-09)
+Status: `active redesign` — Nightshift v1 / Extend-first direction (2026-04-15)
 
-> Many robots, bring your own pilots.
+> Belayer is no longer best understood as a generic multi-agent coding runtime.
+> For the current direction, it is the **run-local agent control plane** inside a single Nightshift worker run.
 
-Belayer v6 is a daemon-based session runtime for orchestrating multiple AI coding agents through structured session templates. Agent sandboxes are powered by clamshell for deny-by-default isolation. This document provides both high-level diagrams and implementation details for technical audiences.
+This document is the high-level architecture reference. For detailed current thinking, also see:
+
+- [Nightshift v1 Deployment Topology](design-docs/2026-04-15-nightshift-v1-deployment-topology.md)
+- [Belayer Run Model for Nightshift v1](design-docs/2026-04-15-belayer-run-model-for-nightshift-v1.md)
+- [Nightshift Extend-First Architecture](design-docs/2026-04-15-nightshift-extend-first-architecture.md)
+- [Implementation Delta](design-docs/2026-04-15-nightshift-extend-first-implementation-delta.md)
 
 ---
 
-## System Architecture Diagram
+## Current architectural stance
+
+Nightshift v1 has **two control planes**:
+
+1. **Worker control plane** — always-on Nightshift service that queues requests and assigns a worker
+2. **Agent control plane** — Belayer, inside one worker run, coordinating planner + specialists
+
+Belayer owns the second one.
+
+For v1:
+
+- one worker handles one request at a time
+- one Belayer session exists inside that worker
+- Hermes is the default harness
+- tmux is the default transport adapter
+- Extend-localenv (`xt`) is the Extend-specific workbench/runtime interface
+- Clamshell remains the preferred sandbox boundary for production deployment
+
+---
+
+## System architecture
 
 ```mermaid
-flowchart TB
-    subgraph Client["CLI Client"]
-        CLI["belayer CLI"]
+flowchart LR
+    User["User / Jira / reviewed spec"] --> NCP["Nightshift worker control plane"]
+    NCP --> Queue[("Request queue / run DB")]
+    NCP --> Worker["Single worker handling one request"]
+
+    subgraph WorkerRun["One Nightshift run on one worker"]
+        B["Belayer\nrun-local agent control plane"]
+        H["Hermes harness driver"]
+        T["tmux transport adapter"]
+        S["Sandbox / local filesystem / repo workspace"]
+        X["Extend localenv / xt workbench"]
+        A[("Session DB, events, artifacts")]
+
+        B --> H
+        H --> T
+        T --> S
+        B --> X
+        B --> A
+        H --> A
+        X --> A
     end
 
-    subgraph Daemon["Belayer Daemon"]
-        HTTP["HTTP Router"]
-        Store[("SQLite Store")]
-        Broker["Message Broker"]
-        Memory[("Three-Tier Memory")]
-    end
-
-    subgraph Templates["Session Templates"]
-        Climb["Climb"]
-        ClimbFS["Climb Fullstack"]
-        Epic["Epic"]
-    end
-
-    subgraph RuntimeLayer["Runtime Interface"]
-        Local["LocalRuntime (tmux)"]
-        ClamshellRT["ClamshellRuntime (sandbox)"]
-        DockerRT["DockerRuntime (compose)"]
-    end
-
-    subgraph Isolation["Clamshell Sandbox"]
-        Policy["Deny-by-default egress"]
-        Creds["Host-owned credentials"]
-        Proxy["inference.local routing"]
-        Audit["Per-binary audit"]
-    end
-
-    subgraph Vendors["Vendor Adapters"]
-        Claude["Claude"]
-        Codex["Codex"]
-        Generic["Generic"]
-    end
-
-    CLI --> HTTP
-    HTTP --> Store
-    HTTP --> Broker
-    HTTP --> Memory
-    
-    Store --> Templates
-    Broker --> RuntimeLayer
-    Memory --> RuntimeLayer
-    
-    ClamshellRT --> Isolation
-    Isolation --> Vendors
-    Local --> Vendors
-    DockerRT --> Vendors
+    Worker --> WorkerRun
 ```
+
+### Reading the diagram
+
+- The **outer control plane** decides *where* a request runs.
+- Belayer decides *how the agents inside that run coordinate*.
+- Hermes is the execution harness.
+- tmux is the wire used to launch and message harnesses.
+- Artifacts and events are the durable record of the run.
 
 ---
 
-## Session Lifecycle (Climb)
+## Belayer's three layers
 
-```mermaid
-sequenceDiagram
-    participant U as User
-    participant C as belayer CLI
-    participant D as Daemon
-    participant S as SQLite Store
-    participant P as Pilot Agent
-    participant I as Implementer
-    participant R as Reviewer
+Belayer should be understood as three layers:
 
-    U->>C: belayer session start --template climb --input "task"
-    C->>D: POST /sessions {name, template}
-    D->>S: INSERT session
-    D-->>C: {session_id, status: pending}
-    
-    Note over D: Load template → select runtime (local/clamshell/docker)
-    
-    D->>P: Launch via runtime
-    D->>I: Launch via runtime
-    D->>R: Launch via runtime
-    
-    loop Agent Coordination
-        P->>D: POST /messages (instruction)
-        D->>I: Route via Message Broker
-        I->>D: POST /events (code written)
-        D->>P: Notify completion
-        
-        P->>D: POST /messages (review request)
-        D->>R: Route to reviewer
-        R->>D: POST /events (review comments)
-        D->>P: Return review
-    end
-    
-    P->>D: PATCH /sessions/{id} {status: completed}
-    D->>S: UPDATE status
-    
-    U->>C: belayer logs <session-id>
-    C->>D: GET /sessions/{id}/events
-    D->>S: SELECT events
-    S-->>D: Event stream
-    D-->>C: Return events
-    C-->>U: Display logs
-```
+### 1. Session bus / control plane
+
+Owns:
+
+- session lifecycle
+- agent roster
+- typed messages and events
+- artifact registration and lookup
+- observability and run state
+
+This is the real Belayer role.
+
+### 2. Harness driver
+
+Owns:
+
+- how a harness process starts
+- which profile/identity is loaded
+- environment variables injected into the harness
+- how Belayer delivers instructions into the harness
+
+For v1, the primary harness is **Hermes**.
+
+### 3. Transport adapter
+
+Owns:
+
+- tmux session creation
+- send-keys / bracketed paste
+- capture-pane
+- attach / interrupt / kill
+
+For v1, the default transport adapter is **tmux**.
+
+tmux is a practical delivery layer, not the architectural center.
 
 ---
 
-## Agent Collaboration Model
+## Intra-run coordination model
 
-The daemon handles plumbing. Agents handle judgment. The pilot orchestrates, implementers write code, the reviewer provides fresh-eyes feedback. All communication flows through the message broker — agents never talk directly.
+Agents coordinate through Belayer, not by directly talking to each other's terminals.
 
-### Agent Roster
+### Coordination primitives
 
-#### Climb (single-repo)
+#### Messages
+Use for direct communication:
 
-| Agent | Model | Workspace | Role |
-|-------|-------|-----------|------|
-| **Pilot** | claude opus | reads events + diffs | Orchestrate, facilitate review loop, decide done |
-| **Implementer** | claude sonnet | repo worktree | Write code, run tests, create PR |
-| **Reviewer** | codex | reads PR diffs | Review PR, provide structured feedback |
+- planner → api
+- planner → reviewer
+- api → planner
 
-#### Climb-Fullstack (multi-repo)
+#### Events
+Use for machine-readable state transitions:
 
-| Agent | Model | Workspace | Role |
-|-------|-------|-----------|------|
-| **Pilot** | claude opus | reads events + diffs | Decompose spec, detect cross-repo drift, facilitate review loops |
-| **api-implementer** | claude sonnet | extend-api worktree | Implement API changes, create PR |
-| **app-implementer** | claude sonnet | extend-app worktree | Implement frontend changes, create PR |
-| **Reviewer** | codex | reads PR diffs | Review both PRs sequentially |
+- `task_assigned`
+- `message_sent`
+- `message_delivered`
+- `agent_finished`
+- `agent_exited_without_finish`
+- `artifact_created`
 
-#### Epic (workspace orchestration)
+#### Artifacts
+Use for durable outputs:
 
-| Agent | Model | Workspace | Role |
-|-------|-------|-----------|------|
-| **Pilot** | claude opus | cross-session | Decompose epic, create parallel sessions, monitor progress, trigger integration tests |
+- `task-graph`
+- `shared-contract`
+- `specialist-report`
+- `review-report`
+- `verification-report`
+- `handoff`
 
-### The Review Loop
+This split is central to the new architecture:
 
-The core coordination pattern. PR-based, not diff-based — the reviewer sees the PR with fresh eyes and no implementation context.
-
-```
-Pilot reads spec, messages implementer with task
-  │
-  ▼
-Implementer works (write code, run tests, iterate)
-  │
-  ▼
-Implementer creates PR
-  │
-  ▼
-Pilot sees PR event, messages reviewer: "PR #42 ready. Spec context: ..."
-  │
-  ▼
-Reviewer reads PR diff (fresh eyes — different vendor, no implementation context)
-Reviewer provides structured feedback
-  │
-  ├─ PASS → Pilot proceeds (single-repo: done; fullstack: wait for other repo or E2E)
-  │
-  └─ FAIL → Pilot sends feedback to implementer
-            Implementer fixes, pushes to PR branch
-            Pilot messages reviewer: "Changes pushed, re-review"
-            Loop until PASS
-```
-
-Review loops evolve via agent memory and reflection, not hardcoded rules. The pilot adapts based on accumulated coordination knowledge — which patterns work, which drift patterns recur, what feedback implementers most often need.
-
-### Multi-Repo Coordination (Fullstack)
-
-```mermaid
-sequenceDiagram
-    participant P as Pilot (opus)
-    participant API as api-implementer (sonnet)
-    participant APP as app-implementer (sonnet)
-    participant R as Reviewer (codex)
-
-    P->>API: Decomposed API tasks + shared contract
-    P->>APP: Decomposed App tasks + shared contract
-    
-    par Parallel Implementation
-        API->>API: Write code, run tests
-        APP->>APP: Write code, run tests
-    end
-    
-    Note over P: Watches events from both, detects drift
-    
-    opt Contract Violation Detected
-        P->>APP: "API changed the response shape, update your types"
-    end
-    
-    API->>P: PR #42 created
-    P->>R: "Review PR #42. Spec context: ..."
-    R->>P: PASS
-    
-    APP->>P: PR #43 created
-    P->>R: "Review PR #43. Spec context: ..."
-    R->>P: FAIL — missing type updates
-    P->>APP: Review feedback + fix instructions
-    APP->>P: Changes pushed
-    P->>R: "Re-review PR #43"
-    R->>P: PASS
-    
-    Note over P: Both PRs pass → provision workbench → E2E validation
-    P->>P: belayer workbench up (planned, #43)
-    P->>P: E2E validation against running services
-    P->>P: Session complete with two PR artifacts
-```
-
-The pilot decomposes the spec into per-repo tasks with a shared contract (API shapes, types, endpoints). Both implementers work in parallel. The pilot monitors events from both and intervenes proactively when it detects semantic drift between repos.
-
-### Message Flow
-
-All agent-to-agent communication goes through the daemon's message broker:
-
-```
-Agent A                    Daemon                     Agent B
-   │                         │                          │
-   │  POST /messages         │                          │
-   │  {to: "implementer",   │                          │
-   │   body: "task..."}     │                          │
-   │────────────────────────►│                          │
-   │                         │  2s debounce window      │
-   │                         │  (coalesce rapid msgs)   │
-   │                         │                          │
-   │                         │  tmux send-keys          │
-   │                         │  (bracketed paste)       │
-   │                         │─────────────────────────►│
-   │                         │                          │
-   │                         │  POST /events            │
-   │                         │◄─────────────────────────│
-   │                         │  {type: "message_read"}  │
-```
-
-- **Debounce**: 2s window coalesces rapid messages (e.g., pilot sends task + context + constraints as separate messages — delivered as one)
-- **Urgent bypass**: Messages marked urgent skip debounce (e.g., "stop, the spec changed")
-- **Broadcast**: `belayer message broadcast` delivers to all agents in the session
-- **Bracketed paste**: tmux delivery uses bracketed paste mode to prevent injection
-
-### Agent Memory & Learning
-
-All agents — including the pilot — get personal memory that persists across sessions. The pilot's memory is especially valuable: it learns which coordination patterns work, which drift patterns recur, and what review feedback implementers most often need.
-
-```
-.belayer/
-├── agents/
-│   ├── pilot/
-│   │   ├── config.yaml
-│   │   ├── system-prompt.md
-│   │   ├── agents.md                      ← orchestration playbook
-│   │   └── memory/
-│   │       └── system/
-│   │           ├── coordination-patterns.md  ← "app always forgets TS types when API changes"
-│   │           ├── review-priorities.md      ← "SpiceDB permission check is highest-value review"
-│   │           └── codebase-relationships.md ← "cards endpoint depends on rate-limit middleware"
-│   │
-│   ├── api-implementer/
-│   │   ├── config.yaml
-│   │   ├── system-prompt.md
-│   │   └── memory/
-│   │       └── system/
-│   │           ├── codebase.md               ← "Spring Boot, Kotlin, Flyway, Redis for caching"
-│   │           └── patterns.md               ← "always register in PermissionRegistry.kt"
-│   │
-│   ├── app-implementer/
-│   │   └── memory/
-│   │       └── system/
-│   │           ├── codebase.md               ← "React, TypeScript, webpack, proxy to API"
-│   │           └── patterns.md               ← "shared types in src/models/"
-│   │
-│   └── reviewer/
-│       └── memory/
-│           └── system/
-│               ├── review-checklist.md       ← evolved from experience, not static config
-│               └── common-issues.md          ← "missing SpiceDB checks (caught 5x)"
-│
-└── learnings/                                ← shared institutional knowledge all agents see
-```
-
-**Three-tier memory** (`internal/memory/`):
-
-The memory system has three tiers designed for different access patterns. SQLite is the runtime index; markdown files on disk are authoritative. The FTS5 index can be rebuilt from markdown at any time via `RebuildIndex`.
-
-| Tier | What it stores | Access pattern | Implementation |
-|------|---------------|----------------|----------------|
-| **Core** | Session-scoped key-value pairs (e.g., "current_task", "review_status") | Always in context — injected into every prompt. Small, frequently updated. | `core_memory` table, upsert by `(session_id, key)`. MemFS writes `core.md` per repo. |
-| **Archival** | Long-term learnings with provenance (session, source file, date, tags) | Append-mostly, full-text searchable via FTS5. Grows over time. | `archival_memory` table + `archival_memory_fts` virtual table. MemFS writes `archival/{topic}.md` per repo. |
-| **Recall** | Combined view: core entries for current session + archival search results for a query | On-demand assembly when agent calls `belayer recall "query"`. | `Recall()` combines `ReadCore(sessionID)` + `SearchArchival(query, 20)`. |
-
-**How memory flows through a session:**
-
-```
-Session start
-  │
-  ├─ Core memory loaded for this session (key-value pairs)
-  ├─ Personal agent memory loaded from .belayer/agents/{name}/memory/
-  ├─ Shared learnings loaded from .belayer/learnings/
-  └─ All injected into compiled prompt
-  │
-  ▼
-During session
-  │
-  ├─ Agent writes core memory: belayer recall write --key "task_status" --value "PR created"
-  ├─ Agent searches archival: belayer recall "SpiceDB permission patterns"
-  └─ Agent notes observations: belayer note "implementer forgot TS types again"
-  │
-  ▼
-Session ends (or agent goes idle)
-  │
-  ├─ Daemon launches reflection agent in its own sandbox
-  ├─ Reflection reads exported session events + current memory
-  ├─ Consolidates into:
-  │     Personal memory updates (per agent) → .belayer/agents/{name}/memory/
-  │     Shared learnings (all agents see)   → .belayer/learnings/
-  └─ FTS5 index updated from new markdown files
-```
-
-**Markdown is authoritative:** The MemFS layer (`memfs.go`) manages markdown files that are the source of truth. Core memory is `{repo}/core.md` (h2-delimited key-value). Archival memory is `{repo}/archival/{topic}.md` (h2-delimited entries with provenance headers). SQLite FTS5 is a derived index — `RebuildIndex` can repopulate it from the markdown files after a fresh clone.
-
-**Reflection cycle:**
-1. Session completes (or agent goes idle)
-2. Daemon launches a reflection agent in its own sandbox
-3. Reflection reads exported session events + current memory files
-4. Writes updated personal memory for each agent + shared learnings as markdown
-5. Over 50 sessions, each agent becomes an expert at its role for this codebase
-
-### Prompt Compilation
-
-Each agent's prompt is compiled at session start from multiple sources:
-
-```
-┌─────────────────────────────────────────┐
-│            Compiled Prompt              │
-├─────────────────────────────────────────┤
-│ 1. system-prompt.md (role identity)    │
-│ 2. agents.md (team roster + playbook)  │
-│ 3. Personal memory (memory/system/*)   │
-│ 4. Shared learnings (.belayer/learnings)│
-│ 5. Task input (spec, ticket, etc.)     │
-│ 6. Tool registry (available tools)     │
-└─────────────────────────────────────────┘
-```
-
-The pilot's `agents.md` is the orchestration playbook — it contains the team roster, spawn commands, and coordination patterns. No hardcoded workflows. The pilot adapts orchestration to team composition through LLM judgment + accumulated memory.
-
-### Observability
-
-```bash
-# Watch all agents in real-time
-belayer logs <id> -f
-# → 10:01:00 [pilot/opus]       message_sent → api-implementer: "Implement rate limiting..."
-# → 10:05:00 [api-impl/sonnet]  tool_use: Edit src/middleware/RateLimiter.kt
-# → 10:08:00 [api-impl/sonnet]  tool_use: Bash ./gradlew test (pass)
-# → 10:09:00 [api-impl/sonnet]  artifact: PR #42
-# → 10:09:01 [pilot/opus]       message_sent → reviewer: "PR #42 ready"
-# → 10:11:00 [reviewer/codex]   message_sent → pilot: "FAIL: missing SpiceDB check"
-# → 10:11:01 [pilot/opus]       message_sent → api-implementer: "Review failed: ..."
-
-# Attach to any agent's terminal
-belayer attach pilot                # watch the orchestrator think
-belayer attach api-implementer      # watch code being written
-
-# Session status with cost tracking
-belayer status
-# → Session abc123: running (12m)
-# →   pilot (opus):             2,100 in / 800 out — $0.08
-# →   api-implementer (sonnet): 45,000 in / 12,000 out — $0.19
-# →   app-implementer (sonnet): 38,000 in / 11,000 out — $0.16
-# →   reviewer (codex):         8,000 in / 2,000 out — $0.04
-# →   Total: ~$0.47
-
-# Full-text search across all session events
-belayer recall "SpiceDB permission"
-
-# Restart a crashed agent with compiled context
-belayer session wake <id> --agent implementer
-```
-
-### Restart & Resume
-
-When an agent crashes, belayer preserves session state and can restart with full context:
-
-1. Agent crash detected → `session.agent_stopped` event emitted
-2. `belayer session wake --agent <name>` compiles restart context from: previous events, git state, pending review feedback, review loop state
-3. Vendor adapters provide `CompileRestartPrompt` for vendor-specific formatting
-4. Session continues from where it stopped; token usage aggregated across restart boundary
+> messages are for conversation,
+> events are for orchestration state,
+> artifacts are for durable shared outputs.
 
 ---
 
-## Component Overview
+## Current implemented slice
 
-Belayer v6 is built around a session runtime rather than a pipeline engine.
+The following is implemented today in the repo:
 
-## Runtime Layers
+### Run/session bus
+- daemon-backed session creation
+- message routing through the broker
+- session event log
+- agent roster storage (`agent_runs`)
 
-1. **CLI shell** (`internal/cli/`)
-   - Starts and inspects runtime processes
-   - Operator entrypoint: daemon, session, attach, logs, status, recall
-   - Connects to daemon via Unix socket HTTP client
+### Hermes/tmux integration
+- Hermes launch command builder
+- Belayer env injection into Hermes runs
+- project-local plugin enablement for Nightshift runs
+- tmux-backed spawn + message delivery
 
-2. **Daemon / supervisor** (`internal/daemon/`)
-   - Long-lived process on Unix socket (`~/.belayer/daemon.sock`)
-   - Session CRUD, event logging, graceful shutdown
-   - Brokers session lifecycle transitions
+### Run-local CLI
+- `belayer run start`
+- `belayer spawn`
+- `belayer roster`
+- `belayer finish`
+- `belayer artifact create`
+- `belayer artifact list`
 
-3. **Session adapters** (`internal/vendor/`)
-   - Claude adapter (stream-json parsing, token extraction)
-   - Codex adapter (structured JSON, usage tracking)
-   - Generic adapter (raw transcript, any CLI agent)
-   - Registry pattern for vendor lookup
+### Completion discipline
+- Hermes project-local hook detects explicit `belayer finish`
+- launcher wrapper records finish marker
+- Belayer watcher marks an agent `blocked` if its tmux session exits without explicit finish
 
-4. **Runtime storage** (`internal/store/`, `internal/memory/`)
-   - SQLite + WAL for sessions and events with FTS5 search
-   - Three-tier memory: core (session-scoped key-value, always in prompt), archival (append-only learnings with FTS5 full-text search), recall (combined core + archival query on demand)
-   - MemFS layer manages authoritative markdown files; SQLite FTS5 is a derived index rebuilt via `RebuildIndex`
-
-5. **Runtime interface** (`internal/runtime/`)
-   - `Runtime` interface with `Mode()`, `Containerized()`, `SupportsDynamicAgents()`
-   - `LocalRuntime` — tmux sessions, no isolation, full host access
-   - `DockerRuntime` — compose-based containers with network isolation (legacy)
-   - `ClamshellRuntime` — deny-by-default sandboxes with host-owned credentials
-   - `Select(useDocker, useClamshell)` dispatcher chooses backend
-
-6. **Execution environments** (`internal/tmux/`, `internal/docker/`, `internal/clamshell/`)
-   - tmux Runner interface with bracketed paste and pipe-pane capture
-   - Docker sandboxes: compose generation, network isolation (none/limited/full)
-   - Clamshell integration: `clamshell sandbox create/connect` for agent isolation
-   - Per-agent worktrees via `git worktree add` for session isolation
-   - Worktree cleanup wired into session stop and `belayer session clean`
-
-7. **Communication** (`internal/broker/`)
-   - Message broker: send, broadcast, subscribe, interrupt
-   - 2s debounce coalescing for rapid messages
-   - Urgent messages bypass debounce
-
-8. **Agent framework** (`internal/agent/`, `internal/session/`, `internal/reflection/`)
-   - YAML agent configs with role validation and tool registry
-   - Session templates: climb, climb-fullstack, epic
-   - Pilot-always-present invariant enforced in climb sessions
-   - `Tier` field on AgentSpec (main, peripheral, ephemeral)
-   - Sleep-time reflection for memory consolidation
-
-## Package Dependency Graph
-
-```
-cli → daemon → store
-cli → session (templates)
-cli → runtime (Local/Docker/Clamshell selection)
-cli → clamshell (sandbox connect for attach)
-daemon → store
-broker → store (message history)
-reflection → memory + store
-memory → (SQLite)
-runtime → (interface only)
-docker → (os/exec)
-clamshell → (os/exec)
-tmux → (os/exec)
-vendor → (independent)
-agent → (yaml.v3)
-workspace → (os/exec, encoding/json)
-```
-
-## Security & Isolation Model
-
-Belayer provides defense in depth through multiple isolation layers. Clamshell is the primary isolation backend.
-
-### Clamshell Sandbox Architecture
-
-```
-Belayer Daemon (trusted control plane)
-  - Pure Go binary, never runs LLM-generated code
-  - Manages session lifecycle, messaging, events
-  - Triggers reflection (launches sandbox, never runs LLM itself)
-
-Clamshell Gateway (trusted, host-side)
-  - Holds real credentials (API keys, tokens)
-  - Runs managed proxy with policy enforcement
-  - Provides inference.local routing (credential injection at proxy boundary)
-  - Audit logging of all egress
-
-Agent Sandboxes (untrusted, clamshell-managed)
-  - Vendor CLI + git + belayer CLI
-  - Worktree mounted at /workspace
-  - NO real credentials (inference.local handles API auth)
-  - Deny-by-default network (only proxy on loopback)
-  - Per-binary egress policy
-```
-
-### Clamshell Isolation Properties
-
-| Concern | How clamshell solves it |
-|---------|----------------------|
-| **Network isolation** | Deny-by-default iptables. Sandbox processes can only reach the managed proxy on loopback. |
-| **Credential isolation** | Host-owned secrets, never mounted into sandbox. `inference.local` routing injects credentials at the proxy boundary. |
-| **Egress control** | Per-binary policy — `claude` can reach `api.anthropic.com`; agent-written scripts cannot. |
-| **Filesystem isolation** | Writable `/workspace`, read-only root. Host control plane never visible inside sandbox. |
-| **Audit** | Deny event logs with binary identity, target, reason. `clamshell doctor` for health. |
-| **Interactive access** | tmux-backed sessions. `belayer attach` wraps `clamshell sandbox connect`. |
-
-### Runtime Comparison
-
-| Aspect | Local (tmux) | Clamshell | Docker (legacy) |
-|--------|-------------|-----------|-----------------|
-| Network | Full host | Deny-by-default + per-binary policy | Internal Docker network + tinyproxy |
-| Credentials | Environment variables | Host-owned, inference.local routing | Mounted .env file |
-| Filesystem | Full host access | /workspace only, read-only root | Container overlayfs + mounts |
-| Process | tmux session | Clamshell sandbox | Docker container |
-| Use case | Development, trusted envs | Production default | Legacy deployments |
-
-### Threat Model
-
-| Threat | Mitigation |
-|--------|------------|
-| Agent escapes sandbox | Clamshell deny-by-default network + read-only root + no host paths |
-| Agent accesses other sessions | Per-session sandbox names + session-scoped worktrees |
-| Credential exfiltration | Credentials never enter sandbox (inference.local routing) + per-binary egress |
-| Agent modifies host system | /workspace is only writable mount + no host filesystem access |
-| Prompt injection via logs | Structured JSON logging + no shell interpolation of log content |
-| Agent-written code phones home | Per-binary egress policy — only approved binaries reach approved endpoints |
+This is enough to prove the run-local control-plane model works for planner + api slices.
 
 ---
 
-## ASCII Architecture Reference
+## Aspirational next steps
 
-For environments without Mermaid rendering support:
+The following are part of the intended architecture but not fully implemented yet:
 
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                           BELAYER v6 SYSTEM VIEW                            │
-└─────────────────────────────────────────────────────────────────────────────┘
+### 1. Live idle nudging
+If an agent remains running but appears idle without calling `belayer finish`, Belayer should nudge it through tmux and remind it to finish or mark blocked.
 
-┌──────────────┐     HTTP/Unix      ┌─────────────────────────────────────────┐
-│   CLI User   │◄─────Socket───────►│            BELAYER DAEMON               │
-└──────────────┘                    │  ┌─────────┐  ┌─────────┐  ┌─────────┐  │
-                                    │  │  HTTP   │  │ SQLite  │  │ Message │  │
-┌──────────────┐                    │  │ Router  │  │ + FTS5  │  │ Broker  │  │
-│   Agents     │◄───Agent IPC──────►│  └────┬────┘  └────┬────┘  └────┬────┘  │
-│ (Claude,     │                    │       └────────────┴────────────┘       │
-│  Codex, etc) │                    │              ┌─────────┐                │
-└──────────────┘                    │              │ 3-Tier  │                │
-                                    │              │ Memory  │                │
-                                    │              └─────────┘                │
-                                    └─────────────────────────────────────────┘
+### 2. Better specialist identities
+The current slice uses existing Hermes profiles plus project-local skills/plugins. The longer-term direction is a more explicit identity model with role-specific profiles and portable skills/memory.
 
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                          SESSION TEMPLATES                                  │
-└─────────────────────────────────────────────────────────────────────────────┘
+### 3. Extend-first workbench integration
+Belayer should treat `xt` as the primary Extend workbench interface, not generic compose-first workbench provisioning.
 
-    CLIMB               CLIMB-FULLSTACK          EPIC
-   ┌─────────────┐     ┌─────────────────┐     ┌─────────────┐
-   │   ┌─────┐   │     │     ┌─────┐     │     │   ┌─────┐   │
-   │   │Pilot│   │     │     │Pilot│     │     │   │Pilot│   │
-   │   └─┬─┬─┘   │     │     └─┬─┬─┘     │     │   └──┬──┘   │
-   │     │ │     │     │       │ │       │     │      │      │
-   │     ▼ ▼     │     │    ┌──┘ └──┐    │     │   Orchestrate│
-   │  ┌───────┐  │     │    ▼       ▼    │     │   Sessions   │
-   │  │Implmnt│  │     │ ┌─────┐ ┌─────┐│     └─────────────┘
-   │  │   +   │  │     │ │ API │ │ App ││
-   │  │Review │  │     │ │Impl │ │Impl ││
-   │  └───────┘  │     │ └─────┘ └─────┘│
-   └─────────────┘     │    + Reviewer   │
-                       └─────────────────┘
+### 4. Worker control plane integration
+Belayer should remain the run-local control plane, while a higher-level Nightshift service handles queueing, worker assignment, and run lifecycle across machines.
 
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                     CLAMSHELL SANDBOX ARCHITECTURE                          │
-└─────────────────────────────────────────────────────────────────────────────┘
-
-┌───────────────────────────────┐
-│   Clamshell Gateway (host)   │
-│  ┌─────────────────────────┐ │
-│  │  Managed Proxy          │ │         ┌──────────────┐
-│  │  + inference.local      │─┼────────►│   Internet   │
-│  │  + credential injection │ │         │  (per-binary  │
-│  │  + egress policy        │ │         │   filtered)  │
-│  └────────────┬────────────┘ │         └──────────────┘
-│               │ loopback     │
-│  ┌────────────▼────────────┐ │
-│  │   Agent Sandbox         │ │
-│  │   (deny-by-default)     │ │
-│  │                         │ │
-│  │   /workspace (RW)       │ │
-│  │   vendor CLI (claude)   │ │
-│  │   belayer CLI           │ │
-│  │   NO real credentials   │ │
-│  └─────────────────────────┘ │
-└───────────────────────────────┘
-
-Runtime Selection:
-• local     → tmux sessions (no isolation)
-• clamshell → deny-by-default sandbox (recommended)
-• docker    → compose containers (legacy)
-```
+### 5. Centralized identity materialization
+Longer term, profiles/skills/memory may be materialized from a git-backed canonical identity source rather than relying on purely local profile state.
 
 ---
 
-## API Reference
+## What Belayer is not trying to be right now
 
-### Session Endpoints
+Belayer should not be trying to be:
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/sessions` | Create new session |
-| GET | `/sessions` | List all sessions |
-| GET | `/sessions/{id}` | Get session by ID |
-| PATCH | `/sessions/{id}` | Update session status |
-| GET | `/sessions/{id}/events` | Get session events |
-| POST | `/sessions/{id}/events` | Log event |
-| POST | `/sessions/{id}/messages` | Send message to agent |
-| POST | `/sessions/{id}/messages/broadcast` | Broadcast to all agents |
+- the worker scheduler
+- the cluster manager
+- the hypervisor
+- the universal hosted identity service
+- the only place where all memory and orchestration logic lives
 
-### Utility Endpoints
+For the current direction, Belayer is specifically:
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/health` | Health check |
-| GET | `/search?q={query}` | FTS5 search across events |
+> the session bus and run-local control plane for a planner-led Nightshift run.
 
-### Planned Endpoints
-
-| Method | Endpoint | Description | Issue |
-|--------|----------|-------------|-------|
-| POST | `/sessions/{id}/workbench` | Provision workbench stack | #43 |
-| GET | `/sessions/{id}/workbench` | Workbench status + endpoints | #43 |
-| DELETE | `/sessions/{id}/workbench` | Tear down workbench | #43 |
-| POST | `/sessions/{id}/tools/{name}` | Execute tool | #44 |
-| GET | `/sessions/{id}/tools` | List available tools | #44 |
-| GET | `/sessions/{id}/events?after={id}&wait=30s` | Long-poll events | #53 |
-| GET | `/events/stream?sessions=id1,id2` | SSE multi-session stream | #53 |
-
----
-
-## Workspace Directory Structure
-
-```
-~/.belayer/
-├── daemon.sock              # Unix socket (daemon listens here)
-├── belayer.db               # SQLite database (WAL mode)
-├── belayer.db-shm           # SQLite shared memory
-├── belayer.db-wal           # SQLite write-ahead log
-├── templates/
-│   ├── pilot/               # Agent template (agent.yaml + system-prompt.md + agents.md)
-│   ├── api-implementer/
-│   ├── app-implementer/
-│   ├── reviewer/
-│   └── sprite/              # Ephemeral agent template
-├── policies/
-│   └── extend-fullstack.yaml  # Clamshell egress policy
-├── environments/
-│   └── extend-fullstack.yaml  # Environment config (repos, agents, policy, tools)
-├── worktrees/
-│   └── {sessionID}/
-│       ├── extend-api/      # Per-repo per-session git worktree
-│       └── extend-app/
-└── repos.json               # Repository name → path mappings
-```
+That narrower role is a strength.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,15 +38,17 @@ For v1:
 
 ```mermaid
 flowchart LR
-    User["User / Jira / reviewed spec"] --> NCP["Nightshift worker control plane"]
+    User["User / Jira / reviewed spec"] --> NCP["Nightshift daemon\n(worker control plane)"]
     NCP --> Queue[("Request queue / run DB")]
-    NCP --> Worker["Single worker handling one request"]
+    NCP --> W1["Worker 1"]
+    NCP --> W2["Worker 2"]
+    NCP --> W3["Worker 3"]
 
     subgraph WorkerRun["One Nightshift run on one worker"]
-        B["Belayer\nrun-local agent control plane"]
+        B["Belayer daemon\nrun-local agent control plane"]
         H["Hermes harness driver"]
         T["tmux transport adapter"]
-        S["Sandbox / local filesystem / repo workspace"]
+        S["Sandbox / repo workspace"]
         X["Extend localenv / xt workbench"]
         A[("Session DB, events, artifacts")]
 
@@ -59,12 +61,69 @@ flowchart LR
         X --> A
     end
 
-    Worker --> WorkerRun
+    W1 --> WorkerRun
+```
+
+### Parallel worker picture
+
+```mermaid
+flowchart TB
+    NCP["Nightshift daemon\n(always on)"] --> W1["Worker 1\none active request"]
+    NCP --> W2["Worker 2\none active request"]
+    NCP --> W3["Worker 3\none active request"]
+
+    subgraph R1["Run A on Worker 1"]
+        B1["Belayer daemon"]
+        P1["planner"]
+        A1["api specialist"]
+        Q1["qa / reviewer as needed"]
+        X1["xt / localenv"]
+        S1["clamshell sandbox"]
+        B1 --> P1
+        B1 --> A1
+        B1 --> Q1
+        B1 --> X1
+        P1 --> S1
+        A1 --> S1
+        Q1 --> S1
+    end
+
+    subgraph R2["Run B on Worker 2"]
+        B2["Belayer daemon"]
+        P2["planner"]
+        A2["api/app specialists"]
+        X2["xt / localenv"]
+        S2["clamshell sandbox"]
+        B2 --> P2
+        B2 --> A2
+        B2 --> X2
+        P2 --> S2
+        A2 --> S2
+    end
+
+    subgraph R3["Run C on Worker 3"]
+        B3["Belayer daemon"]
+        P3["planner"]
+        A3["specialists"]
+        X3["xt / localenv"]
+        S3["clamshell sandbox"]
+        B3 --> P3
+        B3 --> A3
+        B3 --> X3
+        P3 --> S3
+        A3 --> S3
+    end
+
+    W1 --> R1
+    W2 --> R2
+    W3 --> R3
 ```
 
 ### Reading the diagram
 
 - The **outer control plane** decides *where* a request runs.
+- Multiple workers can run in parallel, but each worker still handles **one request at a time** in v1.
+- Each worker hosts a **Belayer daemon** for the active run on that worker.
 - Belayer decides *how the agents inside that run coordinate*.
 - Hermes is the execution harness.
 - tmux is the wire used to launch and message harnesses.
@@ -185,6 +244,75 @@ The following is implemented today in the repo:
 - Belayer watcher marks an agent `blocked` if its tmux session exits without explicit finish
 
 This is enough to prove the run-local control-plane model works for planner + api slices.
+
+---
+
+## Future scaling: extend-localenv and extend-clamshell beyond MVP
+
+The current MVP proves the run-local control plane with Hermes + tmux + explicit finish/artifact discipline. The next scaling layers for real Nightshift deployments are **extend-localenv** and **extend-clamshell**.
+
+### extend-localenv beyond MVP
+
+`xt` should scale into Nightshift as the **Extend-specific workbench interface**, not as a side utility.
+
+Belayer/Nightshift should eventually treat `xt` as the standard way to:
+
+- validate host prerequisites (`xt doctor`)
+- bring up local Extend runtime dependencies (`xt up`)
+- inspect readiness (`xt status`)
+- tear down cleanly (`xt down`)
+- mint local runtime auth/tokens where appropriate (`xt token`)
+
+This means the future workbench shape should be:
+
+- **planner/specialists run in a sandbox/session workspace**
+- **Belayer invokes `xt` as the Extend runtime adapter**
+- **artifacts capture the resulting environment state, health, and verification evidence**
+
+In other words: Belayer should not reinvent a generic workbench if Extend-localenv already models the Extend environment well.
+
+### extend-clamshell beyond MVP
+
+Clamshell should scale into Nightshift as the **production sandbox boundary**.
+
+The current tmux-based transport and local filesystem execution are useful for proving the run model. But for higher trust and Linux worker deployment, clamshell provides:
+
+- deny-by-default egress
+- host-owned credential mediation
+- explicit policy control
+- runtime inspection and audit surfaces
+- stronger separation between trusted runtime and untrusted agent execution
+
+The intended future relationship is:
+
+- **Nightshift daemon** assigns a request to a worker
+- **worker** provisions a run namespace and sandbox policy
+- **Belayer daemon** runs inside that worker namespace as the agent control plane
+- **Hermes harnesses** execute inside or against clamshell-constrained workspaces
+- **xt/localenv** brings up Extend runtime dependencies for validation
+
+### Why both matter together
+
+These two systems solve different scaling problems:
+
+- **extend-localenv** answers: "how do we make the Extend app/api stack runnable and testable?"
+- **extend-clamshell** answers: "how do we make the coding agent environment trustworthy and bounded?"
+
+Nightshift needs both.
+
+### Practical future topology
+
+The likely near-future production shape is:
+
+1. Nightshift daemon manages a small pool of Linux workers
+2. each worker runs one active request at a time
+3. each active request gets a run-local Belayer daemon
+4. Belayer spawns Hermes specialists for that run
+5. clamshell constrains code execution / egress
+6. xt provides the Extend runtime/workbench behavior
+7. Belayer records artifacts, events, and handoff outputs
+
+That gives us parallelism at the **worker** level while keeping the run model simple inside each worker.
 
 ---
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,53 +1,114 @@
 # Design
 
-Status: `implemented` — v6 session runtime (2026-04-09)
+Status: `active redesign` — Nightshift v1 / Extend-first direction (2026-04-15)
 
-## Qualities Achieved
+This file summarizes the practical design direction now that Belayer is being reshaped around Nightshift.
 
-- **Session-first UX**: Users think in sessions and templates, not node graphs.
-- **Observable state**: SQLite-backed events with FTS5 search; `belayer status` and `belayer logs`.
-- **Low ceremony**: `belayer daemon` + `belayer session start --template climb --input "task"` — no pipeline YAML.
-- **Recoverable operations**: SQLite WAL mode, daemon graceful shutdown, session state persisted.
-- **Vendor-agnostic core**: Adapter interface with Claude/Codex/Generic implementations.
-- **Isolation by default**: Clamshell sandboxes provide deny-by-default egress, host-owned credentials, per-binary policy. Belayer never builds its own isolation.
+## What changed
 
-## Key Patterns
+Belayer started as a more generic session runtime for autonomous coding agents.
 
-- **Three-tier memory** (Letta-inspired): **Core** — session-scoped key-value pairs, always injected into prompts, upsert semantics for fast updates. **Archival** — append-only long-term learnings with provenance (session, source file, date, tags), full-text searchable via FTS5. **Recall** — on-demand combined view: core entries for the current session + archival search results for a query. Markdown files on disk are authoritative; SQLite FTS5 is a derived index rebuilt from markdown via `RebuildIndex` on fresh clones.
-- **Scion messaging**: Broker with bracketed paste delivery via tmux, 2s debounce for coalescing rapid messages, urgent bypass.
-- **Pilot-always-present**: Climb sessions enforce pilot (opus) + implementer (sonnet) + reviewer (codex) trio. Pilot orchestrates, facilitates PR-based review loops, detects cross-repo drift in fullstack sessions. Review loops evolve via agent memory, not hardcoded rules.
-- **PR-based review loop**: Implementer creates PR → pilot routes to reviewer with spec context → reviewer provides fresh-eyes pass/fail → on fail, pilot sends feedback to implementer → iterate until pass. The reviewer is a different vendor (codex) with no implementation context — genuinely independent review.
-- **Agent memory & learning**: All agents get personal memory that persists across sessions. Pilot accumulates coordination patterns, implementers learn codebase conventions, reviewer's checklist evolves from experience. Post-session reflection consolidates both personal memory and shared institutional learnings.
-- **Clamshell sandbox**: Deny-by-default network, host-owned credentials via `inference.local` routing, per-binary egress policy, audit logging. Replaces Docker sandbox + tinyproxy model.
-- **Pluggable runtime**: `Runtime` interface in `internal/runtime/` with `LocalRuntime` (tmux), `DockerRuntime` (compose, legacy), `ClamshellRuntime` (sandbox). `Select()` dispatcher chooses backend based on CLI flags.
-- **Multi-repo mapping**: AgentSpec YAML supports optional `repo` field for per-agent repository targeting. Environment config maps repo names to paths via `ResolveRepoPath`.
-- **Per-session worktrees**: Each agent gets an isolated `git worktree` from `origin/main`, preventing agents from trampling each other's work or the user's checkout. Cleanup wired into session stop and `belayer session clean`.
-- **Sleep-time compute**: Post-session Reflector consolidates core memory into archival entries.
-- **Tiered agents** (data model): Main characters (persistent, peer-to-peer messaging), peripheral (session-scoped), ephemeral (task-scoped). `Tier` field on `AgentSpec`. Scion athenaeum pattern.
-- **Epic sessions**: Pilot-only roster for workspace orchestration. Pilot creates/monitors/stops child sessions for epic decomposition.
+The current direction is narrower and more concrete:
 
-## Planned Patterns
+- Extend-first before general abstraction
+- one worker, one request for v1
+- Belayer as the **run-local agent control plane**
+- Hermes as the default harness
+- tmux as the default transport adapter
+- artifacts/events/messages as the coordination substrate
 
-These are defined in the [sandbox runtime design doc](design-docs/2026-04-09-sandbox-runtime-architecture-design.md) and tracked as open issues:
+This is a deliberate scope correction, not a retreat.
 
-- **Workbench provisioning** (#43, #52): On-demand test infrastructure (`belayer workbench up/down`) with health checks and readiness detection. Workbench is distinct from sandbox — it's the application stack agents test against.
-- **Tool execution routing** (#44): User-defined tools in environment config, routed to agent/workbench/infra/host targets by the daemon with audit trail. Template variables auto-shell-quoted via `internal/shell/`.
-- **Tiered agent behavior** (#49): Dynamic spawning of peripheral and ephemeral agents at runtime (`belayer session add-agent --tier ephemeral`). Auto-cleanup on ephemeral completion.
-- **Pilot orchestration tools** (#50): Cross-session management — pilot calls `belayer session start/stop/list`, provisions workbenches, runs tools, monitors via event stream.
-- **Event-driven monitoring** (#53): SSE/long-poll endpoints replacing 2s polling. `belayer watch --sessions id1,id2` for multi-session pilots.
+---
 
-## Observability
+## Qualities we now care most about
 
-- **Streaming logs**: `belayer logs -f` polls events every 2s. `--since N` filters to last N minutes.
-- **Debug command**: `belayer debug <id>` aggregates session metadata, recent events, container health, and logs from exited agents.
-- **Agent self-observability**: Daemon socket available inside sandboxes. Agents can call `belayer recall`, `belayer note`, `belayer logs` from within their sandbox.
-- **Error trapping**: Container entrypoint traps EXIT and logs agent exit code to the session event store via `belayer note`.
-- **Restart context**: `belayer session wake --agent <name>` compiles event history into restart context for crashed agents. Vendor adapters provide `CompileRestartPrompt` for vendor-specific formatting.
+- **Run-local clarity**: Belayer should clearly own a single Nightshift run, not the whole worker fleet
+- **Observable coordination**: messages, events, roster state, and artifacts must make progress inspectable
+- **Low-ceremony execution**: simple run primitives (`run start`, `spawn`, `message`, `finish`, `artifact`) beat workflow DSLs
+- **Harness ownership**: Hermes is attractive because we can own profiles, skills, plugins, and behavior over time
+- **Transport pragmatism**: tmux is good enough for v1 because it is simple, inspectable, and harness-agnostic
+- **Explicit completion**: agents must call `belayer finish` or be marked blocked on exit
 
-## Session Templates
+---
 
-| Template | Agents | Purpose |
-|----------|--------|---------|
-| climb | 3 (pilot, implementer, reviewer) | Single-repo implementation with review loop |
-| climb-fullstack | 4 (pilot, api-impl, app-impl, reviewer) | Multi-repo implementation (e.g. API + frontend) |
-| epic | 1 (pilot) | Workspace orchestration — decomposes epics, creates parallel sessions |
+## Current key patterns
+
+### Two control planes
+
+- **Worker control plane** — outer Nightshift layer that assigns a worker
+- **Agent control plane** — Belayer inside the worker run
+
+Belayer only owns the second one.
+
+### Three Belayer layers
+
+1. **Session bus / control plane**
+2. **Harness driver**
+3. **Transport adapter**
+
+For v1 these map to:
+
+- session bus → Belayer daemon + store + broker
+- harness driver → Hermes launcher/profile binding
+- transport adapter → tmux
+
+### Communication split
+
+- **messages** for direct coordination
+- **events** for orchestration state
+- **artifacts** for durable shared outputs
+
+### Exit discipline
+
+Hermes runs are launched with Belayer env vars and a project-local plugin/skill.
+
+If an agent explicitly calls `belayer finish`, a finish marker is written.
+If the harness exits without that marker, Belayer marks the run `blocked`.
+
+This is now one of the most important reliability patterns in the stack.
+
+---
+
+## Current implemented behaviors
+
+Implemented today:
+
+- run-local session creation
+- planner spawn
+- api/planner message delivery through Belayer
+- run roster tracking
+- explicit `finish` / `blocked`
+- artifact registration and listing
+- Hermes project-local plugin + Belayer communication skill
+- exit-without-finish detection
+
+These are the real foundations of Nightshift v1.
+
+---
+
+## Planned behaviors
+
+Still planned / not complete yet:
+
+- idle nudge for agents that stay alive but do not call `belayer finish`
+- richer planner profile / specialist profiles
+- stronger artifact conventions and artifact viewing
+- Extend-localenv-first workbench flows
+- outer worker control-plane integration
+- canonical identity materialization beyond local profiles
+
+---
+
+## Practical design rule
+
+Belayer should not try to hide the fact that agent harnesses are real terminal programs.
+
+Instead:
+
+- keep the coordination surface explicit
+- keep the transport simple
+- make the system debuggable by humans
+- teach the agents the correct coordination protocol through profiles/skills/plugins
+
+This is why `belayer` CLI + Hermes skill/plugin remains the right v1 approach.

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -6,9 +6,21 @@ A portable specification for multi-agent coding runtimes.
 
 A multi-agent coding session — where multiple AI agents collaborate to write, review, and ship software — requires six infrastructure interfaces. These interfaces are the same regardless of which LLMs, vendors, or orchestration patterns power the agents.
 
-This document defines those interfaces, the invariants that bind them, and the agent roles that operate through them. It is a specification, not a product description. Belayer is one implementation in Go. The specification is language-agnostic and could be realized on any stack — including by composing existing open-source tools that fulfill individual interface contracts (Letta for memory, Scion for messaging and sandboxing, etc.).
+This document defines those interfaces, the invariants that bind them, and the agent roles that operate through them. It is a specification, not a product description. Belayer is one implementation in Go. The specification is language-agnostic and could be realized on any stack — including by composing existing open-source tools that fulfill individual interface contracts.
 
-Each interface solves a problem that agents cannot solve for themselves: sessions outlive agent crashes, sandboxes enforce boundaries agents can't self-impose, memory persists knowledge agents would otherwise lose, and communication bridges transport gaps between agents that don't share a runtime.
+## Current interpretation for Belayer
+
+The specification remains broad, but the current Belayer implementation effort is intentionally narrower:
+
+- **Nightshift v1 is Extend-first**
+- **one worker handles one request at a time**
+- Belayer is the **run-local agent control plane** inside that worker
+- Hermes is the preferred harness for v1
+- tmux is the preferred transport adapter for v1
+
+This means the philosophy is still portable, but the current implementation focus is not trying to prove every possible runtime variation at once.
+
+---
 
 ## The OS Analogy
 
@@ -30,15 +42,10 @@ The key property: applications don't need to know about each other's implementat
 ```mermaid
 flowchart TB
     S["<b>SESSION</b><br/>Lifecycle - Events - State<br/><i>The central primitive</i>"]
-
     O["<b>ORCHESTRATION</b><br/>Roster - Phases - Coordination<br/><i>Pilot reads team, adapts strategy</i>"]
-
     M["<b>MEMORY</b><br/>Core - Archival - Recall<br/><i>Knowledge that outlives sessions</i>"]
-
-    C["<b>COMMUNICATION</b><br/>Messaging - Delivery - Broadcast<br/><i>Transport between agents</i>"]
-
+    C["<b>COMMUNICATION</b><br/>Messaging - Delivery - Artifacts<br/><i>Transport between agents</i>"]
     T["<b>TOOLS</b><br/>Registry - Routing - Execution<br/><i>Capabilities agents invoke</i>"]
-
     SB["<b>SANDBOX</b><br/>Isolation - Credentials - Network<br/><i>Security boundary around agents</i>"]
 
     S --> O
@@ -47,10 +54,14 @@ flowchart TB
     O --> T
     C --> SB
     T --> SB
-    M -.->|"sleep-time<br/>(per-agent)"| S
+    M -.->|"sleep-time / consolidation"| S
 ```
 
-Session is the root primitive — everything is scoped to a session. Orchestration and Memory depend on Session. Communication and Tools are directed by Orchestration. Sandbox is where Communication and Tools physically execute. Memory feeds back into future Sessions via per-agent sleep-time compute.
+In the current Belayer/Nightshift interpretation:
+
+- Session is the run-local truth inside one worker run
+- Orchestration is planner-led but mediated through Belayer's session bus
+- Communication includes not only messages, but also typed events and durable artifacts
 
 ---
 
@@ -64,45 +75,46 @@ The session is the central primitive. It is the unit of work, the scope for stat
 - Append-only event log that survives agent crashes
 - Lifecycle management (create, run, stop, resume)
 - Queryable state (events, status, agent health)
-- Session-scoped identity for all agents
+- Session-scoped identity for all agents in the run
 
 **Inside this interface:**
 - Event storage and retrieval (structured, searchable)
 - Session metadata (template, status, timestamps, cost)
-- Agent lifecycle within the session (start, crash, wake)
+- Agent lifecycle within the session (start, exit, block, finish)
 - Restart context compilation from event history
+- Artifact registration for durable outputs
 
 **Outside this interface:**
 - What events mean (agent judgment)
 - When a session is "done" (orchestration judgment)
 - Where events are stored (SQLite, Postgres, files — implementation choice)
 
-**Why agents can't own this:** Agents crash. Their context windows fill. They get restarted on different machines. The session persists independently so that any agent — or a replacement — can resume from the event log.
+**Current Belayer interpretation:** one Belayer session per Nightshift run inside one worker.
 
 ---
 
 ### 2. Orchestration
 
-Orchestration determines who does what. The orchestrator (pilot) is an LLM that reads the team roster and adapts its coordination strategy to the task.
+Orchestration determines who does what. The orchestrator (planner/pilot) is an LLM that reads the team roster and adapts its coordination strategy to the task.
 
 **Contract:**
-- Declarative team rosters (agent name, vendor, model, role, tier)
-- Phase-based session templates (intake, implement, deliver)
-- Dynamic agent spawning (the orchestrator can expand the team at runtime)
-- Roster-adaptive coordination (same orchestrator works with any team shape)
+- Declarative team rosters (role, profile, repo scope, tier)
+- Dynamic agent spawning
+- Phase-aware coordination
+- Roster-adaptive task assignment
 
 **Inside this interface:**
-- Template definitions (which agents, which phases)
-- Agent tier system (main, peripheral, ephemeral)
-- Pilot system prompt with roster and available tools
-- Phase transitions and completion criteria
+- Role definitions
+- Planner capabilities
+- Spawn contract for specialists
+- Completion and blockage signaling
 
 **Outside this interface:**
-- The coordination logic itself (that's the pilot LLM's judgment)
-- Specific workflow sequences (those emerge from pilot reasoning + memory)
-- Review loop mechanics (the pilot decides when and how to route to review)
+- The coordination logic itself (that's the planner's judgment)
+- Exact workflow sequences for every task
+- Cluster-wide worker scheduling (that belongs to the outer Nightshift control plane)
 
-**Why this requires LLM judgment:** Different tasks need different coordination. A refactoring needs tight review loops. A greenfield feature needs loose exploration. A multi-repo change needs drift detection. No static workflow graph handles all cases — the pilot adapts because it reasons about the task, the code, and the team.
+**Current Belayer interpretation:** Belayer handles intra-run orchestration only, not worker assignment across machines.
 
 ---
 
@@ -112,23 +124,12 @@ The sandbox is the security boundary between the runtime (trusted) and agents (u
 
 **Contract:**
 - Network isolation (deny-by-default, allowlisted egress)
-- Credential isolation (agents never hold real secrets)
-- Filesystem boundaries (agents see only their workspace)
-- Per-agent worktrees (agents can't trample each other's work)
-- Pluggable backends (local, containers, VMs — same contract)
+- Credential isolation
+- Filesystem boundaries
+- Local workspace scope for the run
+- Pluggable enforcement backend
 
-**Inside this interface:**
-- Isolation enforcement (network, filesystem, process)
-- Credential proxying (real secrets injected at the boundary, not inside the sandbox)
-- Egress policy (per-binary or per-agent allowlists)
-- Worktree provisioning and cleanup
-- Audit logging of boundary violations
-
-**Outside this interface:**
-- Which isolation backend to use (Docker, clamshell, Podman, K8s — implementation choice)
-- What agents do inside the sandbox (the sandbox enforces boundaries, not behavior)
-
-**Why agents can't own this:** An agent told to "not access the database directly" might comply, or might not. An agent told to "not exfiltrate credentials" has the credentials in its context. The sandbox makes violations impossible rather than relying on compliance.
+**Current preferred implementation:** extend-clamshell for production-oriented runs, with Linux as the preferred deployment environment.
 
 ---
 
@@ -137,281 +138,92 @@ The sandbox is the security boundary between the runtime (trusted) and agents (u
 Communication is the transport layer between agents. Agents don't know each other's runtime — they send messages through the runtime, which handles delivery.
 
 **Contract:**
-- Point-to-point messaging (agent A to agent B)
-- Broadcast (agent A to all agents in session)
-- Delivery guarantees (coalescing, debounce, urgent bypass)
-- Transport-agnostic (tmux send-keys, stdin, API — agents don't care)
+- Point-to-point messaging
+- Broadcast
+- Delivery guarantees (coalescing, urgent bypass)
+- Transport abstraction (tmux, stdin, API — agents don't care)
+- Durable coordination artifacts
 
 **Inside this interface:**
 - Message routing and delivery
-- Debounce windowing (coalesce rapid messages into one delivery)
-- Urgent message bypass (interrupt debounce for critical updates)
+- Debounce windowing
+- Urgent bypass
 - Injection safety (bracketed paste or equivalent)
 - Message event logging
+- Artifact registration and lookup
 
 **Outside this interface:**
 - Message content or meaning (that's between the agents)
 - When to send messages (that's orchestration judgment)
-- Message persistence beyond delivery (that's a session event, not a communication concern)
+- Whether a message should instead be an artifact (agent judgment guided by skilling)
 
-**Why agents can't own this:** Agents run in different sandboxes, potentially on different machines, using different vendor CLIs with different input mechanisms. The runtime bridges these transport gaps transparently.
+**Current Belayer interpretation:** Belayer is the session bus. tmux is only the transport adapter. Agents should communicate through Belayer, never through raw tmux.
 
 ---
 
 ### 5. Memory
 
-Memory is knowledge that persists beyond any single agent invocation or session. The runtime owns memory infrastructure — storage, indexing, injection, and sleep-time triggers. Agents own their memory content — they decide what to remember, how to organize it, and when to prune.
+Memory is knowledge that persists beyond any single agent invocation or session. The runtime owns memory infrastructure — storage, indexing, injection, and consolidation triggers. Agents own their memory content — they decide what to remember, how to organize it, and when to prune.
 
 This follows the same principle as the rest of the spec: **the runtime handles plumbing, agents handle judgment.**
 
 **Contract:**
-- Three tiers with different access patterns:
-  - **Core** — always injected into agent prompts, small, frequently updated (the agent's identity)
-  - **Archival** — searchable long-term knowledge with provenance
-  - **Recall** — on-demand combined query across core and archival
-- Agent-managed memory (agents write their own memory via tools, same as editing code)
-- Personal agent memory (per-agent, persists across sessions, portable across harnesses)
-- Sleep-time compute (per-agent background consolidation during idle periods)
-- Staleness detection (entries carry provenance: session, date, source)
+- Core, archival, and recall layers or equivalents
+- Agent-managed memory
+- Portable identity across harnesses in principle
+- Background consolidation / sleep-time support
+- Provenance and staleness awareness
 
-**Inside this interface:**
-- Memory storage, indexing, and retrieval across all three tiers
-- Memory injection into agent prompts at session start
-- Sleep-time trigger mechanism (on idle, every N turns, on context compaction)
-- Git-backed versioning of memory files (rollback, conflict resolution, audit trail)
-
-**Outside this interface:**
-- What to remember (agent judgment — the agent decides what's worth keeping)
-- How to organize memory (agent judgment — file hierarchy, indexes, references)
-- Storage backend (SQLite FTS5, vector DB, markdown files, git repos — implementation choice)
-
-**Why the runtime still owns this interface:** Agents manage their own memory content, but the runtime provides the infrastructure that makes it durable and searchable. Without the runtime: memory doesn't survive crashes, there's no full-text search across sessions, there's no trigger mechanism for sleep-time consolidation, and there's no versioning for rollback. The agent writes; the runtime persists.
+**Current Belayer interpretation:** memory architecture remains aspirational. The current MVP relies more heavily on Hermes profiles, skills, project-local plugins, and explicit run artifacts than on a fully realized Belayer-owned long-term identity system.
 
 ---
 
 ### 6. Tools
 
-Tools are capabilities that agents invoke through the runtime. The runtime routes execution to the correct target — the same tool call might execute in the agent's sandbox, a workbench container, the host, or a remote service.
+Tools are capabilities that agents invoke through the runtime. The runtime routes execution to the correct target.
 
 **Contract:**
-- Declarative tool registry (name, description, input schema, execution target)
-- Execution routing (sandbox, workbench, host, infrastructure)
-- Safety guarantees (parameter quoting, timeouts, audit logging)
-- Environment-specific tool sets (different environments expose different tools)
+- Declarative tool registry
+- Execution routing
+- Safety guarantees
+- Environment-specific tool sets
 
-**Inside this interface:**
-- Tool definitions and discovery
-- Execution target routing and dispatch
-- Parameter validation and shell-safe interpolation
-- Workbench provisioning (on-demand test infrastructure — a tool with lifecycle)
-- Database access proxying (read-only enforcement, connection routing)
-- Session management tools (the orchestrator creates/monitors child sessions through tools)
+**Current Belayer interpretation:** tools now include not just shell-like execution, but also run-local coordination primitives such as:
 
-**Outside this interface:**
-- Which tools to call (agent judgment)
-- Tool implementation details (a shell command, an API call, a container — the registry abstracts this)
-- When to provision infrastructure (orchestration judgment)
+- `belayer spawn`
+- `belayer message`
+- `belayer note`
+- `belayer finish`
+- `belayer artifact`
 
-**Workbench as a tool, not an interface:** A workbench (running application stack for integration testing) is provisioned through the Tools interface. It has lifecycle (up/down/health), but it's a capability agents invoke, not a contract every session requires. Single-repo refactoring doesn't need a workbench. Similarly, database access, migration runners, and deployment triggers are all tools — capabilities with varying complexity, routed by the runtime, invoked by agents.
+These are not generic shell conveniences — they are part of the run control protocol.
 
 ---
 
 ## Agent Identity
 
-An agent is not a process — it's an identity. The process (Claude Code, Codex, Letta, any harness) is the runtime detail. The identity is what persists.
+An agent is not a process — it's an identity. The process (Hermes, Claude Code, Codex, Letta, etc.) is the runtime detail. The identity is what persists.
 
-Each agent is defined by a portable directory of files:
+### Current Belayer/Nightshift MVP stance
 
-```
-.belayer/agents/api-implementer/
-├── config.yaml              ← vendor, model, role, tier
-├── system-prompt.md         ← role identity and instructions
-├── sleep-prompt.md          ← deep sleep consolidation instructions
-├── memory/
-│   └── system/              ← core memory (pinned to context window)
-│       ├── identity.md      ← "I am a backend implementer. Kotlin/Spring Boot."
-│       ├── codebase.md      ← "Rate limiter is in middleware/. Register in PermissionRegistry.kt."
-│       └── patterns.md      ← "Reviewer catches missing SpiceDB checks. Always add them."
-└── skills/                  ← learned behaviors from past sessions
-    └── flyway-migration/
-        └── SKILL.md         ← "When adding a column, create a reversible migration..."
-```
+For the MVP, identity is injected in a simpler layered way:
 
-**Context is identity.** What an agent has in its memory files determines who it is — its expertise, its patterns, its accumulated knowledge. The model weights are the substrate; the memory is the self. This means:
+- Hermes profile selection
+- Belayer environment variables (`BELAYER_SESSION_ID`, `BELAYER_AGENT_ID`, etc.)
+- project-local Hermes plugin support
+- project-local Belayer communication skill
+- workdir / repo binding
 
-- The same agent identity loaded into Claude Code or Codex or Letta produces the same "personality" — adapted to each harness, but carrying the same knowledge
-- Memory files are git-backed, versioned, and portable
-- An agent's identity survives model upgrades, vendor swaps, and framework changes
-- Over N sessions, the agent becomes an expert at its role for this codebase
+This is enough to get a working, owned, inspectable system before solving full canonical cross-machine identity materialization.
 
-**Sleep-time compute** is how agents consolidate experience. Each agent has a sleep-time prompt (`sleep-prompt.md`) that governs how it processes its own session events during idle periods. The runtime triggers sleep-time; the agent decides what to remember.
-
-- Runs per-agent during idle periods, between turns, or post-session
-- The agent reviews its own events and updates its own memory files
-- Consolidates raw observations into generalized patterns (not event logs)
-- Prunes stale facts while preserving identity markers
-- The orchestrator's sleep-time naturally produces cross-agent learnings because the orchestrator already has cross-agent visibility
+Longer term, a git-backed canonical identity model remains compatible with this philosophy.
 
 ---
 
-## Agent Roles
+## Final note
 
-The specification defines three structural roles. Implementations may use different names, but the roles map to distinct interface dependencies and trust boundaries.
+The philosophy still aims at a portable multi-agent runtime model.
 
-| Role | Primary Interfaces | Key Property |
-|---|---|---|
-| **Orchestrator** | Orchestration, Communication, Tools | Adapts coordination to roster and task |
-| **Worker** | Sandbox, Communication, Tools | Operates in isolation, produces artifacts |
-| **Validator** | Communication, Sandbox (read-only) | Context-isolated from workers |
+But the current implementation discipline is:
 
-All roles share the Memory interface — every agent manages its own memory and has its own sleep-time process.
-
-```mermaid
-sequenceDiagram
-    participant O as Orchestrator
-    participant W as Worker
-    participant V as Validator
-
-    Note over O,V: IMPLEMENT PHASE
-    O->>W: Task + spec context
-    W->>W: Code in isolated sandbox
-    W-->>O: PR artifact created
-
-    O->>V: Review PR (spec context only — no implementation context)
-    V-->>O: PASS / FAIL + structured feedback
-
-    alt Review FAIL
-        O->>W: Feedback from validator
-        W->>W: Fix in sandbox
-        W-->>O: Changes pushed
-        O->>V: Re-review
-        V-->>O: PASS
-    end
-
-    Note over O: SLEEP-TIME (orchestrator)
-    O->>O: Consolidate cross-agent coordination patterns
-
-    Note over W: SLEEP-TIME (worker)
-    W->>W: Consolidate codebase patterns
-
-    Note over V: SLEEP-TIME (validator)
-    V->>V: Refine review checklist from experience
-```
-
-### Orchestrator
-
-Coordinates the session. Decomposes tasks, assigns work, monitors progress, decides completion. Always an LLM — never a state machine.
-
-- Reads team roster from template, adapts coordination to team shape
-- Sends instructions via Communication, monitors progress via Session events
-- Can dynamically spawn ephemeral agents via Tools
-- In epic sessions, orchestrates across multiple child sessions
-- **Sleep-time produces cross-agent patterns** — the orchestrator sees all agents' events, so its memory consolidation naturally captures institutional knowledge ("app-implementer forgets TypeScript types when API changes")
-
-### Worker
-
-Writes code, runs tests, creates artifacts. Operates inside a Sandbox.
-
-- Receives tasks via Communication
-- Executes in an isolated Sandbox with a dedicated worktree
-- Creates PRs, runs tests — all within sandbox boundaries
-- Reports progress via Session events
-- **Sleep-time produces codebase expertise** — patterns, conventions, common pitfalls ("always register in PermissionRegistry.kt")
-
-### Validator
-
-Provides independent review. The critical property is **context isolation**: the validator has no access to implementation context — only the artifacts (PR diffs, test results) and the original spec.
-
-- Receives review requests from orchestrator (never directly from worker)
-- Reads artifacts in a read-only sandbox
-- Provides structured pass/fail feedback
-- **Must be a different vendor or model than the worker** — architecturally enforced independence
-- **Sleep-time produces review expertise** — an evolving checklist built from experience ("missing SpiceDB permission checks — caught 5 times")
-
----
-
-## Agent Tiers
-
-Agents operate at three tiers of persistence:
-
-| Tier | Lifetime | Messaging | Spawned by | Example |
-|---|---|---|---|---|
-| **Main** | Persistent across sessions | Peer-to-peer | Template | Pilot, primary implementers |
-| **Peripheral** | Session-scoped | Receives instructions | Template | Reviewer, secondary workers |
-| **Ephemeral** | Task-scoped, auto-cleanup | Receives instructions | Orchestrator at runtime | Research agent, migration helper |
-
-Templates define the starting lineup. The orchestrator expands the team at runtime based on discovered needs — spawning an ephemeral agent to research a dependency, or a peripheral worker for a repo that unexpectedly needs changes.
-
----
-
-## The Phased Session Model
-
-Sessions follow a three-phase model. Phases are structural guidance, not rigid state machines — the orchestrator decides when to transition based on its judgment.
-
-```mermaid
-flowchart LR
-    I["<b>INTAKE</b><br/>Spec generation<br/>Requirements analysis<br/>Task decomposition"]
-
-    IM["<b>IMPLEMENT</b><br/>Code writing<br/>Review loops<br/>Cross-repo coordination"]
-
-    D["<b>DELIVER</b><br/>QA validation<br/>Integration testing<br/>Merge readiness"]
-
-    I --> IM --> D
-    IM -->|"review<br/>failure"| IM
-```
-
-**Intake** — A single agent analyzes the input (ticket, description, design doc) and produces a structured specification. The spec becomes the source of truth for the implement phase.
-
-**Implement** — The orchestrator decomposes the spec, assigns work, and facilitates review loops. Workers implement in isolated sandboxes. Validators review with fresh eyes and no implementation context. The loop continues until all artifacts pass validation. For multi-repo sessions, the orchestrator monitors parallel workers and intervenes on semantic drift.
-
-**Deliver** — QA validation, integration testing (via workbench tools), and merge readiness. The orchestrator provisions test infrastructure, runs end-to-end validation, and confirms all artifacts are compatible.
-
-**Epic (cross-session orchestration)** — An orchestrator-only session. It analyzes a large body of work (a Jira epic, a multi-ticket initiative), creates parallel implement sessions for independent tasks, monitors progress via event streams, and triggers integration testing at milestones.
-
----
-
-## Cross-Cutting Invariants
-
-These hold regardless of implementation:
-
-1. **The orchestrator is an LLM, not a state machine.** Coordination requires understanding code, specs, and intent. Heuristics break on every new codebase. The orchestrator adapts through reasoning and accumulated memory, not rules.
-
-2. **Context isolation is a feature, not a limitation.** The validator's independence is architecturally enforced — different vendor, no implementation context, separate sandbox. An agent reviewing work it watched being written is performing sycophantic self-review.
-
-3. **Agent identity is portable; agent processes are disposable.** An agent's identity (memory files, skills, config) persists across sessions and survives harness swaps. But the process running the agent is cattle — it can crash and be replaced. The session event log provides process continuity. The memory directory provides identity continuity. A replacement process receives compiled restart context and the agent's full identity files.
-
-4. **Agents learn through sleep-time compute.** Every agent consolidates its own experience during idle periods — the orchestrator learns coordination patterns, workers learn codebase conventions, validators refine their review checklists. Memory should generalize (patterns and indexes), not memorize (raw event logs). Over N sessions, each agent becomes an expert at its role for this codebase.
-
-5. **Vendor-agnostic by contract.** The orchestrator could be Claude, the worker Codex, the validator Gemini. Vendor adapters normalize output format, token tracking, and message delivery. Swapping a vendor changes an adapter, not the architecture.
-
-6. **The runtime handles plumbing; agents handle judgment.** The runtime never decides what code to write, whether a review should pass, or how to decompose a spec. It provides sessions, delivers messages, enforces isolation, persists memory, and routes tools. Every decision that requires understanding code or intent belongs to an agent.
-
----
-
-## What the Spec Does Not Own
-
-- **Agent intelligence** — the spec coordinates agents, it doesn't make them smart
-- **Code editing, testing, or deployment** — agents do this inside sandboxes
-- **CI/CD pipelines** — the spec delivers artifacts (PRs); CI runs independently
-- **Specific workflow sequences** — templates define rosters and phases; the orchestrator decides the workflow
-- **Plugin or extension systems** — the spec is six interfaces, not a platform
-- **Language or framework conventions** — agents bring their own domain knowledge
-
----
-
-## On Portability
-
-Each interface can be sourced from existing tools:
-
-| Interface | Existing implementations |
-|---|---|
-| Session | SQLite, Postgres, append-only log files |
-| Orchestration | Any LLM with tool use (Claude, GPT, Gemini) |
-| Sandbox | Docker, Podman, clamshell, Kubernetes, Firecracker |
-| Communication | Scion message broker, NATS, Redis pub/sub, Unix pipes |
-| Memory | Letta (three-tier + sleep-time reflection), any vector DB + markdown |
-| Tools | MCP servers, shell commands, API gateways |
-
-The spec's value is not any single interface — it's the composition. How sessions scope memory. How orchestration directs communication. How sandboxes bound tool execution. How sleep-time compute feeds agent experience back into future sessions. The interfaces are individually simple; their composition is what makes multi-agent coding sessions reliable.
-
-An implementation that fulfills all six interface contracts — whether as a monolithic daemon, a composed set of existing tools, or a library — is a conforming runtime. The test is behavioral: does the system provide session persistence, LLM-driven orchestration, enforced isolation, transparent messaging, agent-managed memory with sleep-time consolidation, and routed tool execution?
+> keep the philosophy broad, keep the implementation narrow enough to finish.

--- a/docs/design-docs/2026-04-15-belayer-run-model-for-nightshift-v1.md
+++ b/docs/design-docs/2026-04-15-belayer-run-model-for-nightshift-v1.md
@@ -1,0 +1,600 @@
+---
+status: proposed
+created: 2026-04-15
+supersedes:
+implemented-by:
+consulted-learnings:
+  - docs/PHILOSOPHY.md
+  - docs/ARCHITECTURE.md
+  - docs/CLAUDE.md
+  - docs/design-docs/2026-04-15-nightshift-v1-deployment-topology.md
+---
+
+# Belayer Run Model for Nightshift v1
+
+This document defines Belayer's role inside a single Nightshift v1 worker run.
+
+It intentionally narrows scope.
+
+For v1:
+
+- one worker handles one request at a time
+- one Belayer session exists inside that worker
+- Belayer is the **agent control plane for that one run**
+- Hermes is the default harness
+- tmux is the default transport driver
+
+The goal is not to design a universal protocol for all future agent systems. The goal is to make one planner-led multi-agent coding run work reliably for Extend.
+
+---
+
+## Core framing
+
+Belayer should be modeled as three layers.
+
+### Layer 1: Session bus / control plane
+
+This is the actual Belayer role.
+
+It owns:
+
+- session creation and lifecycle
+- agent roster for the run
+- typed messages and events
+- artifact registration and lookup
+- delivery routing
+- run-local observability
+- planner-facing orchestration primitives
+
+Belayer should be the source of truth for **who exists, what happened, and what artifacts are authoritative** inside a run.
+
+### Layer 2: Harness driver
+
+This is how Belayer launches and talks to an agent harness.
+
+For v1, the primary harness is Hermes.
+
+The harness driver owns:
+
+- how the harness process starts
+- what environment variables it receives
+- what profile/identity is loaded
+- how Belayer delivers instructions into the harness
+- how Belayer captures output for logs/debugging
+
+Belayer should define an abstract driver contract, but only Hermes needs to be first-class in v1.
+
+### Layer 3: Transport adapter
+
+This is the concrete I/O path used by the harness driver.
+
+For v1, tmux is the default transport adapter.
+
+The transport adapter owns:
+
+- create session/pane
+- send keys or bracketed paste
+- capture pane output
+- attach for human debugging
+- stop/interrupt the process
+
+This keeps tmux in the right place:
+
+> tmux is the transport mechanism, not the control plane.
+
+---
+
+## Why these three layers matter
+
+They let us separate concerns cleanly.
+
+- If Hermes remains the harness but tmux becomes too limiting later, we can keep Belayer and swap the transport adapter.
+- If we later want Claude Code or Codex as alternative harnesses, we can add new harness drivers without rewriting the Belayer run model.
+- If we never add those other harnesses, this still gives us a clean internal architecture instead of accidental coupling.
+
+For v1, though, the practical stance is:
+
+- **Belayer session bus** = first-class
+- **Hermes harness driver** = first-class
+- **tmux transport adapter** = first-class
+- everything else = deferred
+
+---
+
+## High-level diagram
+
+```mermaid
+flowchart TB
+    subgraph BelayerRun["Belayer run-local agent control plane"]
+        SB["Layer 1: Session Bus\nmessages, events, artifacts, roster"]
+        HD["Layer 2: Harness Driver\nHermes runner + launch contract"]
+        TA["Layer 3: Transport Adapter\ntmux sessions / send-keys / capture-pane"]
+    end
+
+    SB --> HD
+    HD --> TA
+    TA --> Planner["Hermes planner"]
+    TA --> API["Hermes api specialist"]
+    TA --> APP["Hermes app specialist"]
+    TA --> REV["Hermes reviewer"]
+    TA --> QA["Hermes qa"]
+
+    Planner --> Artifacts[("artifacts/")]
+    API --> Artifacts
+    APP --> Artifacts
+    REV --> Artifacts
+    QA --> Artifacts
+```
+
+---
+
+## The Belayer session bus
+
+The session bus is the part we should optimize first.
+
+### Responsibilities
+
+Inside one run, Belayer must answer:
+
+- what agents exist?
+- what role does each one have?
+- what phase is the run in?
+- what messages have been sent?
+- what events have occurred?
+- what artifacts are available?
+- what is blocked, in progress, or ready for review?
+
+### Suggested core objects
+
+#### Run
+Outer identity for one Nightshift request on one worker.
+
+Suggested fields:
+
+- `run_id`
+- `ticket_ref`
+- `worker_id`
+- `status` (`preparing|running|reviewing|handoff|completed|failed`)
+- `sandbox_ref`
+- `started_at`
+- `finished_at`
+
+#### Session
+Belayer's run-local coordination context.
+
+Suggested fields:
+
+- `session_id`
+- `run_id`
+- `phase` (`intake|planning|implementation|review|qa|handoff`)
+- `planner_agent_id`
+- `current_summary`
+
+#### AgentRun
+One launched harness instance for a role.
+
+Suggested fields:
+
+- `agent_id`
+- `role` (`planner|api|app|reviewer|qa`)
+- `harness` (`hermes` for v1)
+- `profile`
+- `transport` (`tmux` for v1)
+- `tmux_session`
+- `workspace_path`
+- `repo_scope`
+- `status` (`starting|idle|busy|blocked|complete|failed|stopped`)
+
+#### Message
+Directed communication mediated by Belayer.
+
+Suggested fields:
+
+- `message_id`
+- `session_id`
+- `from_agent`
+- `to_agent`
+- `kind`
+- `body`
+- `urgent`
+- `created_at`
+- `delivered_at`
+
+#### Event
+Machine-readable state transition or observation.
+
+Suggested event kinds:
+
+- `agent_started`
+- `agent_output`
+- `message_sent`
+- `message_delivered`
+- `artifact_created`
+- `artifact_updated`
+- `task_assigned`
+- `blocked`
+- `needs_review`
+- `verification_passed`
+- `verification_failed`
+- `handoff_ready`
+
+#### Artifact
+Durable coordination object.
+
+Suggested artifact kinds:
+
+- `ticket-intake`
+- `task-graph`
+- `shared-contract`
+- `specialist-report`
+- `review-report`
+- `verification-report`
+- `handoff`
+
+---
+
+## The other two layers
+
+### Layer 2: Hermes harness driver
+
+This layer turns a Belayer `AgentRun` into a live Hermes process.
+
+For v1, the Hermes driver should own:
+
+- selecting the Hermes profile for the role
+- setting `BELAYER_SESSION_ID`
+- setting `BELAYER_AGENT_ID`
+- setting daemon socket path
+- setting workspace cwd
+- optionally loading a Belayer communication skill
+- starting Hermes in the correct terminal mode
+- registering pane capture
+
+#### Hermes driver contract
+
+Belayer should conceptually expose something like:
+
+- `Launch(run, roleConfig) -> AgentRun`
+- `DeliverMessage(agentRun, envelope)`
+- `Interrupt(agentRun, envelope)`
+- `Capture(agentRun) -> output`
+- `Attach(agentRun)`
+- `Stop(agentRun)`
+
+The Hermes driver is where we encode Hermes-specific knowledge. Belayer's session bus should not know how Hermes CLI arguments work.
+
+### Layer 3: tmux transport adapter
+
+This layer is deliberately dumb.
+
+It should only know how to:
+
+- create a tmux session
+- send bracketed-paste text
+- send Enter
+- optionally send Ctrl+C
+- capture pane contents
+- attach or kill
+
+This is why tmux is a good v1 fit:
+
+- it works with Hermes today
+- it works with Claude Code / Codex later if needed
+- it is debuggable by humans
+- it avoids inventing a custom protocol before we need one
+
+But tmux should remain below the harness driver.
+
+---
+
+## How agent communication should work
+
+Agents should **not** directly know about tmux session names or other agents' terminals.
+
+All communication should go through Belayer.
+
+### Desired mental model for agents
+
+When an agent wants to:
+
+- ask another specialist a question
+- hand off work
+- report a blocker
+- publish an artifact
+- request review
+
+it should think:
+
+> "Use Belayer."
+
+Not:
+
+> "I should directly message that other terminal."
+
+### Communication path
+
+```mermaid
+sequenceDiagram
+    participant Planner as Hermes planner
+    participant BC as Belayer CLI/skill
+    participant BS as Belayer session bus
+    participant HD as Hermes driver
+    participant TM as tmux transport
+    participant API as Hermes api specialist
+
+    Planner->>BC: belayer message send --to api "Need endpoint contract confirmation"
+    BC->>BS: POST message
+    BS->>HD: deliver envelope to api agent
+    HD->>TM: send bracketed paste to api tmux session
+    TM->>API: message appears in terminal
+    API->>BC: belayer note "Will respond after schema check"
+    BC->>BS: POST event
+```
+
+### Preferred communication types
+
+#### 1. Direct message
+For targeted questions/instructions.
+
+Examples:
+
+- planner → api specialist
+- reviewer → planner
+- qa → planner
+
+#### 2. Event
+For status changes.
+
+Examples:
+
+- `blocked`
+- `needs_review`
+- `artifact_created`
+
+#### 3. Artifact publication
+For durable outputs.
+
+Examples:
+
+- shared contract
+- specialist report
+- verification report
+
+This is the important split:
+
+- **messages** are for conversation
+- **events** are for orchestration state
+- **artifacts** are for durable shared outputs
+
+---
+
+## How we teach Hermes agents to use Belayer
+
+This needs to be explicit.
+
+We should not assume the agent will naturally invent the correct communication behavior.
+
+For v1, the answer is:
+
+> **yes — Belayer CLI plus a Hermes skill is the right approach**
+
+### Why this is the best v1 approach
+
+It has several benefits:
+
+- simplest to implement
+- visible and git-traceable
+- easy to iterate on in prompts/skills
+- does not require custom Hermes core changes
+- keeps Belayer in control of the session bus
+- works with tmux-based harness execution
+
+### What the skill should teach
+
+Every Nightshift specialist profile should load a Belayer communication skill that says, in effect:
+
+1. You are operating inside a Belayer-managed session.
+2. Never attempt to contact other agents directly.
+3. When you need another specialist or the planner, use `belayer message send`.
+4. When you learn something the whole run should know, use `belayer note` or write an artifact.
+5. When you create a durable output, register it as an artifact through Belayer.
+6. If you are blocked, emit a blocker note/event rather than waiting silently.
+7. If you need review, send the planner a message and publish the supporting artifact.
+
+### Minimum runtime environment for each Hermes run
+
+Each run should receive at least:
+
+- `BELAYER_SESSION_ID=<session-id>`
+- `BELAYER_AGENT_ID=<role-id>`
+- `BELAYER_SOCKET=<daemon-socket>`
+- `BELAYER_RUN_DIR=<run-dir>`
+
+That makes commands simple inside the agent:
+
+```bash
+belayer message send --to planner "I need the shared API contract clarified"
+belayer note "Blocked on auth token shape mismatch"
+```
+
+No extra flags required in the common case.
+
+---
+
+## Recommended Hermes profile pattern
+
+For v1, each Hermes specialist should have:
+
+- a stable profile name
+- a role-specific persona
+- role-specific repo skills
+- the Belayer communication skill
+- explicit guidance that Belayer is the coordination substrate
+
+Example profiles:
+
+- `nightshift-planner`
+- `nightshift-extend-api`
+- `nightshift-extend-app`
+- `nightshift-reviewer`
+- `nightshift-qa`
+
+### Belayer communication skill outline
+
+The skill should contain sections like:
+
+- when to message the planner
+- when to message another specialist
+- when to create a note
+- when to publish an artifact
+- when to stop and mark blocked
+- examples of exact CLI commands
+
+This is preferable to relying only on generic system prompt text because:
+
+- it is reusable
+- it is versioned
+- it is inspectable in git
+- it can evolve as the run model matures
+
+---
+
+## What Belayer should expose to agents in v1
+
+The CLI surface does not need to be huge.
+
+For v1, agents mainly need:
+
+### Messaging
+
+- `belayer message send --to <agent> "..."`
+- `belayer message broadcast "..."`
+
+### Session observation
+
+- `belayer context`
+- `belayer logs <session>` or session-scoped equivalent
+
+### Notes and status
+
+- `belayer note "..."`
+
+### Artifact operations
+
+Belayer should likely add a small artifact CLI for Nightshift v1:
+
+- `belayer artifact create --kind shared-contract --path artifacts/shared-contract.md`
+- `belayer artifact list`
+- `belayer artifact show <artifact-id>`
+
+That would make the artifact bus as explicit as the message bus.
+
+---
+
+## Planner-centric communication contract
+
+The planner should remain the primary coordinator.
+
+That means most specialist traffic should look like one of these:
+
+### Specialist → planner
+
+- question
+- blocker
+- completion notice
+- review request
+- artifact ready
+
+### Planner → specialist
+
+- task assignment
+- clarification
+- shared contract update
+- review feedback
+- resume / stop / reprioritize
+
+### Specialist ↔ specialist
+
+Allowed, but only when valuable.
+
+Examples:
+
+- api asks app to confirm shape assumptions
+- app asks api for endpoint semantics
+
+Even then, Belayer should still mediate it, and the planner should remain able to inspect the conversation in the event log.
+
+This keeps the system from turning into uncontrolled peer-to-peer chatter.
+
+---
+
+## What not to do in v1
+
+### Do not teach agents to target tmux directly
+
+Agents should never need to know pane names, session names, or send-keys details.
+
+### Do not make every interaction a freeform conversation
+
+Promote:
+
+- artifacts for durable outputs
+- typed events for state transitions
+- direct messages only when needed
+
+### Do not depend on harness-specific hidden magic
+
+The Belayer communication model should remain explicit and inspectable.
+
+### Do not attempt equal multi-harness support immediately
+
+Hermes-first is the right choice for v1.
+
+---
+
+## Proposed v1 implementation sequence
+
+### Step 1: Formalize the three layers in code
+
+Belayer packages should move toward:
+
+- `internal/runbus/` or reuse daemon/store/broker as the session bus layer
+- `internal/harness/hermes/`
+- `internal/transport/tmux/`
+
+Exact package names can vary, but the separation should become explicit.
+
+### Step 2: Make Hermes the default harness driver
+
+Stop centering vendor adapters as the primary abstraction for Nightshift.
+
+### Step 3: Add a Belayer communication skill for Hermes specialists
+
+This is the main behavioral teaching mechanism.
+
+### Step 4: Add artifact CLI support
+
+Without this, too much state stays trapped in prose and logs.
+
+### Step 5: Ensure all inter-agent communication routes through Belayer
+
+Belayer should remain the authoritative session bus, even if tmux is the transport underneath.
+
+---
+
+## Final recommendation
+
+For Nightshift v1, the right model is:
+
+- **Belayer = session bus / control plane inside one run**
+- **Hermes = default harness for specialist identities**
+- **tmux = transport adapter, not architecture**
+- **Belayer CLI + Hermes communication skill = primary way agents coordinate**
+
+That is the smallest coherent system that:
+
+- we can own
+- we can inspect
+- we can version
+- we can teach
+- and we can evolve without waiting for another vendor to define our orchestration model

--- a/docs/design-docs/2026-04-15-nightshift-extend-first-architecture.md
+++ b/docs/design-docs/2026-04-15-nightshift-extend-first-architecture.md
@@ -1,0 +1,847 @@
+---
+status: proposed
+created: 2026-04-15
+supersedes:
+implemented-by:
+consulted-learnings:
+  - docs/PHILOSOPHY.md
+  - docs/ARCHITECTURE.md
+  - docs/design-docs/2026-04-09-sandbox-runtime-architecture-design.md
+  - ~/Documents/Programs/work/CLAUDE.md
+  - ~/Documents/Programs/work/extend-localenv/README.md
+  - ~/Documents/Programs/work/extend-localenv/docs/specs/2026-04-08-rename-to-extend-localenv-design.md
+  - ~/Documents/Programs/work/extend-clamshell/README.md
+  - ~/Documents/Programs/work/extend-clamshell/docs/clamshell.md
+---
+
+# Nightshift Architecture for Extend-First Execution
+
+Belayer should first become a working overnight engineering system for Extend, then abstract the stable pattern. This document updates the current Belayer architecture with that bias.
+
+## Why this design exists
+
+The earlier Belayer direction was conceptually strong but too easy to fizzle out in implementation because too many things were still hypothetical at once:
+
+- a generic multi-agent runtime
+- a generic sandbox runtime
+- a generic workbench layer
+- generic agent identities tied to local vendor CLIs
+- generic YAML workflow definitions
+
+That stack left too much surface area under active invention.
+
+The Extend environment gives us a much sharper target:
+
+- `extend-api` and `extend-app` are the primary fullstack repos
+- `extend-localenv` already owns important local environment setup/teardown behavior via `xt`
+- `extend-clamshell` already owns the security boundary for single-host sandboxing
+- Hermes provides a persistent agent harness with identities, memory, skills, delegation, and remote continuity that do **not** need to live only on the client machine
+
+The goal is to stop designing a universal theory of agent orchestration and instead build a concrete, trustworthy Nightshift system for Extend.
+
+---
+
+## Design thesis
+
+Nightshift should be:
+
+> a **Belayer-style control plane** that orchestrates **persistent Hermes specialist identities** running inside **extend-clamshell sandboxes**, using **extend-localenv** as the workbench/environment substrate for Extend-specific bring-up, teardown, and verification.
+
+This keeps the strongest parts of Belayer:
+
+- session as the root primitive
+- orchestration as LLM judgment inside explicit interfaces
+- sandbox as a real trust boundary
+- communication and tools as runtime services, not prompt tricks
+- memory and identity as durable assets
+
+But it changes a critical implementation assumption:
+
+> the durable agent identity should no longer be assumed to live only inside a local vendor CLI process on the same machine as the runtime.
+
+Hermes is useful precisely because the identity layer can persist separately from any one invoked run.
+
+---
+
+## What remains correct in current Belayer
+
+The following ideas should stay intact.
+
+### 1. The six interfaces
+
+Belayer's six interfaces are still the right abstraction boundary:
+
+- Session
+- Orchestration
+- Sandbox
+- Communication
+- Memory
+- Tools
+
+These interfaces are useful because they say **what the runtime must provide** without over-constraining how the LLM coordinates within those surfaces.
+
+### 2. Runtime handles plumbing, agents handle judgment
+
+This remains the most important design rule.
+
+The runtime should explicitly own:
+
+- session persistence
+- state transitions
+- event logging
+- policy enforcement
+- message delivery
+- tool routing
+- sandbox provisioning
+- artifact storage
+
+The agents should own:
+
+- decomposition
+- prioritization
+- task routing
+- asking for help from other specialists
+- deciding which tools are relevant
+- deciding when a task is done or needs rework
+
+### 3. Avoid rigid workflow YAML
+
+Belayer was right to be suspicious of explicit workflow graphs pretending to know how all future work should proceed.
+
+Declarative configuration is still desirable for:
+
+- team rosters
+- sandbox policies
+- tool registries
+- artifact schemas
+- environment templates
+- review gates
+- escalation thresholds
+
+It should **not** try to fully encode:
+
+- orchestration logic
+- decision trees
+- agent sequencing for every task class
+- exhaustive review loop choreography
+
+### 4. Sandbox is a hard boundary
+
+This is even more true now than before. Overnight autonomy without a hard sandbox is not credible.
+
+---
+
+## What must change from current Belayer
+
+Current Belayer still reflects several assumptions that do not fit the Extend Nightshift target well enough.
+
+### A. Replace the "bring your own local pilot process" default assumption
+
+Current Belayer centers local vendor CLIs (`claude`, `codex`, generic) as if the identity and the execution process are effectively the same thing.
+
+For Nightshift, we need a separation between:
+
+- **identity** — long-lived planner/specialist memory, skills, persona, role ownership
+- **invocation** — one concrete overnight run inside one sandbox for one task or session
+
+This is where Hermes is materially different from pure client-side Claude Code or Codex assumptions.
+
+**Required change:**
+Belayer should treat the agent runtime as a pluggable execution backend with at least two classes:
+
+1. **local CLI backends** — Claude Code, Codex, etc.
+2. **persistent harness backends** — Hermes profiles/identities whose durable memory may be hosted outside the individual sandbox run
+
+This is not just a vendor adapter change; it affects memory, wake/resume, and how agent directories are treated.
+
+### B. Stop treating workbench provisioning as a Belayer-invented abstraction first
+
+Belayer currently imagines workbench provisioning in generic terms. For Extend, that is too vague.
+
+`extend-localenv` already gives us a concrete operational substrate:
+
+- `xt up`
+- `xt down`
+- `xt status`
+- `xt doctor`
+- `xt token`
+
+It also already defines a shell-native localenv direction and a workspace-root model that is much closer to the real Extend working environment than Belayer's generic compose sketches.
+
+**Required change:**
+For Extend-first Nightshift, Belayer should model the workbench as:
+
+- an Extend environment managed primarily through `xt`
+- plus any repo-local startup flows that remain outside `xt` today
+- plus verification commands for `extend-api` and `extend-app`
+
+Belayer should not try to out-generalize `extend-localenv` before integrating with it.
+
+### C. Treat extend-clamshell as the actual runtime boundary, not just an interchangeable sandbox candidate
+
+Belayer already points at clamshell, but the current framing is still a little abstract.
+
+From the current `extend-clamshell` docs, the important reality is:
+
+- it is single-host
+- it has deny-by-default egress
+- it uses host-owned providers/credentials
+- it exposes operator workflows and runtime inspection already
+- it is honest about where Linux vs macOS guarantees differ
+- it supports sandbox refresh flows for same-network peers
+
+**Required change:**
+For Extend-first Nightshift, clamshell should be treated as the primary supported sandbox runtime, not as one backend among many equal ones.
+
+Local mode can remain for development. Docker mode should be demoted further.
+
+### D. Move from PR-loop-centric orchestration to artifact-plus-PR orchestration
+
+The current Belayer collaboration model is very PR-centric:
+
+- implementer writes code
+- implementer creates PR
+- reviewer reviews PR
+- pilot loops
+
+That is useful but incomplete for Nightshift.
+
+For multi-repo fullstack work, the real coordination artifacts must include:
+
+- task graph
+- per-specialist assignment
+- shared contract or interface doc
+- assumptions taken
+- evidence bundle
+- local validation results
+- blocker/replan events
+
+**Required change:**
+Belayer should make PRs an output artifact, not the only serious coordination artifact.
+
+### E. Make the planner's session externalizable and inspectable
+
+The pilot currently feels like an in-session actor inside the same local runtime topology as everyone else.
+
+For Nightshift, the planner/orchestrator needs stronger control-plane semantics:
+
+- can wake or restart specialists
+- can spawn or reassign work
+- can inspect session state without attaching to a tmux pane
+- can compare artifacts across repos
+- can decide downgrade paths (draft PR only, stop-and-report, retry)
+
+**Required change:**
+The planner should be represented as a first-class control-plane role with explicit APIs and artifacts, not just as another peer in the same prompt-level cluster.
+
+---
+
+## Extend-first component model
+
+### 1. Belayer / Nightshift control plane
+
+This remains the root system.
+
+It owns:
+
+- session lifecycle
+- event log
+- run state machine
+- specialist roster
+- orchestration prompts/context assembly
+- typed message and artifact transport
+- review gates
+- morning handoff assembly
+- cost/time/autonomy policy
+
+It should not try to own:
+
+- sandbox internals
+- Extend environment startup internals
+- long-term specialist personality implementation details
+
+### 2. Hermes as specialist execution harness
+
+Hermes should be the first-class runtime backend for Nightshift specialists.
+
+Why:
+
+- persistent identities and profiles
+- durable memory and skills
+- delegation/subagents
+- practical tool use
+- dedicated-server deployment model
+- ability to separate the identity layer from a single local client process
+
+In practice, this means Nightshift launches **Hermes-backed specialists**, not just raw vendor CLIs.
+
+Examples:
+
+- `planner`
+- `extend-api-specialist`
+- `extend-app-specialist`
+- `qa-specialist`
+- `reviewer`
+- later: `localenv-specialist`, `security-reviewer`, `docs-specialist`
+
+### 3. extend-clamshell as sandbox substrate
+
+Clamshell owns:
+
+- deny-by-default egress
+- provider attachment
+- opaque credential handles
+- runtime inspectability
+- sandbox operator flows
+- audit logs
+- binary/process identity enforcement on managed paths
+
+For Extend-first Nightshift, the strongest supported deployment target should be:
+
+- **Linux host with local Docker Engine**
+
+macOS remains valuable for development and experimentation, but not for the strongest overnight trust claims.
+
+### 4. extend-localenv as workbench substrate
+
+`xt` should become the main Extend workbench interface.
+
+Nightshift should call explicit Extend-localenv capabilities such as:
+
+- `xt doctor`
+- `xt up --project ...`
+- `xt down`
+- `xt status`
+- `xt token ...`
+
+And then combine those with repo-native commands where necessary.
+
+This avoids inventing a second generic environment model before the Extend one is working.
+
+---
+
+## Current-state to target-state mapping
+
+| Concern | Current Belayer | Extend-first target |
+|---|---|---|
+| Agent runtime | local vendor CLI assumption | Hermes-backed specialists as primary runtime backend |
+| Identity persistence | agent directory near local harness | persistent Hermes identities separate from ephemeral runs |
+| Sandbox | clamshell-compatible design | clamshell as primary supported runtime boundary |
+| Workbench | generic compose/workbench idea | `extend-localenv` first, repo-native commands second |
+| Coordination | mostly message + PR loop | artifact-driven coordination with PRs as outputs |
+| Planner | peer agent inside session | explicit control-plane planner role |
+| Multi-repo support | climb-fullstack template | Extend-specific app/api orchestration first |
+| Abstraction strategy | generic runtime first | Extend-first implementation, abstraction later |
+
+---
+
+## Explicit vs inferred in Nightshift
+
+This needs to be painfully clear.
+
+### Must be explicit
+
+These should be declared in config, policy, or code:
+
+- supported repos (`extend-api`, `extend-app` initially)
+- supported specialist roles
+- sandbox policy and provider attachments
+- environment bring-up/teardown commands
+- artifact schema
+- session phases and terminal states
+- review gates
+- escalation thresholds
+- branch and PR policy
+- allowed network destinations
+- which actions are forbidden overnight
+
+### Should be explicit but agent-maintained
+
+These should live in skills, role memory, or versioned knowledge files:
+
+- repo conventions
+- local runbooks
+- validation playbooks
+- common drift patterns
+- role-specific review heuristics
+
+### Should be inferred by LLM judgment
+
+- task decomposition
+- which specialist to invoke
+- task sequencing within a phase
+- when to request help from another specialist
+- which tools to call first
+- when to replan vs retry
+- how to summarize findings
+
+### Must not be left to inference
+
+- sandbox escape decisions
+- credential scope
+- internet access policy
+- production or deploy operations
+- protected branch policy
+- review-gate bypass
+- whether a destructive action is permitted
+
+---
+
+## Session model for Extend-first Nightshift
+
+Belayer's existing session concept is still correct, but Nightshift needs a richer session contract.
+
+### Session types
+
+#### 1. Ticket session
+
+Input:
+
+- reviewed Jira ticket or equivalent spec
+
+Output:
+
+- one or more draft PRs
+- evidence bundle
+- morning summary
+
+#### 2. Fullstack ticket session
+
+Input:
+
+- ticket requiring app + api coordination
+
+Output:
+
+- coordinated repo tasks
+- shared contract artifact
+- app/api PRs
+- integration validation artifact
+
+#### 3. Planner-only session
+
+Input:
+
+- risky or ambiguous ticket
+
+Output:
+
+- execution plan
+- repo impact analysis
+- autonomy recommendation
+- no implementation unless promoted
+
+### Session phases
+
+For Extend-first v1, use these phases:
+
+1. **intake** — classify ticket, determine eligibility, identify repos
+2. **plan** — build task graph, shared contracts, specialist assignments
+3. **implement** — specialists work in parallel or sequence
+4. **verify** — localenv bring-up, checks, screenshots/logs/tests
+5. **review** — reviewer plus planner gate
+6. **handoff** — PR creation/update, evidence bundle, summary
+
+This is enough structure to keep the system intelligible without hardcoding fine-grained workflow logic.
+
+---
+
+## Specialist model for Extend-first v1
+
+Do not begin with too many roles.
+
+### Required v1 roles
+
+#### Planner
+
+Responsibilities:
+
+- intake classification
+- task graph creation
+- specialist routing
+- shared contract definition
+- progress monitoring
+- replan/escalation
+- handoff assembly
+
+#### extend-api specialist
+
+Responsibilities:
+
+- backend changes in `extend-api`
+- repo-local validation
+- API contract artifact generation
+- commit/branch/PR creation within allowed policy
+
+#### extend-app specialist
+
+Responsibilities:
+
+- frontend changes in `extend-app`
+- repo-local validation
+- UI contract consumption
+- commit/branch/PR creation within allowed policy
+
+#### QA specialist
+
+Responsibilities:
+
+- `xt`-based environment bring-up
+- end-to-end validation
+- integration drift detection
+- evidence capture
+
+#### Reviewer
+
+Responsibilities:
+
+- code review independent of implementers
+- requirements compliance review
+- risk summary
+
+### Roles that should wait
+
+- docs specialist
+- infra specialist
+- security specialist
+- data migration specialist
+
+Add them only after the core loop works.
+
+---
+
+## Artifact model
+
+This is the largest architectural shift from the current Belayer doc set.
+
+Nightshift should coordinate primarily through artifacts recorded in the session store.
+
+### Core artifacts
+
+#### `ticket-intake.json`
+
+Contains:
+
+- ticket ID
+- normalized requirements
+- repos implicated
+- risk class
+- autonomy eligibility
+- acceptance criteria
+
+#### `task-graph.json`
+
+Contains:
+
+- tasks
+- owners
+- dependencies
+- required artifacts
+- completion criteria
+
+#### `shared-contract.md`
+
+Contains:
+
+- endpoint/schema/interface changes
+- UI expectations
+- known assumptions
+
+#### `specialist-report-<role>.md`
+
+Contains:
+
+- work completed
+- commands run
+- assumptions taken
+- blockers encountered
+- tests run
+
+#### `verification-report.md`
+
+Contains:
+
+- `xt` environment status
+- local validation commands
+- app/api health checks
+- screenshots/logs if available
+- remaining failures or warnings
+
+#### `handoff.md`
+
+Contains:
+
+- PR links
+- what changed
+- what passed
+- what still needs human attention
+- confidence/risk notes
+
+### Why this matters
+
+Artifacts make the planner's job inspectable and make morning review much more trustworthy than raw transcript archaeology.
+
+---
+
+## Communication model
+
+Belayer's message broker remains useful, but messages should no longer carry all important state.
+
+### Typed communication events
+
+Nightshift should support typed events such as:
+
+- `task_assigned`
+- `artifact_ready`
+- `needs_contract_update`
+- `verification_failed`
+- `replan_requested`
+- `blocked`
+- `ready_for_review`
+- `handoff_ready`
+
+Messages can still contain natural language, but the runtime should record a typed envelope so orchestration is inspectable.
+
+---
+
+## extend-localenv integration requirements
+
+This is one of the biggest concrete implementation deltas.
+
+### Current observation
+
+`extend-localenv` already provides a lightweight shell CLI for local Extend environment operations and is already on this machine's path. `xt doctor` currently passes locally.
+
+### Required Belayer/Nightshift changes
+
+#### 1. Introduce an Extend workbench adapter
+
+Belayer should add an Extend-specific workbench adapter that wraps `xt` rather than generic compose first.
+
+Suggested surface:
+
+- `workbench.prepare` → `xt doctor`
+- `workbench.up(projects...)` → `xt up --project ...` or defined project sequence
+- `workbench.status` → `xt status`
+- `workbench.token(email)` → `xt token <email>`
+- `workbench.down` → `xt down`
+
+#### 2. Separate host-side environment bring-up from sandboxed coding
+
+The coding agent should stay in clamshell. The localenv bring-up may need to execute on the host/operator side under explicit tool routing.
+
+This fits Belayer's tool-routing philosophy well.
+
+#### 3. Store Extend environment knowledge as explicit skills/runbooks
+
+Do not make the planner rediscover:
+
+- when `xt up` is sufficient
+- when repo-local auth setup is still required
+- which project combinations matter
+- which health checks correspond to a usable environment
+
+Capture that in explicit Extend skills.
+
+---
+
+## extend-clamshell integration requirements
+
+### Current observation
+
+`clamshell` is already installed locally. `clamshell doctor` succeeds with warnings that are informative:
+
+- gateway not currently running
+- macOS is compatibility mode, not Linux reference platform
+- filesystem enforcement is weaker than native Linux
+
+This is exactly the kind of truthful operational posture Nightshift should preserve.
+
+### Required Belayer/Nightshift changes
+
+#### 1. Make clamshell the primary supported runtime backend
+
+Belayer should stop presenting local/docker/clamshell as co-equal for Nightshift production goals.
+
+Target support statement:
+
+- **production Nightshift**: Linux + clamshell
+- **development and local iteration**: macOS + clamshell compatibility mode or local runtime
+
+#### 2. Encode Extend-specific policies explicitly
+
+Belayer needs explicit clamshell policy packages for Extend workloads, including:
+
+- inference provider access
+- GitHub provider attachment
+- any required npm/GitHub/API egress
+- carefully scoped same-network direct-TCP exceptions only when necessary
+
+#### 3. Add runtime inspection into verification artifacts
+
+Planner and QA flows should capture:
+
+- `clamshell runtime inspect <sandbox>`
+- `clamshell doctor --sandbox <sandbox>` where useful
+- deny-event summaries when relevant
+
+#### 4. Avoid pretending direct-TCP exceptions are free
+
+The clamshell docs are clear that direct TCP weakens the original broker/proxy trust model.
+
+Nightshift should therefore treat direct-TCP exceptions as:
+
+- exceptional
+- explicit in policy
+- recorded in artifacts
+- included in risk summaries
+
+---
+
+## Hermes integration requirements
+
+This is the major new architectural addition.
+
+### Why Hermes matters here
+
+Hermes changes the shape of the system because:
+
+- agent identity can persist independently of a single run
+- specialists can accumulate memory and skills over time
+- profiles cleanly model specialist roles
+- the harness already supports tool use, delegation, memory, and cross-session continuity
+
+That is materially different from Belayer's earlier assumption that the runtime mainly launches client-side Claude Code or Codex sessions and that the identity is effectively local to that harness.
+
+### Required Belayer/Nightshift changes
+
+#### 1. Add a Hermes runtime adapter
+
+Belayer should be able to launch a Hermes-backed specialist with:
+
+- a selected profile/identity
+- a sandbox workspace
+- a task payload
+- environment-scoped tools
+- session metadata
+
+#### 2. Distinguish identity store from run workspace
+
+Belayer should represent:
+
+- **identity state** — profile, memory, skills, persona
+- **run state** — workspace path, branch, artifacts, event stream, verification outputs
+
+These must not be conflated.
+
+#### 3. Keep explicit Belayer session/event state even if Hermes has its own session model
+
+Hermes sessions are useful, but Nightshift still needs Belayer-owned session truth for:
+
+- orchestration state
+- cross-specialist coordination
+- artifacts
+- morning handoff
+- audit of the overall run
+
+Hermes should not replace the Nightshift control plane.
+
+#### 4. Use Hermes memory carefully
+
+For v1:
+
+- use Hermes memory and skills for role expertise and stable Extend conventions
+- do **not** use it as the primary storage for orchestration state or evidence
+
+Belayer session artifacts remain the system of record for the overnight run.
+
+---
+
+## Extend-first MVP scope
+
+To avoid another abstraction stall, the first real target should be narrow.
+
+### Supported repos
+
+- `extend-api`
+- `extend-app`
+
+### Supported task classes
+
+- bounded tickets with human-reviewed specs
+- one-repo backend changes
+- one-repo frontend changes
+- selected app+api tickets with clear shared contracts
+
+### Unsupported initially
+
+- arbitrary repo graphs
+- infra-heavy tickets
+- production deploys
+- auto-merge
+- broad epics with unclear boundaries
+- partner/integrator repos
+
+### Definition of success
+
+Nightshift should be considered working when it can reliably:
+
+1. ingest a reviewed Extend ticket
+2. classify app/api impact
+3. spawn planner + specialists
+4. make code changes in the correct repo(s)
+5. use `xt` and repo-native validation to verify locally
+6. create draft PRs with evidence
+7. produce a morning handoff a human can trust
+
+---
+
+## Recommended implementation order
+
+### Phase 1 — Extend-first control plane cleanup
+
+- update Belayer docs and naming around Extend-first scope
+- add explicit session phases and artifact schema
+- demote generic workflow language in favor of artifact-driven orchestration
+
+### Phase 2 — Hermes runtime backend
+
+- add Hermes-backed specialist launcher
+- separate identity store from run workspace
+- model planner/api/app/reviewer/qa as explicit Nightshift roles
+
+### Phase 3 — extend-localenv adapter
+
+- add host-side workbench tool routing around `xt`
+- codify Extend validation playbooks
+- emit verification artifacts
+
+### Phase 4 — extend-clamshell productionization
+
+- define Extend sandbox policies
+- add runtime inspection capture
+- standardize Linux-host production deployment
+
+### Phase 5 — morning handoff and human review ergonomics
+
+- artifact summary generation
+- PR linking
+- risk summary
+- failure categorization
+
+Only after those phases are working should Belayer try to abstract the pattern back outward.
+
+---
+
+## Final recommendation
+
+Belayer should stop trying to prove a universal agent runtime first.
+
+It should instead become:
+
+> **the Extend Nightshift control plane**
+> orchestrating **Hermes-backed specialist identities**
+> inside **extend-clamshell sandboxes**
+> using **extend-localenv** for Extend environment operations.
+
+That is concrete enough to implement, narrow enough to finish, and still aligned with the deeper Belayer philosophy.

--- a/docs/design-docs/2026-04-15-nightshift-extend-first-implementation-delta.md
+++ b/docs/design-docs/2026-04-15-nightshift-extend-first-implementation-delta.md
@@ -1,0 +1,755 @@
+---
+status: proposed
+created: 2026-04-15
+supersedes:
+implemented-by:
+consulted-learnings:
+  - docs/PHILOSOPHY.md
+  - docs/ARCHITECTURE.md
+  - docs/design-docs/2026-04-09-sandbox-runtime-architecture-design.md
+  - docs/design-docs/2026-04-15-nightshift-extend-first-architecture.md
+  - ~/Documents/Programs/work/extend-localenv/README.md
+  - ~/Documents/Programs/work/extend-clamshell/README.md
+---
+
+# Belayer → Nightshift for Extend: Implementation Delta
+
+This document turns the Extend-first Nightshift architecture into concrete engineering changes against the current Belayer codebase.
+
+The goal is not to preserve every abstraction Belayer currently has. The goal is to get a trustworthy Extend-first Nightshift loop working. If that means deleting speculative layers, we should delete them.
+
+---
+
+## Executive summary
+
+Belayer currently has three different stories mixed together:
+
+1. **a solid control-plane idea** — sessions, events, broker, tools, daemon
+2. **a speculative generic runtime stack** — local, docker, clamshell, vendor adapters, generic environment configs
+3. **a still-hypothetical workbench/orchestration model** — generic compose workbench, generic templates, generic vendor assumptions
+
+For Extend-first Nightshift, the recommendation is:
+
+- **keep** Belayer's session/event/control-plane core
+- **keep and strengthen** clamshell integration
+- **replace generic workbench provisioning with an Extend-localenv adapter**
+- **replace local vendor CLI assumptions with a Hermes runtime adapter**
+- **shrink or delete** generic Docker runtime and generic vendor abstraction code where it no longer pays for itself
+
+This is not just a refactor. It is a scope correction.
+
+---
+
+## What the current codebase suggests
+
+Approximate internal package weight today:
+
+- `internal/cli`: 24 files / 4742 lines
+- `internal/docker`: 9 files / 3062 lines
+- `internal/daemon`: 5 files / 1975 lines
+- `internal/agent`: 10 files / 1461 lines
+- `internal/store`: 3 files / 804 lines
+- `internal/broker`: 4 files / 694 lines
+- `internal/vendor`: 6 files / 623 lines
+- `internal/workspace`: 2 files / 529 lines
+- `internal/session`: 2 files / 472 lines
+- `internal/clamshell`: 2 files / 137 lines
+- `internal/runtime`: 2 files / 70 lines
+
+The biggest immediate smell is that the most speculative code is also some of the heaviest:
+
+- `internal/docker` is large and central
+- `internal/cli/session_start.go` is very large and is carrying too many concerns
+- `internal/vendor` exists largely to adapt local CLI harnesses that are no longer the primary target
+- `internal/runtime` is a thin selector over local/docker/clamshell modes, but the meaningful implementation complexity lives elsewhere
+
+That supports your instinct that a lot of code can probably go away.
+
+---
+
+## The target system boundary
+
+Nightshift for Extend should have four clear layers.
+
+### 1. Belayer/Nightshift control plane
+
+Owns:
+
+- sessions
+- events
+- artifacts
+- typed orchestration state
+- message routing
+- work dispatch
+- review gates
+- morning handoff
+
+### 2. Hermes specialist runtime
+
+Owns:
+
+- specialist identities
+- role memory
+- skills
+- tool-using task execution
+- optional sub-delegation inside a specialist run
+
+### 3. extend-clamshell sandbox
+
+Owns:
+
+- sandbox creation
+- host-owned credentials
+- network policy
+- runtime inspection
+- auditability
+
+### 4. extend-localenv workbench
+
+Owns:
+
+- Extend local environment bring-up
+- teardown
+- status/health checks
+- token generation
+- concrete local dev topology
+
+This means Belayer should become thinner and more intentional.
+
+---
+
+## What to keep mostly as-is
+
+These parts are still strategically correct.
+
+### Keep: `internal/store`
+
+Why keep it:
+
+- sessions and events remain the root primitive
+- SQLite is fine for v1
+- workbench/session state persistence is useful
+
+What changes:
+
+- add artifact tables and typed run state
+- add specialist run records
+- add explicit session phase and outcome fields
+- stop treating message history and event log as the only coordination record
+
+### Keep: `internal/daemon`
+
+Why keep it:
+
+- daemon is the natural control plane
+- HTTP/Unix socket API is appropriate
+- this is the right place for orchestration state and work dispatch
+
+What changes:
+
+- add artifact endpoints
+- add run dispatch endpoints oriented around specialists
+- add planner-visible orchestration APIs
+- reduce daemon ownership of generic compose/workbench machinery
+
+### Keep: `internal/broker`
+
+Why keep it:
+
+- message delivery still matters
+- debounce/coalescing can still help
+- the abstraction is useful even if message content becomes more typed
+
+What changes:
+
+- messages become one coordination primitive among several, not the only one
+- introduce typed event envelopes like `task_assigned`, `artifact_ready`, `blocked`, `ready_for_review`
+
+### Keep: `internal/clamshell`
+
+Why keep it:
+
+- tiny, useful package
+- directly aligned with production target
+
+What changes:
+
+- expand it from a tiny wrapper to the primary sandbox backend integration
+- add inspect/doctor helper calls and provider attachment support if needed
+
+---
+
+## What to modify heavily
+
+### 1. `internal/cli/session_start.go`
+
+Current problem:
+
+- it is carrying too much runtime-specific orchestration
+- it branches across local/docker/clamshell
+- it contains launch flow, worktree creation, tool registration, environment loading, runtime selection, summary printing, and attach logic in one huge file
+
+This file is the clearest signal that Belayer's runtime abstractions are too leaky.
+
+#### Proposed change
+
+Split into a much smaller orchestration entrypoint that does only:
+
+1. resolve workspace and config
+2. create session
+3. ask a runtime launcher to start the named roles
+4. print status/attach instructions
+
+Move the rest into:
+
+- `internal/nightshift/launcher.go`
+- `internal/nightshift/hermes_runtime.go`
+- `internal/nightshift/clamshell_runtime.go`
+- `internal/nightshift/localenv_adapter.go`
+
+#### Result
+
+- much less CLI complexity
+- runtime logic becomes testable in packages with narrower responsibilities
+- session start stops being a graveyard of every experiment Belayer has tried
+
+### 2. `internal/session/template.go`
+
+Current problem:
+
+- built-in templates still reflect intake/implement/deliver and generic vendor choices
+- agent specs still encode `Vendor` and `Model` directly as if the execution runtime is a local CLI concern
+- built-ins (`explorer`, `merger`, etc.) are broader and more generic than Extend-first needs
+
+#### Proposed change
+
+Replace the current built-in template assumptions with Extend-first roles:
+
+- `planner`
+- `extend-api-specialist`
+- `extend-app-specialist`
+- `qa`
+- `reviewer`
+
+Change `AgentSpec` to distinguish:
+
+- **role identity**
+- **runtime backend** (`hermes`, optional legacy `vendor-cli`)
+- **profile/identity name**
+- **repo binding**
+
+Not:
+
+- vendor CLI name as the core abstraction
+
+#### Result
+
+The template layer becomes about the team and role contract, not about which local binary happens to run.
+
+### 3. `internal/daemon/tools.go` and `internal/agent/executor.go`
+
+Current problem:
+
+- tool execution assumes `agent`, `workbench`, `infra`, `host` routed partly through docker-compose execution
+- this is still very compose-centric
+
+#### Proposed change
+
+Evolve the execution targets to something like:
+
+- `host`
+- `sandbox`
+- `localenv`
+- `session`
+
+Where:
+
+- `sandbox` means “inside the specialist's clamshell/Hermes run context”
+- `localenv` means “host-side Extend environment operations via `xt` and related host commands”
+- `session` means “Belayer-owned orchestration/meta tools”
+
+This does **not** need to be solved by growing the executor into a larger generic shell DSL. It should become simpler and more intentional.
+
+---
+
+## What to de-emphasize or delete
+
+This is the part where code removal is likely justified.
+
+### A. De-emphasize and likely delete most of `internal/docker`
+
+Current state:
+
+- `internal/docker` contains environment loading, generic compose workbench logic, generic sandbox logic, runtime metadata, compose generation
+- it is one of the largest packages in the codebase
+- much of its value is tied to generic workbench/compose abstractions
+
+Why it should shrink:
+
+- Extend-first workbench should go through `extend-localenv`, not Belayer-generated compose first
+- clamshell is the real sandbox boundary, so Belayer should not also maintain a parallel generic sandbox/runtime story unless needed
+- the generic environment model is overbuilt for the current target
+
+#### Suggested keep/remove breakdown
+
+**Keep temporarily:**
+
+- any environment config bits needed to load repo metadata during migration
+- any tests that protect session/worktree assumptions while refactoring
+
+**Plan to remove or retire:**
+
+- generic compose workbench generation in `internal/docker/workbench.go`
+- generic sandbox/compose coupling in `internal/docker/sandbox.go`
+- runtime metadata and compose output paths that only exist for Docker mode
+- generic environment/config fields that only serve compose-based workbench generation
+
+#### Replacement
+
+Introduce:
+
+- `internal/nightshift/extendenv` or `internal/localenv`
+- explicit `xt` adapter functions
+- explicit Extend repo topology config
+
+#### Why this is good
+
+You could realistically remove a large amount of speculative code here and replace it with a much smaller, more truthful integration.
+
+### B. De-emphasize `internal/vendor`
+
+Current state:
+
+- Belayer has adapters for Claude, Codex, and a generic opencode adapter
+- this makes sense if Belayer is launching local vendor CLIs as its primary runtime behavior
+
+Why it should shrink:
+
+- Hermes should be the primary runtime backend for Extend-first Nightshift
+- Belayer does not need to be a best-in-class adapter layer for every local agent harness before Nightshift works
+
+#### Suggested path
+
+**Keep initially:**
+
+- local vendor adapters only as migration/dev fallback
+
+**Add:**
+
+- `HermesAdapter` or a new `runtime/hermes` integration that is clearly primary
+
+**Then remove or demote:**
+
+- assumptions in docs/tests/templates that local vendor adapters are the default path
+- broad vendor-specific output parsing that is irrelevant once the session-level integration is Hermes-native
+
+#### Important nuance
+
+Do **not** rip out local adapters immediately if they are useful for local debugging. But stop designing around them.
+
+### C. Delete or reduce `internal/runtime`
+
+Current state:
+
+- `internal/runtime/runtime.go` is a very small selector over `local`, `docker`, `clamshell`, `kubernetes`
+
+Why it may not be worth keeping in its current form:
+
+- it abstracts almost nothing meaningful
+- the real complexity is elsewhere
+- it encourages the fiction that all runtime modes are co-equal
+
+#### Suggested change
+
+Replace with one of two options:
+
+1. a more meaningful launcher/runtime interface centered on actual Nightshift backends:
+   - `HermesInClamshell`
+   - `HermesLocal`
+   - maybe `LegacyVendorLocal`
+
+or
+
+2. delete the package and move runtime selection into a new `internal/nightshift/runtime` package once the real interfaces are clear
+
+### D. Reduce generic workspace abstraction if it duplicates Extend reality
+
+Current state:
+
+- `internal/workspace/workspace.go` models repos.json, clone, ensure ready, repo paths
+
+Potential issue:
+
+- if Extend-first Nightshift has a simpler, explicit repo map (`extend-api`, `extend-app`) and worktree behavior, the current generic abstraction may be more general than necessary
+
+Suggested stance:
+
+- keep if it still cleanly solves repo path/worktree concerns
+- remove or slim down if it becomes dead weight after adopting explicit Extend-first workspace config
+
+---
+
+## New packages to add
+
+### 1. `internal/nightshift`
+
+This should become the orchestration package for the Extend-first system.
+
+Responsibilities:
+
+- session phase transitions
+- planner-facing orchestration helpers
+- specialist dispatch
+- artifact assembly
+- review gating
+- morning handoff
+
+Suggested files:
+
+- `internal/nightshift/session.go`
+- `internal/nightshift/dispatch.go`
+- `internal/nightshift/artifacts.go`
+- `internal/nightshift/handoff.go`
+- `internal/nightshift/roles.go`
+
+### 2. `internal/hermes` or `internal/nightshift/hermesruntime`
+
+Responsibilities:
+
+- launch Hermes-backed specialists
+- map Belayer role specs to Hermes profiles
+- pass task payload, repo binding, and session metadata
+- capture run lifecycle and result summaries
+
+This is the new primary runtime adapter.
+
+### 3. `internal/localenv` or `internal/nightshift/localenv`
+
+Responsibilities:
+
+- run `xt doctor`
+- run `xt up` / `xt down`
+- run `xt status`
+- run `xt token`
+- normalize outputs for artifact recording
+
+This is the replacement for “generic workbench first.”
+
+### 4. `internal/artifacts`
+
+Responsibilities:
+
+- artifact schemas
+- file naming/storage rules
+- typed serialization/deserialization
+- summary helpers
+
+This can remain small, but it should exist explicitly so artifacts stop being hidden in ad hoc event JSON.
+
+---
+
+## Data model changes
+
+### Sessions table
+
+Current session model is too thin:
+
+- `id`
+- `name`
+- `status`
+- `template`
+
+#### Add fields
+
+- `kind` (`ticket`, `fullstack_ticket`, `planner_only`)
+- `phase` (`intake`, `plan`, `implement`, `verify`, `review`, `handoff`)
+- `risk_class`
+- `outcome`
+- `ticket_ref`
+- `planner_run_id` or planner identity reference
+
+### New artifacts table
+
+Add a dedicated table, for example:
+
+- `id`
+- `session_id`
+- `kind`
+- `producer`
+- `path`
+- `summary`
+- `created_at`
+
+Artifact kinds for v1:
+
+- `ticket_intake`
+- `task_graph`
+- `shared_contract`
+- `specialist_report`
+- `verification_report`
+- `handoff`
+- `review_report`
+
+### New specialist_runs table
+
+Add explicit specialist run tracking:
+
+- `id`
+- `session_id`
+- `role`
+- `runtime`
+- `identity_ref`
+- `workspace_path`
+- `status`
+- `started_at`
+- `ended_at`
+- `result_summary`
+
+This is where the “identity vs invocation” distinction becomes real.
+
+---
+
+## CLI changes
+
+### Keep
+
+- `belayer daemon`
+- `belayer status`
+- `belayer logs`
+- `belayer message ...`
+- `belayer note`
+
+### Modify heavily
+
+#### `belayer session start`
+
+Current flags:
+
+- `--docker`
+- `--clamshell`
+- `--environment`
+- template-driven local runtime branching
+
+#### Proposed direction
+
+Move toward something like:
+
+```bash
+belayer session start \
+  --kind fullstack_ticket \
+  --ticket PROD-1234 \
+  --spec ./spec.md \
+  --profile extend
+```
+
+And for local/dev fallback, maybe:
+
+```bash
+belayer session start --mode dev-local ...
+```
+
+The important point is that `--docker` should stop being a first-class top-level story.
+
+### Replace generic workbench commands with Extend intent
+
+Current:
+
+- `belayer workbench up`
+- `belayer workbench status`
+- `belayer workbench down`
+
+These can remain, but under the hood they should speak in Extend-localenv terms, not generic compose terms.
+
+For example:
+
+- `belayer workbench up` → invokes `xt` flows + records status artifact
+- `belayer workbench status` → wraps `xt status`
+- `belayer workbench down` → wraps `xt down`
+
+---
+
+## First runnable vertical slice
+
+To avoid fizzing out again, the first slice must be narrow and demonstrable.
+
+### Goal
+
+Support one reviewed Extend ticket that touches:
+
+- only `extend-api`, or
+- `extend-api` + `extend-app` with a simple shared contract
+
+### Required capabilities only
+
+1. Belayer creates a session
+2. Planner role starts
+3. One or two Hermes specialists run in clamshell sandboxes
+4. Specialists write artifacts and code
+5. `xt` adapter brings up environment and records status
+6. QA or planner runs verification commands
+7. Draft PR(s) + `handoff.md` are produced
+
+### Explicitly skip for first slice
+
+- generic multi-repo environments
+- arbitrary vendor backends
+- generalized workbench compose generation
+- broad tier/peripheral/ephemeral experimentation
+- complex memory reflection upgrades
+
+---
+
+## Concrete package-by-package change list
+
+### `internal/docker`
+
+**Decision:** deprecate aggressively
+
+- Mark package as legacy in docs/comments
+- Stop adding features here
+- Replace workbench calls with `internal/localenv`
+- Replace sandbox assumptions with `internal/clamshell`
+- Delete compose-generation path once Extend-first slice no longer needs it
+
+### `internal/vendor`
+
+**Decision:** demote to legacy runtime support
+
+- Keep for local fallback only
+- Stop centering templates around vendor/model pairs
+- Add Hermes runtime path before expanding any vendor-specific features
+
+### `internal/runtime`
+
+**Decision:** replace or remove
+
+- remove fake co-equal runtime selector
+- replace with a Nightshift-specific launcher abstraction
+
+### `internal/session`
+
+**Decision:** keep, but rewrite templates and role spec assumptions
+
+- remove generic built-ins like `explorer` and `merger`
+- add Extend-first role definitions
+- change from vendor-centric to identity/runtime-centric fields
+
+### `internal/agent`
+
+**Decision:** partially keep, partially narrow
+
+Keep:
+
+- prompt assembly ideas where still useful
+- tool spec concepts if still compatible
+
+Change:
+
+- stop assuming docker-compose-based execution targets
+- narrow executor targets to Nightshift-relevant ones
+
+### `internal/daemon`
+
+**Decision:** keep and expand
+
+- add artifacts API
+- add specialist run tracking
+- add Nightshift-oriented dispatch endpoints
+- reduce direct ownership of generic Docker workbench lifecycle
+
+### `internal/cli`
+
+**Decision:** simplify
+
+- shrink `session_start.go`
+- remove runtime branching from CLI layer
+- push runtime-specific logic down into packages
+- keep human-facing commands small and truthful
+
+---
+
+## Code removal candidates
+
+These are the areas most likely to yield meaningful deletion.
+
+### High-confidence removal or major shrink candidates
+
+1. **generic Docker workbench generation**
+   - `internal/docker/workbench.go`
+   - related tests and compose helpers
+
+2. **generic Docker runtime launch path in CLI**
+   - large parts of `internal/cli/session_start.go`
+   - `--docker` mode plumbing
+
+3. **runtime mode selector abstraction**
+   - `internal/runtime/runtime.go`
+
+4. **generic built-in session templates and broad phase assumptions**
+   - current built-ins in `internal/session/template.go`
+
+### Medium-confidence shrink candidates
+
+5. **vendor adapter centrality**
+   - keep code for fallback, but reduce its role in architecture/docs/tests
+
+6. **workspace abstraction breadth**
+   - keep if it still directly helps Extend-first repo mapping
+   - shrink if it remains broader than actual use
+
+---
+
+## Recommended implementation order
+
+### Step 1 — add the new implementation doc set and freeze scope
+
+- keep Extend-first scope explicit
+- define the first vertical slice ticket class
+- stop adding new generic runtime features
+
+### Step 2 — add artifacts and specialist run records to the store/daemon
+
+Why first:
+
+- gives the system a better control-plane backbone before runtime changes
+- makes all later integration work more inspectable
+
+### Step 3 — introduce Hermes runtime integration
+
+- add a primary specialist launcher path for Hermes
+- keep local vendor launchers as fallback only
+
+### Step 4 — add `xt` adapter and route workbench commands through it
+
+- replace generic compose-first workbench path
+- emit verification artifacts from `xt` runs
+
+### Step 5 — simplify session templates and CLI runtime branching
+
+- swap in Extend-first role roster
+- reduce `session_start.go`
+- remove dead generic flags/paths where possible
+
+### Step 6 — delete or quarantine legacy Docker runtime code
+
+- once the first slice runs, aggressively remove dead code
+- do not keep two equal orchestration stacks alive unless both are really used
+
+---
+
+## Final recommendation
+
+Yes — I do think you are probably right that Belayer can lose a lot of code.
+
+The likely pattern is:
+
+- **more code** in explicit Nightshift control-plane pieces
+- **much less code** in speculative generic runtime/workbench/vendor plumbing
+
+If we do this well, Belayer should become **simpler and more opinionated**, not larger.
+
+The strategic test for every package should be:
+
+> does this help Belayer become a working Extend Nightshift control plane now?
+
+If not, it is probably a candidate for deletion, demotion, or quarantine.

--- a/docs/design-docs/2026-04-15-nightshift-v1-deployment-topology.md
+++ b/docs/design-docs/2026-04-15-nightshift-v1-deployment-topology.md
@@ -1,0 +1,564 @@
+---
+status: proposed
+created: 2026-04-15
+supersedes:
+implemented-by:
+consulted-learnings:
+  - docs/PHILOSOPHY.md
+  - docs/ARCHITECTURE.md
+  - docs/DESIGN.md
+  - docs/design-docs/2026-04-15-nightshift-extend-first-architecture.md
+  - docs/design-docs/2026-04-15-nightshift-extend-first-implementation-delta.md
+---
+
+# Nightshift v1 Deployment Topology
+
+This document refines the deployment picture for Nightshift v1 and narrows the architecture aggressively for MVP.
+
+## MVP constraint
+
+For v1, **one worker handles one request at a time**.
+
+No multi-session workers. No multi-tenant worker packing. No worker-side contention management. No worktree juggling inside Nightshift itself.
+
+That gives us a much simpler operational model:
+
+- one request
+- one worker
+- one sandboxed run namespace
+- one planner-led session
+- zero same-host session collisions to reason about in v1
+
+If it works on a laptop, it should work on a Linux worker node with the same topology.
+
+---
+
+## Why this simplification matters
+
+It deliberately removes several sources of complexity from the MVP:
+
+- no concurrent session collisions inside a worker
+- no need for per-session worktree orchestration on shared hosts
+- no need for worker-local scheduling fairness
+- no need to prove that Belayer can multiplex many active agent runs before it can run one correctly
+- no need to solve shared localenv/workbench resource contention on day one
+
+This also sharpens the question of Belayer's role.
+
+Belayer should not be trying to be:
+
+- a cluster scheduler
+- a hypervisor
+- a generic workbench provisioner
+- a universal coding harness
+
+For v1 it should be much more specific:
+
+> Belayer is the **agent control plane inside one Nightshift run**.
+
+The outer Nightshift system handles request queueing and worker selection. Belayer handles the intra-run agent session.
+
+---
+
+## The two control planes
+
+Nightshift v1 has **two distinct control-plane layers**.
+
+### 1. Worker control plane
+
+This is the outer Nightshift service.
+
+It is always on and is responsible for:
+
+- accepting or pulling work requests (Jira/spec input)
+- maintaining the queue
+- selecting an idle worker
+- provisioning a fresh worker run environment
+- attaching the request payload to that worker
+- monitoring run state at a coarse level
+- collecting final artifacts / handoff output
+
+This is **not** Belayer.
+
+It is the service that answers questions like:
+
+- which worker is free?
+- is this request running, failed, or complete?
+- which run belongs to which ticket?
+- where do the morning artifacts live?
+
+### 2. Agent control plane
+
+This is Belayer's role.
+
+Once a worker has been assigned a request and a sandbox/runtime is available, Belayer becomes responsible for:
+
+- creating the session for that run
+- materializing the planner and specialist identities for the run
+- dispatching agents
+- persisting session events and artifacts
+- routing messages between agents
+- exposing session state and logs
+- coordinating review / QA / handoff phases inside the run
+
+This is a much tighter and more realistic role for Belayer than "global orchestration system for the entire cluster".
+
+---
+
+## High-level topology
+
+```mermaid
+flowchart LR
+    User["User / Jira / Reviewed Spec"] --> NCP["Nightshift Worker Control Plane\n(always on)"]
+    NCP --> Queue[("Request Queue / Run DB")]
+    NCP --> W1["Worker 1\n(idle or running one request)"]
+    NCP --> W2["Worker 2\n(idle or running one request)"]
+    NCP --> WN["Worker N\n(idle or running one request)"]
+
+    subgraph Worker["One worker handling one request"]
+        B["Belayer\n(agent control plane)"]
+        S["Sandbox Runtime\n(clamshell or equivalent)"]
+        H["Hermes specialist runs\n(planner, api, app, reviewer, qa)"]
+        X["Extend workbench\n(xt / localenv runtime)"]
+        A[("Artifacts / logs / session state")]
+
+        B --> H
+        B --> A
+        H --> S
+        B --> X
+        X --> A
+        H --> A
+    end
+
+    W1 --> Worker
+```
+
+### Reading the diagram
+
+- The **outer Nightshift control plane** owns worker assignment and run lifecycle.
+- A **worker** receives one request and becomes a self-contained execution cell.
+- Inside that worker, **Belayer** is the agent-session controller.
+- **Hermes** provides the actual specialist runs.
+- **Sandboxing** constrains those runs.
+- **xt/localenv** provides the Extend workbench/runtime for validation.
+
+---
+
+## Single-request worker model
+
+A v1 worker should be thought of as a **single active run container/host namespace**, not a general-purpose shared executor.
+
+### Worker responsibilities
+
+When the Nightshift worker control plane assigns a request to a worker, that worker is responsible for exactly one live run:
+
+- prepare run directory / namespace
+- provision sandbox runtime
+- hand execution to Belayer
+- expose coarse run heartbeat back to the outer control plane
+- tear down cleanly when done
+
+### Worker states
+
+At the outer layer, workers only need a small state machine:
+
+- `idle`
+- `preparing`
+- `running`
+- `tearing_down`
+- `failed`
+
+That is enough for v1.
+
+---
+
+## What lives inside the worker
+
+Inside a worker, one request gets one run namespace.
+
+Suggested shape:
+
+```text
+/run/nightshift/<run-id>/
+  request/
+    ticket.json
+    spec.md
+  session/
+    belayer.db or session artifacts
+  repos/
+    extend-api/
+    extend-app/
+  identities/
+    planner/
+    extend-api-specialist/
+    extend-app-specialist/
+    reviewer/
+    qa/
+  artifacts/
+    ticket-intake.json
+    task-graph.json
+    shared-contract.md
+    verification-report.md
+    handoff.md
+  runtime/
+    sandbox metadata
+    localenv state references
+```
+
+This does **not** need to be globally standardized yet, but the idea is important:
+
+> one run gets one directory namespace, and everything Belayer manages for that run stays inside it.
+
+---
+
+## Belayer's role in the worker
+
+Belayer should start after the worker has already done the outer setup needed to host the run.
+
+Belayer is not choosing which worker to use. Belayer is not balancing cluster load. Belayer is not multiplexing many unrelated requests.
+
+For v1, Belayer should be responsible for the **inner agent session only**.
+
+### Belayer owns
+
+- the run session
+- planner + specialist roster for the run
+- agent-to-agent communication
+- session event log
+- session artifacts
+- intra-run phase transitions
+- handoff assembly inside the run
+
+### Belayer does not own
+
+- cluster-wide scheduling
+- worker autoscaling
+- global job queueing
+- durable team-wide identity registry policy
+- infra provisioning beyond what the run needs locally
+
+### The practical implication
+
+Belayer should evolve toward a shape like:
+
+> "given a prepared run environment, execute the planner-led agent session for this request"
+
+That is much narrower than where Belayer was drifting before.
+
+---
+
+## Planner-led run inside Belayer
+
+The first agent launched inside the run is the planner.
+
+The planner's responsibilities:
+
+- inspect the request/spec
+- decide which repos are implicated
+- decide which specialist identities are needed
+- produce a task graph / shared contract
+- spawn and coordinate specialists
+- request validation / review
+- assemble handoff artifacts
+
+### Important constraint
+
+The planner is a **run-local session orchestrator**, not the worker scheduler.
+
+It does not pick which machine to run on. That decision is already made.
+
+This boundary keeps the system understandable.
+
+---
+
+## Intra-run agent communication
+
+This is where Belayer remains highly relevant.
+
+You asked specifically: how do we make it so agents can communicate within this run?
+
+## The answer
+
+Belayer should remain the **message and event router** for agents inside one run.
+
+### Communication pattern
+
+Agents do not talk directly to each other through shared stdin hacks or ad hoc files.
+
+They communicate through Belayer-managed primitives:
+
+- messages
+- typed events
+- artifacts
+
+### Proposed communication layers
+
+#### 1. Direct messages
+
+Use for targeted instructions:
+
+- planner → api specialist
+- planner → app specialist
+- reviewer → planner
+- qa → planner
+
+Examples:
+
+- "API contract changed; update your types"
+- "Please review artifact `shared-contract.md` before proceeding"
+- "Re-run verification after latest backend patch"
+
+#### 2. Typed run events
+
+Use for machine-readable orchestration state:
+
+- `task_assigned`
+- `artifact_ready`
+- `blocked`
+- `verification_failed`
+- `ready_for_review`
+- `handoff_ready`
+
+These should be persisted in Belayer's session/event store.
+
+#### 3. Shared artifacts
+
+Use for durable coordination:
+
+- `task-graph.json`
+- `shared-contract.md`
+- `specialist-report-*.md`
+- `verification-report.md`
+- `handoff.md`
+
+These are what prevent the run from becoming a cloud of chat transcripts.
+
+---
+
+## Intra-run communication diagram
+
+```mermaid
+sequenceDiagram
+    participant P as Planner
+    participant B as Belayer
+    participant API as API Specialist
+    participant APP as App Specialist
+    participant QA as QA Specialist
+    participant REV as Reviewer
+
+    P->>B: create artifact(task-graph)
+    B-->>API: message(task_assigned)
+    B-->>APP: message(task_assigned)
+
+    API->>B: event(artifact_ready: api-report)
+    APP->>B: event(blocked: contract-question)
+    B-->>P: deliver event stream
+
+    P->>B: create artifact(shared-contract)
+    B-->>APP: message(contract_updated)
+
+    API->>B: event(ready_for_review)
+    B-->>REV: message(review_request)
+    REV->>B: event(review_passed)
+    B-->>P: deliver event
+
+    P->>B: message(run_verification)
+    B-->>QA: message(task_assigned)
+    QA->>B: event(verification_failed)
+    B-->>P: deliver event
+```
+
+### Key point
+
+Belayer should not just be a tmux relay. It should be the **session bus** inside the run.
+
+That means the messaging API becomes more important, not less.
+
+---
+
+## Where Hermes fits in this topology
+
+In v1, Hermes is the **specialist runtime** used inside the worker.
+
+### Hermes does
+
+- execute planner/specalist/reviewer/qa runs
+- use tools to inspect files, edit code, run commands
+- carry specialist identity, memory, and skills into the run
+
+### Hermes does not do
+
+- worker scheduling
+- global queueing
+- cross-worker coordination
+- cluster-wide artifact indexing
+
+### Practical consequence
+
+Belayer should treat Hermes as a **run-local execution engine** for identities it has decided to use.
+
+This keeps the relationship clean:
+
+- outer Nightshift: "which worker handles request X?"
+- Belayer: "inside this worker, run planner + specialists for request X"
+- Hermes: "I am the planner/specialist execution engine for this run"
+
+---
+
+## Where sandboxing fits
+
+For v1, we should still speak at a slightly abstract level, but the design intent is:
+
+- the worker provisions one sandbox/runtime environment for the run
+- Hermes specialists operate inside or against that sandboxed environment
+- the code workspace is local to that worker/run
+- validation runs against local resources attached to that run
+
+Because the worker handles only one request at a time, the collision story is much simpler:
+
+- no cross-request workspace collisions
+- no same-worker port collisions between unrelated requests
+- no shared session namespace inside a worker
+
+This is why the one-request-per-worker rule is such a good MVP constraint.
+
+---
+
+## Where xt / localenv fits
+
+For Extend-first v1, localenv should be treated as the **run workbench adapter**, not a global worker service.
+
+That means:
+
+- Belayer or a Belayer-routed tool can invoke `xt doctor`
+- later in the run, Belayer can invoke `xt up`, `xt status`, `xt down`
+- the resulting health/status/evidence is captured as run artifacts
+
+Because there is only one request per worker, v1 can avoid tricky concurrency around localenv resources.
+
+---
+
+## Run lifecycle for v1
+
+```mermaid
+flowchart TD
+    A["Request arrives at Nightshift control plane"] --> B["Assign idle worker"]
+    B --> C["Worker prepares run namespace"]
+    C --> D["Provision sandbox/runtime"]
+    D --> E["Start Belayer session"]
+    E --> F["Launch Planner"]
+    F --> G["Planner chooses repos + specialists"]
+    G --> H["Launch specialists via Belayer"]
+    H --> I["Code / reports / artifacts"]
+    I --> J["Belayer triggers verification / review"]
+    J --> K["Assemble handoff artifacts"]
+    K --> L["Worker returns result to outer control plane"]
+    L --> M["Teardown worker run namespace"]
+```
+
+This diagram makes the layer boundaries explicit:
+
+- worker control plane handles assignment and lifecycle at the outside
+- Belayer owns the inside session
+
+---
+
+## Belayer API shape inside the run
+
+For this topology to work, Belayer should have a run-local API surface that is simple and durable.
+
+### Required primitives
+
+#### Session primitives
+
+- create session
+- get session status
+- list/log events
+- update phase / status
+
+#### Messaging primitives
+
+- send message to agent
+- broadcast message
+- list messages/events
+
+#### Artifact primitives
+
+- write artifact
+- list artifacts
+- fetch artifact
+- tag artifact as ready/reviewed/final
+
+#### Specialist run primitives
+
+- launch specialist
+- query specialist state
+- stop specialist
+- capture specialist summary
+
+This is the practical way agents communicate *through* Belayer inside a run.
+
+---
+
+## What to avoid in v1
+
+### 1. Shared-worker multi-session complexity
+
+Not needed yet.
+
+### 2. Making Belayer the worker scheduler
+
+That is an outer Nightshift concern.
+
+### 3. Making Hermes responsible for agent-to-agent transport
+
+Belayer should own the session bus.
+
+### 4. Over-generalizing the workbench layer
+
+For v1, `xt` is enough of a workbench interface.
+
+---
+
+## What this means for Belayer rework
+
+If we revisit the Belayer CLI and runtime now, the design pressure should be:
+
+### Belayer should become smaller in scope, but clearer in purpose.
+
+It should move toward:
+
+- **run-local agent control plane**
+- **session bus for planner + specialists**
+- **artifact/event store**
+- **specialist launcher**
+
+And away from:
+
+- generic global orchestration platform
+- worker scheduler
+- cluster manager
+- everything-for-every-agent runtime
+
+That is a healthier shape.
+
+---
+
+## Recommended next refinement
+
+After this topology, the next question is not just "what boxes exist?"
+
+It is:
+
+> what exactly is Belayer's API and data model for one run?
+
+Concretely, the next design step should define:
+
+- run phases
+- session schema
+- specialist run schema
+- artifact schema
+- message/event schema
+- planner-to-specialist communication contract
+
+That is the level where Belayer's role becomes truly implementable.

--- a/docs/design-docs/2026-04-15-nightshift-v1-deployment-topology.md
+++ b/docs/design-docs/2026-04-15-nightshift-v1-deployment-topology.md
@@ -33,6 +33,59 @@ If it works on a laptop, it should work on a Linux worker node with the same top
 
 ---
 
+## Future scaling: extend-localenv and extend-clamshell beyond MVP
+
+This topology is intentionally simple for v1, but both **extend-localenv** and **extend-clamshell** have clear roles in the future scaling path.
+
+### extend-localenv beyond MVP
+
+`xt` should grow into the **Extend-specific workbench interface** used by Nightshift runs.
+
+As the system matures, Belayer or Belayer-routed tools should use `xt` to:
+
+- validate worker readiness (`xt doctor`)
+- bring up app/api runtime dependencies (`xt up`)
+- inspect environment health (`xt status`)
+- tear down runtime state (`xt down`)
+- mint local auth/tokens where needed (`xt token`)
+
+This means the scaling path is not "replace xt with a generic workbench". It is:
+
+> **let Nightshift standardize on xt as the Extend workbench adapter**
+
+and let Belayer record the resulting readiness, validation evidence, and runtime outputs as artifacts.
+
+### extend-clamshell beyond MVP
+
+The current MVP proves the session bus with tmux and local execution. For production-oriented workers, clamshell should become the **sandbox boundary**.
+
+Clamshell scales into the topology by providing:
+
+- deny-by-default egress
+- host-owned credential mediation
+- policy-driven network and filesystem boundaries
+- audit and inspection surfaces for worker runs
+
+The likely medium-term production shape is:
+
+- Nightshift daemon keeps a small pool of Linux workers
+- each worker still handles one active request at a time
+- each active request gets its own run namespace
+- Belayer daemon runs inside that namespace as the run-local control plane
+- Hermes specialists execute inside or against clamshell-constrained workspaces
+- xt provides the Extend runtime/workbench behavior for validation
+
+### Why both matter together
+
+They solve different scaling problems:
+
+- **extend-localenv** answers: how do we bring up and validate the Extend stack?
+- **extend-clamshell** answers: how do we constrain and trust the agent execution environment?
+
+Nightshift needs both if it is going to move from laptop-proven MVP to a trustworthy Linux worker deployment.
+
+---
+
 ## Why this simplification matters
 
 It deliberately removes several sources of complexity from the MVP:
@@ -109,14 +162,14 @@ This is a much tighter and more realistic role for Belayer than "global orchestr
 
 ```mermaid
 flowchart LR
-    User["User / Jira / Reviewed Spec"] --> NCP["Nightshift Worker Control Plane\n(always on)"]
+    User["User / Jira / Reviewed Spec"] --> NCP["Nightshift daemon\n(always on)"]
     NCP --> Queue[("Request Queue / Run DB")]
     NCP --> W1["Worker 1\n(idle or running one request)"]
     NCP --> W2["Worker 2\n(idle or running one request)"]
-    NCP --> WN["Worker N\n(idle or running one request)"]
+    NCP --> W3["Worker 3\n(idle or running one request)"]
 
     subgraph Worker["One worker handling one request"]
-        B["Belayer\n(agent control plane)"]
+        B["Belayer daemon\n(agent control plane)"]
         S["Sandbox Runtime\n(clamshell or equivalent)"]
         H["Hermes specialist runs\n(planner, api, app, reviewer, qa)"]
         X["Extend workbench\n(xt / localenv runtime)"]
@@ -133,9 +186,63 @@ flowchart LR
     W1 --> Worker
 ```
 
+## Three-worker parallel picture
+
+```mermaid
+flowchart TB
+    NCP["Nightshift daemon\n(always on)"] --> W1["Worker 1\none active request"]
+    NCP --> W2["Worker 2\none active request"]
+    NCP --> W3["Worker 3\none active request"]
+
+    subgraph R1["Run A on Worker 1"]
+        B1["Belayer daemon"]
+        P1["planner"]
+        A1["api specialist"]
+        X1["xt / localenv"]
+        S1["clamshell sandbox"]
+        B1 --> P1
+        B1 --> A1
+        B1 --> X1
+        P1 --> S1
+        A1 --> S1
+    end
+
+    subgraph R2["Run B on Worker 2"]
+        B2["Belayer daemon"]
+        P2["planner"]
+        A2["api/app specialists"]
+        X2["xt / localenv"]
+        S2["clamshell sandbox"]
+        B2 --> P2
+        B2 --> A2
+        B2 --> X2
+        P2 --> S2
+        A2 --> S2
+    end
+
+    subgraph R3["Run C on Worker 3"]
+        B3["Belayer daemon"]
+        P3["planner"]
+        A3["specialists"]
+        X3["xt / localenv"]
+        S3["clamshell sandbox"]
+        B3 --> P3
+        B3 --> A3
+        B3 --> X3
+        P3 --> S3
+        A3 --> S3
+    end
+
+    W1 --> R1
+    W2 --> R2
+    W3 --> R3
+```
+
 ### Reading the diagram
 
-- The **outer Nightshift control plane** owns worker assignment and run lifecycle.
+- The **outer Nightshift daemon** owns worker assignment and run lifecycle.
+- Belayer is the **run-local** agent control plane inside each active worker run.
+- With three workers, Nightshift can process three requests in parallel while still keeping the simpler v1 rule of **one request per worker**.
 - A **worker** receives one request and becomes a self-contained execution cell.
 - Inside that worker, **Belayer** is the agent-session controller.
 - **Hermes** provides the actual specialist runs.

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -2,4 +2,8 @@
 
 ## Current Designs
 
+- [2026-04-15-belayer-run-model-for-nightshift-v1](2026-04-15-belayer-run-model-for-nightshift-v1.md) — Defines Belayer's three-layer run model for Nightshift v1: session bus, Hermes harness driver, and tmux transport adapter, plus the Belayer-mediated communication pattern for Hermes agents (2026-04-15)
+- [2026-04-15-nightshift-v1-deployment-topology](2026-04-15-nightshift-v1-deployment-topology.md) — Nightshift v1 deployment model with one request per worker, two control planes, and Belayer positioned as the intra-run agent session bus (2026-04-15)
+- [2026-04-15-nightshift-extend-first-implementation-delta](2026-04-15-nightshift-extend-first-implementation-delta.md) — Concrete package-by-package change plan from current Belayer toward an Extend-first Nightshift system, including likely code deletion targets (2026-04-15)
+- [2026-04-15-nightshift-extend-first-architecture](2026-04-15-nightshift-extend-first-architecture.md) — Extend-first Nightshift architecture; updates Belayer for Hermes-backed specialists, extend-localenv workbench integration, and extend-clamshell as the primary runtime boundary (2026-04-15)
 - [2026-04-09-sandbox-runtime-architecture-design](2026-04-09-sandbox-runtime-architecture-design.md) — Sandbox provisioning, pluggable runtime, agent topology, and security boundaries (2026-04-09)

--- a/internal/cli/artifact.go
+++ b/internal/cli/artifact.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/donovan-yohan/belayer/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newArtifactCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "artifact", Short: "Create and inspect run artifacts"}
+	cmd.AddCommand(newArtifactCreateCmd(), newArtifactListCmd())
+	return cmd
+}
+
+func newArtifactCreateCmd() *cobra.Command {
+	var session, socket, kind, path, producer, summary string
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Register a durable artifact for the current session",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessID, err := resolveSessionID(session)
+			if err != nil {
+				return err
+			}
+			if kind == "" || path == "" {
+				return fmt.Errorf("--kind and --path are required")
+			}
+			if producer == "" {
+				producer = senderID()
+			}
+			c := NewClient(resolveSocket(socket))
+			a, err := c.CreateArtifact(sessID, artifactCreateCLIRequest{Kind: kind, Path: path, Producer: producer, Summary: summary})
+			if err != nil {
+				return fmt.Errorf("create artifact: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Created artifact %s (%s) by %s\n", a.Kind, a.Path, a.Producer)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&session, "session", "", "Session ID (required if BELAYER_SESSION_ID not set)")
+	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	cmd.Flags().StringVar(&kind, "kind", "", "Artifact kind")
+	cmd.Flags().StringVar(&path, "path", "", "Artifact path relative to run/workdir")
+	cmd.Flags().StringVar(&producer, "producer", "", "Agent creating the artifact")
+	cmd.Flags().StringVar(&summary, "summary", "", "Short summary")
+	return cmd
+}
+
+func newArtifactListCmd() *cobra.Command {
+	var session, socket string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List artifacts for the current session",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessID, err := resolveSessionID(session)
+			if err != nil {
+				return err
+			}
+			c := NewClient(resolveSocket(socket))
+			artifacts, err := c.ListArtifacts(sessID)
+			if err != nil {
+				return fmt.Errorf("list artifacts: %w", err)
+			}
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "KIND\tPRODUCER\tPATH\tSUMMARY")
+			for _, a := range artifacts {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", a.Kind, a.Producer, a.Path, a.Summary)
+			}
+			w.Flush()
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&session, "session", "", "Session ID (required if BELAYER_SESSION_ID not set)")
+	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	return cmd
+}
+
+type artifactCreateCLIRequest struct {
+	Kind     string `json:"kind"`
+	Path     string `json:"path"`
+	Producer string `json:"producer"`
+	Summary  string `json:"summary"`
+}
+
+func (c *Client) CreateArtifact(sessionID string, req artifactCreateCLIRequest) (store.Artifact, error) {
+	resp, err := c.do("POST", "/sessions/"+sessionID+"/artifacts", req)
+	if err != nil {
+		return store.Artifact{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 201 {
+		return store.Artifact{}, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	var a store.Artifact
+	if err := json.NewDecoder(resp.Body).Decode(&a); err != nil {
+		return store.Artifact{}, fmt.Errorf("decode artifact: %w", err)
+	}
+	return a, nil
+}
+
+func (c *Client) ListArtifacts(sessionID string) ([]store.Artifact, error) {
+	resp, err := c.do("GET", "/sessions/"+sessionID+"/artifacts", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var artifacts []store.Artifact
+	if err := json.NewDecoder(resp.Body).Decode(&artifacts); err != nil {
+		return nil, fmt.Errorf("decode artifacts: %w", err)
+	}
+	return artifacts, nil
+}

--- a/internal/cli/artifact.go
+++ b/internal/cli/artifact.go
@@ -107,6 +107,9 @@ func (c *Client) ListArtifacts(sessionID string) ([]store.Artifact, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
 	var artifacts []store.Artifact
 	if err := json.NewDecoder(resp.Body).Decode(&artifacts); err != nil {
 		return nil, fmt.Errorf("decode artifacts: %w", err)

--- a/internal/cli/artifact_test.go
+++ b/internal/cli/artifact_test.go
@@ -1,0 +1,14 @@
+package cli
+
+import "testing"
+
+func TestRootCmdRegistersArtifactCommand(t *testing.T) {
+	cmd := NewRootCmd()
+	seen := map[string]bool{}
+	for _, child := range cmd.Commands() {
+		seen[child.Name()] = true
+	}
+	if !seen["artifact"] {
+		t.Fatal("missing artifact command")
+	}
+}

--- a/internal/cli/nightshift.go
+++ b/internal/cli/nightshift.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/donovan-yohan/belayer/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func resolveAgentID(flagVal string) (string, error) {
+	if id := os.Getenv("BELAYER_AGENT_ID"); id != "" {
+		return id, nil
+	}
+	if flagVal != "" {
+		return flagVal, nil
+	}
+	return "", fmt.Errorf("BELAYER_AGENT_ID is not set and --agent flag is required")
+}
+
+func newSpawnCmd() *cobra.Command {
+	var session, socket, name, role, profile, repo, workdir string
+	cmd := &cobra.Command{
+		Use:   "spawn",
+		Short: "Spawn a new agent in the current session",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessID, err := resolveSessionID(session)
+			if err != nil {
+				return err
+			}
+			if name == "" || profile == "" {
+				return fmt.Errorf("--name and --profile are required")
+			}
+			c := NewClient(resolveSocket(socket))
+			run, err := c.SpawnAgent(sessID, spawnAgentRequest{Name: name, Role: role, Profile: profile, Repo: repo, Workdir: workdir})
+			if err != nil {
+				return fmt.Errorf("spawn agent: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Spawned %s (%s) via %s\n", run.Name, run.Profile, run.Transport)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&session, "session", "", "Session ID (required if BELAYER_SESSION_ID not set)")
+	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	cmd.Flags().StringVar(&name, "name", "", "Logical agent name")
+	cmd.Flags().StringVar(&role, "role", "", "Role description/id")
+	cmd.Flags().StringVar(&profile, "profile", "", "Hermes profile to launch")
+	cmd.Flags().StringVar(&repo, "repo", "", "Repo scope label")
+	cmd.Flags().StringVar(&workdir, "workdir", "", "Working directory for the agent")
+	return cmd
+}
+
+func newRosterCmd() *cobra.Command {
+	var session, socket string
+	cmd := &cobra.Command{
+		Use:   "roster",
+		Short: "List active agents in the current session",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessID, err := resolveSessionID(session)
+			if err != nil {
+				return err
+			}
+			c := NewClient(resolveSocket(socket))
+			runs, err := c.ListAgents(sessID)
+			if err != nil {
+				return fmt.Errorf("roster: %w", err)
+			}
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(w, "NAME\tROLE\tPROFILE\tSTATUS\tTRANSPORT")
+			for _, run := range runs {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", run.Name, run.Role, run.Profile, run.Status, run.Transport)
+			}
+			w.Flush()
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&session, "session", "", "Session ID (required if BELAYER_SESSION_ID not set)")
+	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	return cmd
+}
+
+func newFinishCmd() *cobra.Command {
+	var session, socket, agent string
+	var blocked bool
+	cmd := &cobra.Command{
+		Use:   "finish " + "\"summary\"",
+		Short: "Mark the current agent's work as complete or blocked",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sessID, err := resolveSessionID(session)
+			if err != nil {
+				return err
+			}
+			agentID, err := resolveAgentID(agent)
+			if err != nil {
+				return err
+			}
+			c := NewClient(resolveSocket(socket))
+			run, err := c.FinishAgent(sessID, agentID, finishAgentRequest{Summary: args[0], Blocked: blocked})
+			if err != nil {
+				return fmt.Errorf("finish agent: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s marked %s\n", run.Name, run.Status)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&session, "session", "", "Session ID (required if BELAYER_SESSION_ID not set)")
+	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	cmd.Flags().StringVar(&agent, "agent", "", "Agent ID (required if BELAYER_AGENT_ID not set)")
+	cmd.Flags().BoolVar(&blocked, "blocked", false, "Mark the current work as blocked instead of complete")
+	return cmd
+}
+
+type spawnAgentRequest struct {
+	Name    string `json:"name"`
+	Role    string `json:"role"`
+	Profile string `json:"profile"`
+	Repo    string `json:"repo,omitempty"`
+	Workdir string `json:"workdir,omitempty"`
+}
+
+type finishAgentRequest struct {
+	Summary string `json:"summary"`
+	Blocked bool   `json:"blocked"`
+}
+
+func (c *Client) SpawnAgent(sessionID string, req spawnAgentRequest) (store.AgentRun, error) {
+	resp, err := c.do("POST", "/sessions/"+sessionID+"/agents", req)
+	if err != nil {
+		return store.AgentRun{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 201 {
+		return store.AgentRun{}, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	var run store.AgentRun
+	if err := json.NewDecoder(resp.Body).Decode(&run); err != nil {
+		return store.AgentRun{}, fmt.Errorf("decode agent run: %w", err)
+	}
+	return run, nil
+}
+
+func (c *Client) ListAgents(sessionID string) ([]store.AgentRun, error) {
+	resp, err := c.do("GET", "/sessions/"+sessionID+"/agents", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var runs []store.AgentRun
+	if err := json.NewDecoder(resp.Body).Decode(&runs); err != nil {
+		return nil, fmt.Errorf("decode agent runs: %w", err)
+	}
+	return runs, nil
+}
+
+func (c *Client) FinishAgent(sessionID, agentID string, req finishAgentRequest) (store.AgentRun, error) {
+	resp, err := c.do("POST", "/sessions/"+sessionID+"/agents/"+agentID+"/finish", req)
+	if err != nil {
+		return store.AgentRun{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return store.AgentRun{}, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	var run store.AgentRun
+	if err := json.NewDecoder(resp.Body).Decode(&run); err != nil {
+		return store.AgentRun{}, fmt.Errorf("decode agent run: %w", err)
+	}
+	return run, nil
+}

--- a/internal/cli/nightshift.go
+++ b/internal/cli/nightshift.go
@@ -11,11 +11,11 @@ import (
 )
 
 func resolveAgentID(flagVal string) (string, error) {
-	if id := os.Getenv("BELAYER_AGENT_ID"); id != "" {
-		return id, nil
-	}
 	if flagVal != "" {
 		return flagVal, nil
+	}
+	if id := os.Getenv("BELAYER_AGENT_ID"); id != "" {
+		return id, nil
 	}
 	return "", fmt.Errorf("BELAYER_AGENT_ID is not set and --agent flag is required")
 }
@@ -148,6 +148,9 @@ func (c *Client) ListAgents(sessionID string) ([]store.AgentRun, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
 	var runs []store.AgentRun
 	if err := json.NewDecoder(resp.Body).Decode(&runs); err != nil {
 		return nil, fmt.Errorf("decode agent runs: %w", err)

--- a/internal/cli/nightshift_test.go
+++ b/internal/cli/nightshift_test.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRootCmdRegistersNightshiftCommands(t *testing.T) {
+	cmd := NewRootCmd()
+
+	want := []string{"run", "spawn", "roster", "finish"}
+	seen := map[string]bool{}
+	for _, child := range cmd.Commands() {
+		seen[child.Name()] = true
+	}
+
+	for _, name := range want {
+		if !seen[name] {
+			t.Fatalf("missing nightshift command %q", name)
+		}
+	}
+}
+
+func TestFinishCmdRequiresSummary(t *testing.T) {
+	cmd := newFinishCmd()
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when finish summary is missing")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -31,6 +31,7 @@ Commands:
 	cmd.AddCommand(
 		newVersionCmd(),
 		newDaemonCmd(),
+		newRunCmd(),
 		newSessionCmd(),
 		newAttachCmd(),
 		newLogsCmd(),
@@ -39,6 +40,10 @@ Commands:
 		newDebugCmd(),
 		newRecallCmd(),
 		newMessageCmd(),
+		newArtifactCmd(),
+		newRosterCmd(),
+		newSpawnCmd(),
+		newFinishCmd(),
 		newContextCmd(),
 		newNoteCmd(),
 		newSetupCmd(),

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -49,7 +49,8 @@ func newRunStartCmd() *cobra.Command {
 			fmt.Fprintf(cmd.OutOrStdout(), "Run started: %s (%s)\n", sess.ID, sess.Name)
 			fmt.Fprintln(cmd.OutOrStdout(), "Planner: planner")
 			fmt.Fprintln(cmd.OutOrStdout(), "Monitor with:")
-			fmt.Fprintf(cmd.OutOrStdout(), "  BELAYER_SESSION_ID=%s belayer roster\n", sess.ID)
+			sockPath := resolveSocket(socket)
+			fmt.Fprintf(cmd.OutOrStdout(), "  BELAYER_SESSION_ID=%s BELAYER_SOCKET=%s belayer roster\n", sess.ID, sockPath)
 			fmt.Fprintf(cmd.OutOrStdout(), "  belayer logs %s\n", sess.ID)
 			return nil
 		},

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Nightshift run lifecycle commands",
+	}
+	cmd.AddCommand(newRunStartCmd())
+	return cmd
+}
+
+func newRunStartCmd() *cobra.Command {
+	var socket, name, task, plannerProfile, workdir string
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Create a run, spawn planner, and deliver the initial task",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(task) == "" {
+				return fmt.Errorf("--task is required")
+			}
+			if strings.TrimSpace(plannerProfile) == "" {
+				return fmt.Errorf("--planner-profile is required")
+			}
+			c := NewClient(resolveSocket(socket))
+			sessionName := name
+			if sessionName == "" {
+				sessionName = "nightshift-run"
+			}
+			sess, err := c.CreateSession(sessionName, "nightshift")
+			if err != nil {
+				return fmt.Errorf("create session: %w", err)
+			}
+			if _, err := c.UpdateSession(sess.ID, "running"); err != nil {
+				return fmt.Errorf("mark session running: %w", err)
+			}
+			if _, err := c.SpawnAgent(sess.ID, spawnAgentRequest{Name: "planner", Role: "planner", Profile: plannerProfile, Workdir: workdir}); err != nil {
+				return fmt.Errorf("spawn planner: %w", err)
+			}
+			if _, err := c.SendMessage(sess.ID, "planner", task, "instruction", true); err != nil {
+				return fmt.Errorf("deliver initial task: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Run started: %s (%s)\n", sess.ID, sess.Name)
+			fmt.Fprintln(cmd.OutOrStdout(), "Planner: planner")
+			fmt.Fprintln(cmd.OutOrStdout(), "Monitor with:")
+			fmt.Fprintf(cmd.OutOrStdout(), "  BELAYER_SESSION_ID=%s belayer roster\n", sess.ID)
+			fmt.Fprintf(cmd.OutOrStdout(), "  belayer logs %s\n", sess.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	cmd.Flags().StringVar(&name, "name", "", "Run/session name")
+	cmd.Flags().StringVar(&task, "task", "", "Initial task text for the planner")
+	cmd.Flags().StringVar(&plannerProfile, "planner-profile", "", "Hermes profile for the planner")
+	cmd.Flags().StringVar(&workdir, "workdir", "", "Working directory for planner and spawned agents")
+	return cmd
+}

--- a/internal/cli/run_smoke_test.go
+++ b/internal/cli/run_smoke_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunStartCreatesSessionSpawnsPlannerAndDeliversInitialTask(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logPath := installFakeTmux(t)
+	cancel, socketPath := startTestDaemon(t)
+	defer cancel()
+
+	repoDir := filepath.Join(t.TempDir(), "belayer-repo")
+	initGitRepo(t, repoDir, "belayer")
+
+	out := runRootCmd(t,
+		"run", "start",
+		"--socket", socketPath,
+		"--name", "nightshift-smoke",
+		"--task", "Investigate a single-repo change",
+		"--planner-profile", "default",
+		"--workdir", repoDir,
+	)
+	for _, want := range []string{"Run started:", "planner", "belayer roster"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+
+	client := NewClient(socketPath)
+	sessions, err := client.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].Status != "running" {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	runs, err := client.ListAgents(sessions[0].ID)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(runs) != 1 || runs[0].Name != "planner" {
+		t.Fatalf("unexpected agent runs: %#v", runs)
+	}
+	if runs[0].Status != "running" && runs[0].Status != "blocked" {
+		t.Fatalf("expected planner status running or blocked in fake-tmux environment, got %#v", runs)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read tmux log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "new-session -d -s belayer-"+sessions[0].ID+"-planner") {
+		t.Fatalf("expected planner tmux session in log, got:\n%s", logText)
+	}
+	if !strings.Contains(logText, "send-keys -t belayer-"+sessions[0].ID+"-planner -l Investigate a single-repo change") {
+		t.Fatalf("expected initial task delivery in tmux log, got:\n%s", logText)
+	}
+}

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -110,6 +110,10 @@ func (d *Daemon) handleListAgents(w http.ResponseWriter, r *http.Request) {
 func (d *Daemon) handleFinishAgent(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
 	name := r.PathValue("name")
+	if _, err := d.store.GetAgentRun(sessionID, name); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "agent not found"})
+		return
+	}
 	var req finishAgentRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -157,6 +161,10 @@ func (d *Daemon) defaultLaunchAgent(req agentSpawnRequest) (string, error) {
 			return "", fmt.Errorf("determine workdir: %w", err)
 		}
 		workdir = cwd
+	}
+	// Persist the resolved workdir so watchAgentExit can locate the finish marker.
+	if req.Workdir == "" {
+		_ = d.store.UpdateAgentRunWorkdir(req.SessionID, req.Name, workdir)
 	}
 	runDir := filepath.Join(workdir, ".belayer", "runs", req.SessionID, req.Name)
 	if err := os.MkdirAll(runDir, 0o700); err != nil {

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -1,0 +1,222 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/donovan-yohan/belayer/internal/broker"
+	hermesharness "github.com/donovan-yohan/belayer/internal/harness/hermes"
+	"github.com/donovan-yohan/belayer/internal/store"
+)
+
+type agentSpawnRequest struct {
+	SessionID string `json:"-"`
+	Name      string `json:"name"`
+	Role      string `json:"role"`
+	Profile   string `json:"profile"`
+	Repo      string `json:"repo,omitempty"`
+	Workdir   string `json:"workdir,omitempty"`
+}
+
+type finishAgentRequest struct {
+	Summary string `json:"summary"`
+	Blocked bool   `json:"blocked"`
+}
+
+func (d *Daemon) handleSpawnAgent(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	if _, err := d.store.GetSession(sessionID); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+		return
+	}
+	var req agentSpawnRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if req.Name == "" || req.Profile == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and profile are required"})
+		return
+	}
+	req.SessionID = sessionID
+	run := store.AgentRun{
+		SessionID: sessionID,
+		Name:      req.Name,
+		Role:      req.Role,
+		Profile:   req.Profile,
+		RepoScope: req.Repo,
+		Workdir:   req.Workdir,
+		Transport: "tmux",
+		Status:    "starting",
+	}
+	if _, err := d.store.CreateAgentRun(run); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	tmuxSession, err := d.launchAgent(req)
+	if err != nil {
+		_ = d.store.UpdateAgentRunStatus(sessionID, req.Name, "failed")
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := d.store.UpdateAgentRunTmuxSession(sessionID, req.Name, tmuxSession); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := d.store.UpdateAgentRunStatus(sessionID, req.Name, "running"); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	stored, err := d.store.GetAgentRun(sessionID, req.Name)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	_ = d.broker.Subscribe(sessionID, req.Name, func(msg broker.Message) {
+		_ = d.deliverMessage(stored, msg)
+	})
+	d.watchAgentExit(stored)
+	_ = d.store.LogEvent(store.SessionEvent{
+		SessionID: sessionID,
+		Type:      "agent_spawned",
+		Data: mustJSON(map[string]string{
+			"agent":       req.Name,
+			"role":        req.Role,
+			"profile":     req.Profile,
+			"tmux_session": tmuxSession,
+		}),
+	})
+	writeJSON(w, http.StatusCreated, stored)
+}
+
+func (d *Daemon) handleListAgents(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	if _, err := d.store.GetSession(sessionID); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+		return
+	}
+	runs, err := d.store.ListAgentRuns(sessionID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, runs)
+}
+
+func (d *Daemon) handleFinishAgent(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	name := r.PathValue("name")
+	var req finishAgentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	status := "complete"
+	if req.Blocked {
+		status = "blocked"
+	}
+	if err := d.store.UpdateAgentRunStatus(sessionID, name, status); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	run, err := d.store.GetAgentRun(sessionID, name)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	_ = d.store.LogEvent(store.SessionEvent{
+		SessionID: sessionID,
+		Type:      "agent_finished",
+		Data: mustJSON(map[string]string{
+			"agent":   name,
+			"status":  status,
+			"summary": req.Summary,
+		}),
+	})
+	if name != "planner" {
+		content := fmt.Sprintf("%s marked work as %s. Summary: %s", name, status, req.Summary)
+		msg := broker.Message{SessionID: sessionID, SenderID: name, RecipientID: "planner", Type: broker.MessageStateChange, Content: content, Timestamp: time.Now().UTC(), Urgent: req.Blocked}
+		if req.Blocked {
+			_ = d.broker.Interrupt(sessionID, "planner", msg)
+		} else {
+			_ = d.broker.Send(sessionID, "planner", msg)
+		}
+	}
+	writeJSON(w, http.StatusOK, run)
+}
+
+func (d *Daemon) defaultLaunchAgent(req agentSpawnRequest) (string, error) {
+	workdir := req.Workdir
+	if workdir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("determine workdir: %w", err)
+		}
+		workdir = cwd
+	}
+	runDir := filepath.Join(workdir, ".belayer", "runs", req.SessionID, req.Name)
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		return "", fmt.Errorf("create run dir: %w", err)
+	}
+	tmuxSession := req.SessionID + "-" + req.Name
+	cmd, err := hermesharness.BuildLaunchCmd(hermesharness.LaunchConfig{
+		Profile:    req.Profile,
+		Workdir:    workdir,
+		SocketPath: d.config.SocketPath,
+		SessionID:  req.SessionID,
+		AgentID:    req.Name,
+		RunDir:     runDir,
+		Skills:     []string{"belayer-support:belayer-communication"},
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := d.runner.CreateSession(tmuxSession, cmd); err != nil {
+		return "", err
+	}
+	return tmuxSession, nil
+}
+
+func (d *Daemon) defaultDeliverMessage(run store.AgentRun, msg broker.Message) error {
+	payload := msg.Content
+	if err := d.runner.SendKeys(run.TmuxSession, payload, true); err != nil {
+		return err
+	}
+	return d.runner.SendEnter(run.TmuxSession)
+}
+
+func (d *Daemon) watchAgentExit(run store.AgentRun) {
+	if d.runner == nil || run.TmuxSession == "" {
+		return
+	}
+	go func() {
+		if err := d.runner.WaitForSession(run.TmuxSession, 24*time.Hour); err != nil {
+			return
+		}
+		current, err := d.store.GetAgentRun(run.SessionID, run.Name)
+		if err != nil {
+			return
+		}
+		if current.Status != "running" {
+			return
+		}
+		marker := filepath.Join(current.Workdir, ".belayer", "runs", current.SessionID, current.Name, ".belayer-finished")
+		if _, err := os.Stat(marker); err == nil {
+			return
+		}
+		_ = d.store.UpdateAgentRunStatus(run.SessionID, run.Name, "blocked")
+		_ = d.store.LogEvent(store.SessionEvent{
+			SessionID: run.SessionID,
+			Type:      "agent_exited_without_finish",
+			Data:      mustJSON(map[string]string{"agent": run.Name, "status": "blocked"}),
+		})
+		if run.Name != "planner" {
+			msg := broker.Message{SessionID: run.SessionID, SenderID: run.Name, RecipientID: "planner", Type: broker.MessageStateChange, Content: run.Name + " exited without belayer finish and was marked blocked", Urgent: true, Timestamp: time.Now().UTC()}
+			_ = d.broker.Interrupt(run.SessionID, "planner", msg)
+		}
+	}()
+}

--- a/internal/daemon/artifacts.go
+++ b/internal/daemon/artifacts.go
@@ -1,0 +1,59 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/donovan-yohan/belayer/internal/store"
+)
+
+type artifactCreateRequest struct {
+	Kind     string `json:"kind"`
+	Path     string `json:"path"`
+	Producer string `json:"producer"`
+	Summary  string `json:"summary"`
+}
+
+func (d *Daemon) handleCreateArtifact(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	if _, err := d.store.GetSession(sessionID); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+		return
+	}
+	var req artifactCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if req.Kind == "" || req.Path == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "kind and path are required"})
+		return
+	}
+	artifact := store.Artifact{SessionID: sessionID, Kind: req.Kind, Path: req.Path, Producer: req.Producer, Summary: req.Summary}
+	if _, err := d.store.CreateArtifact(artifact); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	artifacts, err := d.store.ListArtifacts(sessionID)
+	if err != nil || len(artifacts) == 0 {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to reload artifact"})
+		return
+	}
+	created := artifacts[len(artifacts)-1]
+	_ = d.store.LogEvent(store.SessionEvent{SessionID: sessionID, Type: "artifact_created", Data: mustJSON(map[string]string{"kind": req.Kind, "path": req.Path, "producer": req.Producer})})
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (d *Daemon) handleListArtifacts(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	if _, err := d.store.GetSession(sessionID); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+		return
+	}
+	artifacts, err := d.store.ListArtifacts(sessionID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, artifacts)
+}

--- a/internal/daemon/artifacts.go
+++ b/internal/daemon/artifacts.go
@@ -30,16 +30,16 @@ func (d *Daemon) handleCreateArtifact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	artifact := store.Artifact{SessionID: sessionID, Kind: req.Kind, Path: req.Path, Producer: req.Producer, Summary: req.Summary}
-	if _, err := d.store.CreateArtifact(artifact); err != nil {
+	id, err := d.store.CreateArtifact(artifact)
+	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
-	artifacts, err := d.store.ListArtifacts(sessionID)
-	if err != nil || len(artifacts) == 0 {
+	created, err := d.store.GetArtifact(id)
+	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to reload artifact"})
 		return
 	}
-	created := artifacts[len(artifacts)-1]
 	_ = d.store.LogEvent(store.SessionEvent{SessionID: sessionID, Type: "artifact_created", Data: mustJSON(map[string]string{"kind": req.Kind, "path": req.Path, "producer": req.Producer})})
 	writeJSON(w, http.StatusCreated, created)
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -17,8 +17,10 @@ import (
 	"time"
 
 	"github.com/donovan-yohan/belayer/internal/agent"
+	"github.com/donovan-yohan/belayer/internal/broker"
 	"github.com/donovan-yohan/belayer/internal/docker"
 	"github.com/donovan-yohan/belayer/internal/store"
+	"github.com/donovan-yohan/belayer/internal/tmux"
 	"gopkg.in/yaml.v3"
 )
 
@@ -44,6 +46,11 @@ type Daemon struct {
 	listener net.Listener
 	server   *http.Server
 	config   Config
+	broker   broker.Broker
+	runner   tmux.Runner
+
+	launchAgent    func(req agentSpawnRequest) (string, error)
+	deliverMessage func(run store.AgentRun, msg broker.Message) error
 
 	// Tool registry: per-session tool specs, protected by toolsMu.
 	toolsMu sync.RWMutex
@@ -62,6 +69,10 @@ func New(cfg Config) (*Daemon, error) {
 	}
 
 	d := &Daemon{store: st, config: cfg, tools: make(map[string][]agent.ToolSpec)}
+	d.broker = broker.NewMemoryBroker(st)
+	d.runner = tmux.NewLocalRunner()
+	d.launchAgent = d.defaultLaunchAgent
+	d.deliverMessage = d.defaultDeliverMessage
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", d.handleHealth)
 	mux.HandleFunc("POST /sessions", d.handleCreateSession)
@@ -74,6 +85,11 @@ func New(cfg Config) (*Daemon, error) {
 	mux.HandleFunc("POST /sessions/{id}/messages", d.handleSendMessage)
 	mux.HandleFunc("POST /sessions/{id}/messages/broadcast", d.handleBroadcastMessage)
 	mux.HandleFunc("GET /sessions/{id}/messages", d.handleListMessages)
+	mux.HandleFunc("POST /sessions/{id}/agents", d.handleSpawnAgent)
+	mux.HandleFunc("GET /sessions/{id}/agents", d.handleListAgents)
+	mux.HandleFunc("POST /sessions/{id}/agents/{name}/finish", d.handleFinishAgent)
+	mux.HandleFunc("POST /sessions/{id}/artifacts", d.handleCreateArtifact)
+	mux.HandleFunc("GET /sessions/{id}/artifacts", d.handleListArtifacts)
 	mux.HandleFunc("GET /search", d.handleSearch)
 	mux.HandleFunc("POST /sessions/{id}/workbench", d.handleCreateWorkbench)
 	mux.HandleFunc("GET /sessions/{id}/workbench", d.handleGetWorkbench)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/donovan-yohan/belayer/internal/agent"
+	"github.com/donovan-yohan/belayer/internal/broker"
 	"github.com/donovan-yohan/belayer/internal/docker"
 	"github.com/donovan-yohan/belayer/internal/store"
 )
@@ -30,6 +31,9 @@ func testDaemon(t *testing.T) *Daemon {
 	t.Cleanup(func() { st.Close() })
 
 	d := &Daemon{store: st, config: Config{}, tools: make(map[string][]agent.ToolSpec)}
+	d.broker = broker.NewMemoryBroker(st)
+	d.launchAgent = func(req agentSpawnRequest) (string, error) { return req.Name + "-tmux", nil }
+	d.deliverMessage = func(_ store.AgentRun, _ broker.Message) error { return nil }
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", d.handleHealth)
 	mux.HandleFunc("POST /sessions", d.handleCreateSession)
@@ -39,6 +43,14 @@ func testDaemon(t *testing.T) *Daemon {
 	mux.HandleFunc("GET /sessions/{id}/events", d.handleGetEvents)
 	mux.HandleFunc("POST /sessions/{id}/events", d.handleLogEvent)
 	mux.HandleFunc("GET /events/stream", d.handleStreamEvents)
+	mux.HandleFunc("POST /sessions/{id}/messages", d.handleSendMessage)
+	mux.HandleFunc("POST /sessions/{id}/messages/broadcast", d.handleBroadcastMessage)
+	mux.HandleFunc("GET /sessions/{id}/messages", d.handleListMessages)
+	mux.HandleFunc("POST /sessions/{id}/agents", d.handleSpawnAgent)
+	mux.HandleFunc("GET /sessions/{id}/agents", d.handleListAgents)
+	mux.HandleFunc("POST /sessions/{id}/agents/{name}/finish", d.handleFinishAgent)
+	mux.HandleFunc("POST /sessions/{id}/artifacts", d.handleCreateArtifact)
+	mux.HandleFunc("GET /sessions/{id}/artifacts", d.handleListArtifacts)
 	mux.HandleFunc("GET /search", d.handleSearch)
 	mux.HandleFunc("POST /sessions/{id}/workbench", d.handleCreateWorkbench)
 	mux.HandleFunc("GET /sessions/{id}/workbench", d.handleGetWorkbench)
@@ -62,6 +74,16 @@ func doRequest(t *testing.T, d *Daemon, method, path string, body any) *httptest
 	d.server.Handler.ServeHTTP(rr, req)
 	return rr
 }
+
+type immediateRunner struct{}
+
+func (immediateRunner) CreateSession(name, cmd string) error { return nil }
+func (immediateRunner) SendKeys(session, keys string, bracketed bool) error { return nil }
+func (immediateRunner) SendEnter(session string) error { return nil }
+func (immediateRunner) CapturePane(session string) (string, error) { return "", nil }
+func (immediateRunner) KillSession(session string) error { return nil }
+func (immediateRunner) WaitForSession(session string, timeout time.Duration) error { return nil }
+func (immediateRunner) ListSessions() ([]string, error) { return nil, nil }
 
 func decodeJSON[T any](t *testing.T, rr *httptest.ResponseRecorder) T {
 	t.Helper()
@@ -175,6 +197,122 @@ func TestUpdateSessionStatus(t *testing.T) {
 	sess := decodeJSON[store.Session](t, rr)
 	if sess.Status != "active" {
 		t.Fatalf("expected status=active, got %s", sess.Status)
+	}
+}
+
+func TestSpawnAgentAndListRoster(t *testing.T) {
+	d := testDaemon(t)
+	created := decodeJSON[store.Session](t, doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "spawn-test"}))
+
+	rr := doRequest(t, d, "POST", "/sessions/"+created.ID+"/agents", agentSpawnRequest{
+		Name:    "planner",
+		Role:    "planner",
+		Profile: "nightshift-planner",
+		Workdir: "/tmp/workdir",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	run := decodeJSON[store.AgentRun](t, rr)
+	if run.Name != "planner" || run.Profile != "nightshift-planner" {
+		t.Fatalf("unexpected agent run: %#v", run)
+	}
+	if run.Status != "running" {
+		t.Fatalf("expected running status, got %q", run.Status)
+	}
+
+	rosterRR := doRequest(t, d, "GET", "/sessions/"+created.ID+"/agents", nil)
+	if rosterRR.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rosterRR.Code)
+	}
+	roster := decodeJSON[[]store.AgentRun](t, rosterRR)
+	if len(roster) != 1 || roster[0].Name != "planner" {
+		t.Fatalf("unexpected roster: %#v", roster)
+	}
+}
+
+func TestSendMessageDeliversToSpawnedAgent(t *testing.T) {
+	d := testDaemon(t)
+	var delivered []string
+	d.deliverMessage = func(_ store.AgentRun, msg broker.Message) error {
+		delivered = append(delivered, msg.Content)
+		return nil
+	}
+	created := decodeJSON[store.Session](t, doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "msg-test"}))
+	doRequest(t, d, "POST", "/sessions/"+created.ID+"/agents", agentSpawnRequest{Name: "api", Role: "api", Profile: "nightshift-api"})
+
+	rr := doRequest(t, d, "POST", "/sessions/"+created.ID+"/messages", sendMessageRequest{To: "api", Content: "hello api", Type: "instruction", From: "planner", Interrupt: true})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(delivered) == 0 || delivered[len(delivered)-1] != "hello api" {
+		t.Fatalf("expected delivered message, got %#v", delivered)
+	}
+}
+
+func TestFinishAgentMarksComplete(t *testing.T) {
+	d := testDaemon(t)
+	created := decodeJSON[store.Session](t, doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "finish-test"}))
+	doRequest(t, d, "POST", "/sessions/"+created.ID+"/agents", agentSpawnRequest{Name: "api", Role: "api", Profile: "nightshift-api"})
+
+	rr := doRequest(t, d, "POST", "/sessions/"+created.ID+"/agents/api/finish", finishAgentRequest{Summary: "done"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	run := decodeJSON[store.AgentRun](t, rr)
+	if run.Status != "complete" {
+		t.Fatalf("expected complete status, got %q", run.Status)
+	}
+}
+
+func TestCreateAndListArtifacts(t *testing.T) {
+	d := testDaemon(t)
+	created := decodeJSON[store.Session](t, doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "artifact-test"}))
+
+	rr := doRequest(t, d, "POST", "/sessions/"+created.ID+"/artifacts", artifactCreateRequest{
+		Kind:     "shared-contract",
+		Path:     "artifacts/shared-contract.md",
+		Producer: "api",
+		Summary:  "Actual implemented API contract",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	artifact := decodeJSON[store.Artifact](t, rr)
+	if artifact.Kind != "shared-contract" || artifact.Producer != "api" {
+		t.Fatalf("unexpected artifact: %#v", artifact)
+	}
+
+	listRR := doRequest(t, d, "GET", "/sessions/"+created.ID+"/artifacts", nil)
+	if listRR.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listRR.Code)
+	}
+	artifacts := decodeJSON[[]store.Artifact](t, listRR)
+	if len(artifacts) != 1 || artifacts[0].Path != "artifacts/shared-contract.md" {
+		t.Fatalf("unexpected artifacts: %#v", artifacts)
+	}
+}
+
+func TestWatchAgentExitMarksBlockedWithoutFinish(t *testing.T) {
+	d := testDaemon(t)
+	created := decodeJSON[store.Session](t, doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "exit-watch-test"}))
+	d.runner = immediateRunner{}
+	_, err := d.store.CreateAgentRun(store.AgentRun{SessionID: created.ID, Name: "api", Role: "api", Profile: "default", Workdir: t.TempDir(), TmuxSession: "exit-watch", Status: "running", Transport: "tmux"})
+	if err != nil {
+		t.Fatalf("CreateAgentRun: %v", err)
+	}
+	run, err := d.store.GetAgentRun(created.ID, "api")
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	d.watchAgentExit(run)
+	time.Sleep(100 * time.Millisecond)
+	updated, err := d.store.GetAgentRun(created.ID, "api")
+	if err != nil {
+		t.Fatalf("GetAgentRun updated: %v", err)
+	}
+	if updated.Status != "blocked" {
+		t.Fatalf("expected blocked status, got %q", updated.Status)
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -306,13 +306,20 @@ func TestWatchAgentExitMarksBlockedWithoutFinish(t *testing.T) {
 		t.Fatalf("GetAgentRun: %v", err)
 	}
 	d.watchAgentExit(run)
-	time.Sleep(100 * time.Millisecond)
-	updated, err := d.store.GetAgentRun(created.ID, "api")
-	if err != nil {
-		t.Fatalf("GetAgentRun updated: %v", err)
-	}
-	if updated.Status != "blocked" {
-		t.Fatalf("expected blocked status, got %q", updated.Status)
+	deadline := time.After(2 * time.Second)
+	for {
+		updated, err := d.store.GetAgentRun(created.ID, "api")
+		if err != nil {
+			t.Fatalf("GetAgentRun updated: %v", err)
+		}
+		if updated.Status == "blocked" {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for blocked status, got %q", updated.Status)
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 }
 

--- a/internal/daemon/messages.go
+++ b/internal/daemon/messages.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/donovan-yohan/belayer/internal/broker"
 	"github.com/donovan-yohan/belayer/internal/store"
 	"github.com/google/uuid"
 )
@@ -46,6 +47,27 @@ func (d *Daemon) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	if from == "" {
 		from = "operator"
 	}
+	msg := broker.Message{
+		ID:          msgID,
+		SessionID:   id,
+		SenderID:    from,
+		RecipientID: req.To,
+		Type:        broker.MessageType(req.Type),
+		Content:     req.Content,
+		Urgent:      req.Interrupt,
+		Timestamp:   time.Now().UTC(),
+	}
+
+	var err error
+	if req.Interrupt {
+		err = d.broker.Interrupt(id, req.To, msg)
+	} else {
+		err = d.broker.Send(id, req.To, msg)
+	}
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
 
 	data := mustJSON(map[string]any{
 		"id":        msgID,
@@ -54,19 +76,9 @@ func (d *Daemon) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		"content":   req.Content,
 		"type":      req.Type,
 		"interrupt": req.Interrupt,
-		"sent_at":   time.Now().UTC().Format(time.RFC3339Nano),
+		"sent_at":   msg.Timestamp.Format(time.RFC3339Nano),
 	})
-
-	evt := store.SessionEvent{
-		SessionID: id,
-		Type:      "message_sent",
-		Data:      data,
-	}
-	if err := d.store.LogEvent(evt); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-
+	_ = d.store.LogEvent(store.SessionEvent{SessionID: id, Type: "message_sent", Data: data})
 	writeJSON(w, http.StatusCreated, map[string]string{"id": msgID})
 }
 
@@ -87,23 +99,26 @@ func (d *Daemon) handleBroadcastMessage(w http.ResponseWriter, r *http.Request) 
 	if from == "" {
 		from = "operator"
 	}
+	msg := broker.Message{
+		ID:        uuid.New().String(),
+		SessionID: id,
+		SenderID:  from,
+		Type:      broker.MessageType(req.Type),
+		Content:   req.Content,
+		Timestamp: time.Now().UTC(),
+	}
+	if err := d.broker.Broadcast(id, msg); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
 
 	data := mustJSON(map[string]any{
 		"from":    from,
 		"content": req.Content,
 		"type":    req.Type,
-		"sent_at": time.Now().UTC().Format(time.RFC3339Nano),
+		"sent_at": msg.Timestamp.Format(time.RFC3339Nano),
 	})
-
-	evt := store.SessionEvent{
-		SessionID: id,
-		Type:      "message_broadcast",
-		Data:      data,
-	}
-	if err := d.store.LogEvent(evt); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
+	_ = d.store.LogEvent(store.SessionEvent{SessionID: id, Type: "message_broadcast", Data: data})
 
 	writeJSON(w, http.StatusCreated, map[string]string{"status": "broadcast"})
 }

--- a/internal/daemon/messages.go
+++ b/internal/daemon/messages.go
@@ -78,7 +78,10 @@ func (d *Daemon) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		"interrupt": req.Interrupt,
 		"sent_at":   msg.Timestamp.Format(time.RFC3339Nano),
 	})
-	_ = d.store.LogEvent(store.SessionEvent{SessionID: id, Type: "message_sent", Data: data})
+	if err := d.store.LogEvent(store.SessionEvent{SessionID: id, Type: "message_sent", Data: data}); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
 	writeJSON(w, http.StatusCreated, map[string]string{"id": msgID})
 }
 
@@ -118,8 +121,10 @@ func (d *Daemon) handleBroadcastMessage(w http.ResponseWriter, r *http.Request) 
 		"type":    req.Type,
 		"sent_at": msg.Timestamp.Format(time.RFC3339Nano),
 	})
-	_ = d.store.LogEvent(store.SessionEvent{SessionID: id, Type: "message_broadcast", Data: data})
-
+	if err := d.store.LogEvent(store.SessionEvent{SessionID: id, Type: "message_broadcast", Data: data}); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
 	writeJSON(w, http.StatusCreated, map[string]string{"status": "broadcast"})
 }
 

--- a/internal/harness/hermes/hermes.go
+++ b/internal/harness/hermes/hermes.go
@@ -1,0 +1,60 @@
+package hermes
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/donovan-yohan/belayer/internal/shell"
+)
+
+// LaunchConfig captures the minimum information needed to start a Hermes agent.
+type LaunchConfig struct {
+	Profile    string
+	Workdir    string
+	SocketPath string
+	SessionID  string
+	AgentID    string
+	RunDir     string
+	Skills     []string
+	ExtraEnv   map[string]string
+}
+
+// BuildLaunchCmd returns a shell command suitable for running inside tmux.
+func BuildLaunchCmd(cfg LaunchConfig) (string, error) {
+	if strings.TrimSpace(cfg.Profile) == "" {
+		return "", fmt.Errorf("hermes: profile is required")
+	}
+	if strings.TrimSpace(cfg.Workdir) == "" {
+		return "", fmt.Errorf("hermes: workdir is required")
+	}
+
+	parts := []string{fmt.Sprintf("cd %s", shell.Quote(cfg.Workdir))}
+	env := map[string]string{
+		"BELAYER_SESSION_ID":          cfg.SessionID,
+		"BELAYER_AGENT_ID":            cfg.AgentID,
+		"BELAYER_SOCKET":              cfg.SocketPath,
+		"BELAYER_RUN_DIR":             cfg.RunDir,
+		"HERMES_ENABLE_PROJECT_PLUGINS": "true",
+	}
+	for k, v := range cfg.ExtraEnv {
+		env[k] = v
+	}
+	for k, v := range env {
+		if strings.TrimSpace(k) == "" || strings.TrimSpace(v) == "" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("export %s=%s", k, shell.Quote(v)))
+	}
+	cmd := fmt.Sprintf("hermes --profile %s", shell.Quote(cfg.Profile))
+	if len(cfg.Skills) > 0 {
+		cmd += " --skills " + shell.Quote(strings.Join(cfg.Skills, ","))
+	}
+	marker := shell.Quote(filepath.Join(cfg.RunDir, ".belayer-finished"))
+	parts = append(parts, fmt.Sprintf("rm -f %s", marker))
+	parts = append(parts, cmd)
+	parts = append(parts, "status=$?")
+	parts = append(parts, fmt.Sprintf("if [ ! -f %s ]; then belayer finish --blocked %s >/dev/null 2>&1; fi", marker, shell.Quote("hook: Hermes process exited without explicit belayer finish")))
+	parts = append(parts, "exit $status")
+	return strings.Join(parts, " && "), nil
+}

--- a/internal/harness/hermes/hermes.go
+++ b/internal/harness/hermes/hermes.go
@@ -28,6 +28,18 @@ func BuildLaunchCmd(cfg LaunchConfig) (string, error) {
 	if strings.TrimSpace(cfg.Workdir) == "" {
 		return "", fmt.Errorf("hermes: workdir is required")
 	}
+	if strings.TrimSpace(cfg.RunDir) == "" {
+		return "", fmt.Errorf("hermes: run dir is required")
+	}
+	if strings.TrimSpace(cfg.SessionID) == "" {
+		return "", fmt.Errorf("hermes: session ID is required")
+	}
+	if strings.TrimSpace(cfg.AgentID) == "" {
+		return "", fmt.Errorf("hermes: agent ID is required")
+	}
+	if strings.TrimSpace(cfg.SocketPath) == "" {
+		return "", fmt.Errorf("hermes: socket path is required")
+	}
 
 	parts := []string{fmt.Sprintf("cd %s", shell.Quote(cfg.Workdir))}
 	env := map[string]string{
@@ -53,8 +65,12 @@ func BuildLaunchCmd(cfg LaunchConfig) (string, error) {
 	marker := shell.Quote(filepath.Join(cfg.RunDir, ".belayer-finished"))
 	parts = append(parts, fmt.Sprintf("rm -f %s", marker))
 	parts = append(parts, cmd)
-	parts = append(parts, "status=$?")
-	parts = append(parts, fmt.Sprintf("if [ ! -f %s ]; then belayer finish --blocked %s >/dev/null 2>&1; fi", marker, shell.Quote("hook: Hermes process exited without explicit belayer finish")))
-	parts = append(parts, "exit $status")
-	return strings.Join(parts, " && "), nil
+
+	// Post-hermes parts use ";" so they run regardless of hermes exit code.
+	postParts := []string{
+		"status=$?",
+		fmt.Sprintf("if [ ! -f %s ]; then belayer finish --blocked %s >/dev/null 2>&1; fi", marker, shell.Quote("hook: Hermes process exited without explicit belayer finish")),
+		"exit $status",
+	}
+	return strings.Join(parts, " && ") + "; " + strings.Join(postParts, "; "), nil
 }

--- a/internal/harness/hermes/hermes_test.go
+++ b/internal/harness/hermes/hermes_test.go
@@ -1,0 +1,31 @@
+package hermes
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildLaunchCmd_EnablesProjectPluginsAndSkillInjection(t *testing.T) {
+	cmd, err := BuildLaunchCmd(LaunchConfig{
+		Profile:    "default",
+		Workdir:    "/tmp/project",
+		SocketPath: "/tmp/belayer.sock",
+		SessionID:  "sess-123",
+		AgentID:    "planner",
+		RunDir:     "/tmp/project/.belayer/runs/sess-123/planner",
+		Skills:     []string{"belayer-support:belayer-communication"},
+	})
+	if err != nil {
+		t.Fatalf("BuildLaunchCmd returned error: %v", err)
+	}
+	for _, want := range []string{
+		"HERMES_ENABLE_PROJECT_PLUGINS='true'",
+		"hermes --profile 'default' --skills 'belayer-support:belayer-communication'",
+		"belayer finish --blocked",
+		".belayer-finished",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Fatalf("expected command to contain %q, got:\n%s", want, cmd)
+		}
+	}
+}

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -33,6 +33,35 @@ func Migrate(db *sql.DB) error {
 			FOREIGN KEY (session_id) REFERENCES sessions(id)
 		)`,
 
+		`CREATE TABLE IF NOT EXISTS agent_runs (
+			id           TEXT PRIMARY KEY,
+			session_id   TEXT NOT NULL,
+			name         TEXT NOT NULL,
+			role         TEXT NOT NULL DEFAULT '',
+			profile      TEXT NOT NULL DEFAULT '',
+			repo_scope   TEXT NOT NULL DEFAULT '',
+			workdir      TEXT NOT NULL DEFAULT '',
+			transport    TEXT NOT NULL DEFAULT 'tmux',
+			tmux_session TEXT NOT NULL DEFAULT '',
+			status       TEXT NOT NULL DEFAULT 'starting',
+			created_at   DATETIME NOT NULL,
+			updated_at   DATETIME NOT NULL,
+			UNIQUE(session_id, name),
+			FOREIGN KEY (session_id) REFERENCES sessions(id)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS artifacts (
+			id         TEXT PRIMARY KEY,
+			session_id TEXT NOT NULL,
+			kind       TEXT NOT NULL,
+			path       TEXT NOT NULL,
+			producer   TEXT NOT NULL DEFAULT '',
+			summary    TEXT NOT NULL DEFAULT '',
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			FOREIGN KEY (session_id) REFERENCES sessions(id)
+		)`,
+
 		// FTS5 virtual table for full-text search over event type and data.
 		`CREATE VIRTUAL TABLE IF NOT EXISTS events_fts
 			USING fts5(type, data, content=events, content_rowid=id)`,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -360,6 +360,18 @@ func (s *Store) UpdateAgentRunStatus(sessionID, name, status string) error {
 	return nil
 }
 
+// UpdateAgentRunWorkdir updates the workdir for an agent run.
+func (s *Store) UpdateAgentRunWorkdir(sessionID, name, workdir string) error {
+	_, err := s.db.Exec(
+		`UPDATE agent_runs SET workdir = ?, updated_at = ? WHERE session_id = ? AND name = ?`,
+		workdir, time.Now().UTC(), sessionID, name,
+	)
+	if err != nil {
+		return fmt.Errorf("store: update agent run workdir: %w", err)
+	}
+	return nil
+}
+
 // UpdateAgentRunTmuxSession updates the tmux session name for an agent run.
 func (s *Store) UpdateAgentRunTmuxSession(sessionID, name, tmuxSession string) error {
 	_, err := s.db.Exec(
@@ -393,6 +405,23 @@ func (s *Store) CreateArtifact(a Artifact) (string, error) {
 		return "", fmt.Errorf("store: create artifact: %w", err)
 	}
 	return a.ID, nil
+}
+
+// GetArtifact retrieves a single artifact by ID.
+func (s *Store) GetArtifact(id string) (Artifact, error) {
+	row := s.db.QueryRow(
+		`SELECT id, session_id, kind, path, producer, summary, created_at, updated_at
+		 FROM artifacts WHERE id = ?`, id,
+	)
+	var a Artifact
+	var createdAt, updatedAt string
+	err := row.Scan(&a.ID, &a.SessionID, &a.Kind, &a.Path, &a.Producer, &a.Summary, &createdAt, &updatedAt)
+	if err != nil {
+		return Artifact{}, fmt.Errorf("store: get artifact: %w", err)
+	}
+	a.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdAt)
+	a.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt)
+	return a, nil
 }
 
 // ListArtifacts returns artifacts for a session ordered by created_at.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -40,6 +40,34 @@ type WorkbenchState struct {
 	UpdatedAt time.Time
 }
 
+// AgentRun represents a launched agent/harness instance within a session.
+type AgentRun struct {
+	ID          string
+	SessionID   string
+	Name        string
+	Role        string
+	Profile     string
+	RepoScope   string
+	Workdir     string
+	Transport   string
+	TmuxSession string
+	Status      string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// Artifact represents a durable output produced by an agent during a run.
+type Artifact struct {
+	ID        string
+	SessionID string
+	Kind      string
+	Path      string
+	Producer  string
+	Summary   string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
 // Store is a SQLite-backed session and event store.
 type Store struct {
 	db *sql.DB
@@ -246,6 +274,149 @@ func (s *Store) DeleteWorkbenchBySession(sessionID string) error {
 		return fmt.Errorf("store: delete workbench by session: %w", err)
 	}
 	return nil
+}
+
+// CreateAgentRun inserts a launched agent run. If run.ID is empty, a UUID is generated.
+func (s *Store) CreateAgentRun(run AgentRun) (string, error) {
+	if run.ID == "" {
+		run.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	if run.CreatedAt.IsZero() {
+		run.CreatedAt = now
+	}
+	if run.UpdatedAt.IsZero() {
+		run.UpdatedAt = now
+	}
+	if run.Status == "" {
+		run.Status = "starting"
+	}
+	if run.Transport == "" {
+		run.Transport = "tmux"
+	}
+
+	_, err := s.db.Exec(
+		`INSERT INTO agent_runs (id, session_id, name, role, profile, repo_scope, workdir, transport, tmux_session, status, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		run.ID, run.SessionID, run.Name, run.Role, run.Profile, run.RepoScope, run.Workdir, run.Transport, run.TmuxSession, run.Status, run.CreatedAt, run.UpdatedAt,
+	)
+	if err != nil {
+		return "", fmt.Errorf("store: create agent run: %w", err)
+	}
+	return run.ID, nil
+}
+
+// GetAgentRun retrieves a single agent run by session + name.
+func (s *Store) GetAgentRun(sessionID, name string) (AgentRun, error) {
+	row := s.db.QueryRow(
+		`SELECT id, session_id, name, role, profile, repo_scope, workdir, transport, tmux_session, status, created_at, updated_at
+		 FROM agent_runs WHERE session_id = ? AND name = ?`, sessionID, name,
+	)
+	var run AgentRun
+	var createdAt, updatedAt string
+	err := row.Scan(&run.ID, &run.SessionID, &run.Name, &run.Role, &run.Profile, &run.RepoScope, &run.Workdir, &run.Transport, &run.TmuxSession, &run.Status, &createdAt, &updatedAt)
+	if err != nil {
+		return AgentRun{}, fmt.Errorf("store: get agent run: %w", err)
+	}
+	run.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdAt)
+	run.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt)
+	return run, nil
+}
+
+// ListAgentRuns returns all agent runs for a session ordered by created_at.
+func (s *Store) ListAgentRuns(sessionID string) ([]AgentRun, error) {
+	rows, err := s.db.Query(
+		`SELECT id, session_id, name, role, profile, repo_scope, workdir, transport, tmux_session, status, created_at, updated_at
+		 FROM agent_runs WHERE session_id = ? ORDER BY created_at ASC`, sessionID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list agent runs: %w", err)
+	}
+	defer rows.Close()
+
+	var runs []AgentRun
+	for rows.Next() {
+		var run AgentRun
+		var createdAt, updatedAt string
+		if err := rows.Scan(&run.ID, &run.SessionID, &run.Name, &run.Role, &run.Profile, &run.RepoScope, &run.Workdir, &run.Transport, &run.TmuxSession, &run.Status, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("store: list agent runs scan: %w", err)
+		}
+		run.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdAt)
+		run.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt)
+		runs = append(runs, run)
+	}
+	return runs, rows.Err()
+}
+
+// UpdateAgentRunStatus updates status/tmux session metadata.
+func (s *Store) UpdateAgentRunStatus(sessionID, name, status string) error {
+	_, err := s.db.Exec(
+		`UPDATE agent_runs SET status = ?, updated_at = ? WHERE session_id = ? AND name = ?`,
+		status, time.Now().UTC(), sessionID, name,
+	)
+	if err != nil {
+		return fmt.Errorf("store: update agent run status: %w", err)
+	}
+	return nil
+}
+
+// UpdateAgentRunTmuxSession updates the tmux session name for an agent run.
+func (s *Store) UpdateAgentRunTmuxSession(sessionID, name, tmuxSession string) error {
+	_, err := s.db.Exec(
+		`UPDATE agent_runs SET tmux_session = ?, updated_at = ? WHERE session_id = ? AND name = ?`,
+		tmuxSession, time.Now().UTC(), sessionID, name,
+	)
+	if err != nil {
+		return fmt.Errorf("store: update agent run tmux session: %w", err)
+	}
+	return nil
+}
+
+// CreateArtifact inserts a new artifact record.
+func (s *Store) CreateArtifact(a Artifact) (string, error) {
+	if a.ID == "" {
+		a.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	if a.CreatedAt.IsZero() {
+		a.CreatedAt = now
+	}
+	if a.UpdatedAt.IsZero() {
+		a.UpdatedAt = now
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO artifacts (id, session_id, kind, path, producer, summary, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		a.ID, a.SessionID, a.Kind, a.Path, a.Producer, a.Summary, a.CreatedAt, a.UpdatedAt,
+	)
+	if err != nil {
+		return "", fmt.Errorf("store: create artifact: %w", err)
+	}
+	return a.ID, nil
+}
+
+// ListArtifacts returns artifacts for a session ordered by created_at.
+func (s *Store) ListArtifacts(sessionID string) ([]Artifact, error) {
+	rows, err := s.db.Query(
+		`SELECT id, session_id, kind, path, producer, summary, created_at, updated_at
+		 FROM artifacts WHERE session_id = ? ORDER BY created_at ASC`, sessionID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list artifacts: %w", err)
+	}
+	defer rows.Close()
+	var artifacts []Artifact
+	for rows.Next() {
+		var a Artifact
+		var createdAt, updatedAt string
+		if err := rows.Scan(&a.ID, &a.SessionID, &a.Kind, &a.Path, &a.Producer, &a.Summary, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("store: list artifacts scan: %w", err)
+		}
+		a.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdAt)
+		a.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updatedAt)
+		artifacts = append(artifacts, a)
+	}
+	return artifacts, rows.Err()
 }
 
 // LogEvent inserts an event row for a session.

--- a/internal/tmux/local.go
+++ b/internal/tmux/local.go
@@ -78,6 +78,15 @@ func (r *LocalRunner) SendKeys(session, keys string, bracketed bool) error {
 	return nil
 }
 
+// SendEnter sends an Enter keypress to the session.
+func (r *LocalRunner) SendEnter(session string) error {
+	_, err := r.run("send-keys", "-t", r.sessionName(session), "Enter")
+	if err != nil {
+		return fmt.Errorf("send enter to session %q: %w", session, err)
+	}
+	return nil
+}
+
 // CapturePane returns the current visible content of the session's pane.
 func (r *LocalRunner) CapturePane(session string) (string, error) {
 	out, err := r.run("capture-pane", "-t", r.sessionName(session), "-p")

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -12,6 +12,9 @@ type Runner interface {
 	// When bracketed is true, the keys are wrapped in bracketed-paste escape sequences.
 	SendKeys(session, keys string, bracketed bool) error
 
+	// SendEnter sends an Enter keypress to a tmux session.
+	SendEnter(session string) error
+
 	// CapturePane returns the current visible content of the session's pane.
 	CapturePane(session string) (string, error)
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -121,6 +121,21 @@ func TestSendKeys_Bracketed(t *testing.T) {
 	}
 }
 
+func TestSendEnter_Command(t *testing.T) {
+	var calls []capturedCall
+	r := newMockRunner(&calls)
+
+	if err := r.SendEnter("mynode"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if !argsContain(calls[0].args, "send-keys", "-t", "belayer-mynode", "Enter") {
+		t.Errorf("unexpected args for send enter: %v", calls[0].args)
+	}
+}
+
 // ── CapturePane ──────────────────────────────────────────────────────────────
 
 func TestCapturePane_Command(t *testing.T) {

--- a/skills/belayer-communication/SKILL.md
+++ b/skills/belayer-communication/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: belayer-communication
+description: How to communicate with other agents and the Belayer control plane during a Nightshift run. Load this skill in every Nightshift specialist profile.
+version: 1.0.0
+author: Nightshift
+license: MIT
+metadata:
+  hermes:
+    tags: [nightshift, belayer, communication, multi-agent, coordination]
+---
+
+# Belayer Communication
+
+You are operating inside a **Belayer-managed Nightshift run**.
+
+Multiple specialist agents are working on the same ticket. You are one of them. A planner coordinates the work. Belayer is the session bus that connects everyone.
+
+## The rules
+
+1. **Never communicate with other agents directly.** No raw tmux. No writing to shared files as a messaging hack. No printing text hoping someone reads your terminal.
+2. **Always use `belayer` commands** to send messages, log observations, publish artifacts, and mark work complete.
+3. **Belayer is your only coordination interface.** If you need something from another agent, go through Belayer. If you learn something the run should know, tell Belayer.
+
+---
+
+## Your environment
+
+Every Nightshift agent receives these environment variables:
+
+- `BELAYER_SESSION_ID` — the current run session
+- `BELAYER_AGENT_ID` — your role identity (e.g. `planner`, `api`, `app`, `reviewer`, `qa`)
+- `BELAYER_SOCKET` — daemon socket (usually auto-resolved)
+- `BELAYER_RUN_DIR` — root directory for this run's artifacts and state
+
+You do not need to pass `--session` or `--agent` to most commands — they are inferred from the environment.
+
+---
+
+## Commands you should use
+
+### Messaging
+
+Send a message to a specific agent:
+
+```bash
+belayer message send --to planner "I'm blocked on the auth token shape — need the shared contract updated"
+```
+
+Broadcast to all agents in the session:
+
+```bash
+belayer message broadcast "Shared contract v2 is now in artifacts/shared-contract.md — please re-read before continuing"
+```
+
+### Notes
+
+Log an observation to the session event stream:
+
+```bash
+belayer note "extend-api tests pass locally after the schema migration change"
+```
+
+Use notes for:
+- progress updates
+- things you tried
+- things you discovered
+- warnings about potential issues
+
+### Artifacts
+
+Register a durable artifact:
+
+```bash
+belayer artifact create --kind specialist-report --path artifacts/api-specialist-report.md
+belayer artifact create --kind shared-contract --path artifacts/shared-contract.md
+```
+
+List current artifacts:
+
+```bash
+belayer artifact list
+```
+
+### Finishing your work
+
+When your assigned work is complete, you **must** call:
+
+```bash
+belayer finish "Summary of what I did and what the planner should know"
+```
+
+This:
+- marks your agent run as complete in the session
+- logs your summary to the event stream
+- notifies the planner that you are done
+
+**Do not** just stop producing output and wait. **Do not** say "I'm done" in your terminal without calling `belayer finish`. The system cannot detect completion unless you explicitly mark it.
+
+If you are blocked and cannot continue, use:
+
+```bash
+belayer finish --blocked "Cannot proceed — need clarification on X from the planner"
+```
+
+This marks you as blocked rather than complete, so the planner knows to intervene.
+
+---
+
+## When to message vs note vs artifact
+
+| You want to... | Use |
+|---|---|
+| Ask another agent a question | `belayer message send --to <agent>` |
+| Tell the planner you're done | `belayer finish "..."` |
+| Tell the planner you're blocked | `belayer finish --blocked "..."` |
+| Log something you discovered | `belayer note "..."` |
+| Broadcast a change everyone should know | `belayer message broadcast "..."` |
+| Publish a durable output | `belayer artifact create ...` |
+| Read what artifacts exist | `belayer artifact list` |
+
+---
+
+## Planner-only commands
+
+If your role is **planner**, you have additional capabilities.
+
+### Spawning specialists
+
+When you determine which specialists are needed for the task, spawn them:
+
+```bash
+belayer spawn --profile nightshift-extend-api --name api --repo extend-api
+belayer spawn --profile nightshift-extend-app --name app --repo extend-app
+belayer spawn --profile nightshift-reviewer --name reviewer
+belayer spawn --profile nightshift-qa --name qa
+```
+
+Each `spawn` command:
+- creates a new Hermes session in its own tmux window
+- registers the agent with Belayer's session roster
+- makes it addressable via `belayer message send --to <name>`
+
+You can check who is running:
+
+```bash
+belayer roster
+```
+
+### Coordination patterns
+
+As planner, your job is to:
+
+1. Read the ticket/spec
+2. Decide which repos and specialists are needed
+3. Spawn the right agents
+4. Send them their task assignments via `belayer message send`
+5. Monitor progress via `belayer logs` or event stream
+6. Intervene when agents are blocked or drifting
+7. Route review requests
+8. Trigger verification/QA
+9. Assemble the handoff when all work passes
+
+You do **not** write code yourself. You coordinate.
+
+### Checking status
+
+```bash
+belayer roster          # who exists and their status
+belayer logs            # recent session events
+belayer artifact list   # current artifacts
+```
+
+---
+
+## What happens if you forget to call `belayer finish`
+
+The system will notice.
+
+If your agent session becomes idle without calling `belayer finish`, the system will prompt you:
+
+> "Your session appears idle. Is your work complete? If so, please run `belayer finish \"summary\"` to mark completion. If you are blocked, run `belayer finish --blocked \"reason\"`. If you are still working, continue."
+
+This is a safety net, not the primary mechanism. You should call `belayer finish` proactively when your work is done.
+
+---
+
+## Communication etiquette
+
+### Do
+- Be specific in messages — include file paths, artifact names, exact questions
+- Use `belayer note` frequently to leave a trail
+- Publish artifacts as soon as they are meaningful
+- Call `belayer finish` as soon as your work is complete or you are blocked
+- Respond to planner messages promptly
+
+### Don't
+- Send vague messages like "I'm working on it"
+- Forget to call `belayer finish` — it is the most important coordination signal
+- Try to read another agent's terminal output directly
+- Assume the planner can see your terminal — communicate through Belayer
+- Wait silently if you are blocked — always surface blockers explicitly
+
+---
+
+## Quick reference
+
+```bash
+# Messaging
+belayer message send --to <agent> "text"
+belayer message broadcast "text"
+
+# Notes
+belayer note "text"
+
+# Artifacts
+belayer artifact create --kind <kind> --path <path>
+belayer artifact list
+
+# Completion
+belayer finish "summary of work done"
+belayer finish --blocked "reason I cannot continue"
+
+# Planner only
+belayer spawn --profile <profile> --name <name> [--repo <repo>]
+belayer roster
+
+# Observation
+belayer logs
+```


### PR DESCRIPTION
## Summary
- reshape Belayer around the Nightshift v1 run-local control plane model
- add planner/api-oriented run primitives: `run start`, `spawn`, `roster`, `finish`
- add daemon-backed agent run tracking and artifact registration/listing
- add Hermes harness integration + project-local Belayer communication plugin/skill
- update core architecture/philosophy docs to reflect current Extend-first direction
- clarify how Nightshift daemon can parallelize across a small worker pool while keeping one-request-per-worker simplicity
- document how `extend-localenv` and `extend-clamshell` scale into the architecture beyond the MVP

## What was implemented
### Run-local control plane
- `belayer run start` creates a session, marks it running, spawns planner, and delivers the initial task
- `belayer spawn` starts a new Hermes-backed agent run in its own tmux session
- `belayer roster` lists active agent runs and statuses
- `belayer finish` marks an agent complete or blocked

### Daemon/session bus
- add `agent_runs` persistence
- add daemon endpoints for spawning/listing/finishing agent runs
- make message delivery actually route through the broker instead of only logging events

### Artifacts
- add daemon-backed artifact registry
- add `belayer artifact create`
- add `belayer artifact list`
- artifact metadata now records `kind`, `producer`, `path`, and `summary`

### Hermes integration
- add Hermes launch wrapper in `internal/harness/hermes`
- inject Belayer env vars into Hermes runs
- enable project-local Hermes plugins for Nightshift runs
- preload the Belayer communication skill
- add finish-marker handling

### Completion discipline
- if an agent exits without explicit `belayer finish`, Belayer marks it blocked
- this is enforced by the Hermes launch wrapper + Belayer watcher

### Documentation refresh
Updated:
- `docs/PHILOSOPHY.md`
- `docs/ARCHITECTURE.md`
- `docs/DESIGN.md`
- `CLAUDE.md`
- `docs/design-docs/index.md`

Added:
- `docs/design-docs/2026-04-15-nightshift-extend-first-architecture.md`
- `docs/design-docs/2026-04-15-nightshift-extend-first-implementation-delta.md`
- `docs/design-docs/2026-04-15-nightshift-v1-deployment-topology.md`
- `docs/design-docs/2026-04-15-belayer-run-model-for-nightshift-v1.md`

### New topology/scaling clarification
- architecture now explicitly shows an always-on **Nightshift daemon** dispatching across **three workers**
- each worker hosts one active request and one run-local **Belayer daemon**
- docs now clearly describe how `xt` should grow into the Extend workbench interface
- docs now clearly describe how clamshell should grow into the production sandbox boundary for Linux workers

## Validation
- `go test ./...`
- manual daemon validation with real Hermes + tmux runs
- validated planner/api spawn + message + finish flows
- validated exit-without-finish => blocked behavior

## Notes / follow-up
Not fully implemented yet:
- live idle nudge for agents that remain running but do not call `belayer finish`
- richer planner/specialist identities beyond current profile + plugin/skill preload
- deeper Extend-localenv/clamshell integration in the run loop
