### PR TITLE
fix: run monitoring improvements from arielcharts post-mortem

### DIFF
--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -183,15 +183,18 @@ stateDiagram-v2
     Starting --> Running: bridge:started
     Running --> Idle: Task done, waiting for specialists
     Idle --> Running: Specialist reports in (message or interrupt)
-    Idle --> Complete: Idle timeout (5 min) or explicit finish
-    Running --> Complete: belayer finish
+    Idle --> Incomplete: Idle timeout (5 min), no response
+    Running --> Complete: belayer finish → PM approval
     Running --> Blocked: Unrecoverable error
+    Running --> Incomplete: Agent decides it cannot finish
     Idle --> Complete: Stop command
 ```
 
-When the supervisor completes a task, it enters an **idle loop**: polling every 5 seconds for new messages, listening on stdin for interrupts. If a specialist sends a message, the supervisor wakes up and continues. If nothing happens for 5 minutes, it exits cleanly.
+When the supervisor completes a task, it enters an **idle loop**: polling every 5 seconds for new messages, listening on stdin for interrupts. If a specialist sends a message, the supervisor wakes up and continues. If nothing happens for 5 minutes, the supervisor exits as **incomplete** — this is not a successful completion, it means no specialist reported back.
 
-This means the supervisor doesn't burn tokens while waiting. It's not running inference. It's a Python process sleeping in a poll loop, ready to resume the Hermes conversation the moment work arrives.
+The **incomplete** state is distinct from both **complete** (work finished) and **blocked** (unrecoverable error). It means the agent made progress but could not finish — either due to idle timeout, getting stuck in a loop, or making a deliberate decision to escalate. When the supervisor reports incomplete, the daemon transitions the session to `needs_human_review`. Any agent can report incomplete via `belayer_report_status(status="incomplete")`.
+
+The supervisor doesn't burn tokens while idling. It's not running inference. It's a Python process sleeping in a poll loop, ready to resume the Hermes conversation the moment work arrives.
 
 ### Specialists (ephemeral, spawn-and-complete)
 
@@ -203,9 +206,10 @@ stateDiagram-v2
     Starting --> Running: bridge:started
     Running --> Complete: Task done (bridge:finished)
     Running --> Blocked: Error or exit without finish
+    Running --> Incomplete: Cannot finish, escalates to human
 ```
 
-Specialists are ephemeral by default (`ephemeral=true`). When their task is done, the bridge posts `bridge:finished` and the process exits.
+Specialists are ephemeral by default (`ephemeral=true`). When their task is done, the bridge posts `bridge:finished` and the process exits. If a specialist gets stuck, it can report `incomplete` to escalate — the daemon logs an `agent_escalated` event and the supervisor is notified.
 
 But their **names persist**. The `agent_runs` table keeps the row. If the supervisor needs to assign more work to the same role, it spawns with the same name. The daemon detects the prior run, carries over the `HermesSessionID`, and the specialist resumes with its full conversation history.
 
@@ -290,11 +294,15 @@ Daemon-internal events (not from bridge):
 | `agent_spawned` | Spawn handler | Roster update |
 | `agent_finished` | Finish handler | Status update |
 | `agent_exited_without_finish` | Exit watcher | Marks agent `blocked` |
+| `agent_escalated` | Status event handler | Agent reported `incomplete`, logged for monitoring |
 | `artifact_created` | Artifact handler | Registry update |
 | `session_created` | Session handler | — |
 | `session_completed` | Completion approved handler | Session status → complete |
+| `session_stalled` | Bridge finished/failed handler | All agents exited without completion → session status → stalled |
+| `warning:supervisor_exited_early` | Bridge finished handler | Supervisor exited while specialists still running |
 | `completion_rejected` | Completion rejected handler | Tracks cycle count |
 | `completion_escalated` | Rejection limit handler | Session status → needs_human_review |
+| `pm_spawn_failed` | PM spawn error | Notifies supervisor to retry |
 | `pm_spawn_failed` | PM spawn error | Notifies supervisor to retry |
 
 ### How telemetry enables resume

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -303,7 +303,6 @@ Daemon-internal events (not from bridge):
 | `completion_rejected` | Completion rejected handler | Tracks cycle count |
 | `completion_escalated` | Rejection limit handler | Session status → needs_human_review |
 | `pm_spawn_failed` | PM spawn error | Notifies supervisor to retry |
-| `pm_spawn_failed` | PM spawn error | Notifies supervisor to retry |
 
 ### How telemetry enables resume
 

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -296,6 +296,7 @@ Daemon-internal events (not from bridge):
 | `agent_exited_without_finish` | Exit watcher | Marks agent `blocked` |
 | `agent_escalated` | Status event handler | Agent reported `incomplete`, logged for monitoring |
 | `artifact_created` | Artifact handler | Registry update |
+| `run_initiated` | CLI `run start` | Records initial task prompt and supervisor profile |
 | `session_created` | Session handler | — |
 | `session_completed` | Completion approved handler | Session status → complete |
 | `session_stalled` | Bridge finished/failed handler | All agents exited without completion → session status → stalled |

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -77,6 +77,8 @@ Agents never communicate by writing to shared files or reading each other's term
 
 The daemon is a Go process running on a Unix socket. It owns the session state and routes all inter-agent communication.
 
+Every run has two mandatory agents — the **supervisor** and the **PM** — plus zero or more specialist agents spawned by the supervisor at runtime. The supervisor orchestrates work; the PM gates completion. Everything else is dynamic.
+
 ```mermaid
 flowchart TB
     subgraph daemon["Belayer Daemon (Go, Unix socket)"]
@@ -89,23 +91,25 @@ flowchart TB
 
     subgraph supervisor_box["Supervisor (non-ephemeral, always-on)"]
         supervisor_hermes["Hermes + Bridge"]
-        supervisor_tools["Base tools + Belayer coordination + spawn + completion"]
+        supervisor_tools["Base tools + Belayer coordination\n+ spawn + request_completion"]
     end
 
-    subgraph spec_a["Specialist A (ephemeral)"]
-        spec_a_hermes["Hermes + Bridge"]
-        spec_a_tools["Base tools + Belayer baseline"]
+    subgraph pm_box["PM (ephemeral, auto-spawned by daemon)"]
+        pm_hermes["Hermes + Bridge"]
+        pm_tools["Base tools + Belayer baseline\n+ approve/reject_completion"]
     end
 
-    subgraph spec_b["Specialist B (ephemeral)"]
-        spec_b_hermes["Hermes + Bridge"]
-        spec_b_tools["Base tools + Belayer baseline"]
+    subgraph specialists["Specialist 1..N (ephemeral, spawned by supervisor)"]
+        spec_hermes["Hermes + Bridge"]
+        spec_tools["Base tools + Belayer baseline"]
     end
 
     supervisor_hermes <-->|"stdin/stdout JSON\n+ HTTP over Unix socket"| daemon
-    spec_a_hermes <-->|"stdin/stdout JSON\n+ HTTP over Unix socket"| daemon
-    spec_b_hermes <-->|"stdin/stdout JSON\n+ HTTP over Unix socket"| daemon
+    pm_hermes <-->|"stdin/stdout JSON\n+ HTTP over Unix socket"| daemon
+    spec_hermes <-->|"stdin/stdout JSON\n+ HTTP over Unix socket"| daemon
 ```
+
+The supervisor is always the first agent spawned. It reads the spec, decomposes work, and spawns specialists (frontend, backend, qa, reviewer, etc.) as needed. The PM is never spawned by the supervisor — the daemon auto-spawns it when the supervisor calls `belayer_request_completion`, creating an adversarial verification step that the supervisor cannot skip.
 
 ### What the daemon owns
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -45,6 +45,101 @@ flowchart TB
 
 ---
 
+## Two-Daemon Topology
+
+A multi-agent coding system needs **two control planes** at different scopes:
+
+1. **Outer daemon** — always-on, manages a pool of workers, queues requests, persists long-lived data (logs, memory, artifacts) that outlive any individual run.
+2. **Inner daemon** — ephemeral, lives inside one worker for one run, coordinates agent-to-agent communication, records telemetry and artifacts to a run-local database.
+
+The inner daemon and everything it manages are **ephemeral** — when the worker dies, the run-local state dies with it. Anything that matters beyond the run (logs, learned knowledge, output artifacts) must be exported to the outer daemon before the worker is reclaimed.
+
+```mermaid
+flowchart LR
+    User["User / ticket / spec"] --> OD["Outer daemon\n(always-on)"]
+    OD --> Queue[("Request queue\nlong-lived storage")]
+    OD --> W1["Worker 1"]
+    OD --> W2["Worker 2"]
+    OD --> W3["Worker 3"]
+
+    subgraph WorkerRun["One run on one worker (ephemeral)"]
+        ID["Inner daemon\n(agent control plane)"]
+        H["Harness driver"]
+        SB["Sandbox / workspace"]
+        DB[("Run-local DB\nevents, telemetry, artifacts")]
+
+        ID --> H
+        H --> SB
+        ID --> DB
+    end
+
+    W1 --> WorkerRun
+    DB -.->|"export: logs,\nartifacts, memory"| Queue
+```
+
+Workers run in parallel. Each handles one request at a time. Each hosts an inner daemon for the active run.
+
+```mermaid
+flowchart TB
+    OD["Outer daemon\n(always on)"] --> W1["Worker 1\none active request"]
+    OD --> W2["Worker 2\none active request"]
+    OD --> W3["Worker 3\none active request"]
+
+    subgraph R1["Run A"]
+        ID1["Inner daemon"]
+        P1["supervisor"]
+        A1["specialist"]
+        Q1["reviewer"]
+        SB1["sandbox"]
+        DB1[("run-local DB")]
+        ID1 --> P1
+        ID1 --> A1
+        ID1 --> Q1
+        P1 --> SB1
+        A1 --> SB1
+        Q1 --> SB1
+        ID1 --> DB1
+    end
+
+    subgraph R2["Run B"]
+        ID2["Inner daemon"]
+        P2["supervisor"]
+        A2["specialists"]
+        SB2["sandbox"]
+        DB2[("run-local DB")]
+        ID2 --> P2
+        ID2 --> A2
+        P2 --> SB2
+        A2 --> SB2
+        ID2 --> DB2
+    end
+
+    subgraph R3["Run C"]
+        ID3["Inner daemon"]
+        P3["supervisor"]
+        A3["specialists"]
+        SB3["sandbox"]
+        DB3[("run-local DB")]
+        ID3 --> P3
+        ID3 --> A3
+        P3 --> SB3
+        A3 --> SB3
+        ID3 --> DB3
+    end
+
+    W1 --> R1
+    W2 --> R2
+    W3 --> R3
+
+    DB1 -.->|"export"| OD
+    DB2 -.->|"export"| OD
+    DB3 -.->|"export"| OD
+```
+
+The key invariant: **run-local state is disposable, outer state is durable.** The inner daemon optimizes for low-latency coordination between agents during the run. The outer daemon optimizes for persistence — logs for debugging, artifacts for delivery, memory for future runs. The export path between them is what makes ephemeral runs useful beyond their lifetime.
+
+---
+
 ## The Six Interfaces
 
 ### 1. Session

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -45,7 +45,7 @@ flowchart TB
 
 ---
 
-## Two-Daemon Topology
+## Topology
 
 A multi-agent coding system needs **two control planes** at different scopes:
 
@@ -77,64 +77,100 @@ flowchart LR
     DB -.->|"export: logs,\nartifacts, memory"| Queue
 ```
 
-Workers run in parallel. Each handles one request at a time. Each hosts an inner daemon for the active run.
+### How the six interfaces map to the architecture
+
+Each box in the architecture implements one of the six runtime interfaces. The diagram below is color-coded: boxes with the same color implement the same interface.
 
 ```mermaid
 flowchart TB
-    OD["Outer daemon\n(always on)"] --> W1["Worker 1\none active request"]
-    OD --> W2["Worker 2\none active request"]
-    OD --> W3["Worker 3\none active request"]
+    subgraph legend [" "]
+        direction LR
+        L1["SESSION"]:::session
+        L2["ORCHESTRATION"]:::orch
+        L3["COMMUNICATION"]:::comm
+        L4["SANDBOX"]:::sandbox
+        L5["MEMORY"]:::memory
+        L6["TOOLS"]:::tools
+    end
 
-    subgraph R1["Run A"]
-        ID1["Inner daemon"]
-        P1["supervisor"]
-        A1["specialist"]
-        Q1["reviewer"]
-        SB1["sandbox"]
-        DB1[("run-local DB")]
-        ID1 --> P1
-        ID1 --> A1
-        ID1 --> Q1
-        P1 --> SB1
-        A1 --> SB1
-        Q1 --> SB1
+    OD["Outer daemon\n(always-on)"]
+    MEM[("Durable memory\nlogs, learnings")]:::memory
+
+    OD --> S1
+    OD --> S2
+    OD --> S3
+
+    subgraph S1["Session A (Worker 1)"]
+        ID1["Session bus / inner daemon\nmessages, events, artifacts"]:::comm
+        SUP1["Supervisor agent\ndecomposes, delegates, decides"]:::orch
+        SP1["Specialist agents\n(frontend, backend, QA, ...)"]:::orch
+        H1["Harness + tool catalog\nexecution routing"]:::tools
+        SB1["Sandbox\nisolation boundary"]:::sandbox
+        DB1[("Run-local DB\ntelemetry, events")]:::session
+
+        ID1 <--> SUP1
+        ID1 <--> SP1
+        SUP1 --> H1
+        SP1 --> H1
+        H1 --> SB1
         ID1 --> DB1
     end
 
-    subgraph R2["Run B"]
-        ID2["Inner daemon"]
-        P2["supervisor"]
-        A2["specialists"]
-        SB2["sandbox"]
-        DB2[("run-local DB")]
-        ID2 --> P2
-        ID2 --> A2
-        P2 --> SB2
-        A2 --> SB2
+    subgraph S2["Session B (Worker 2)"]
+        ID2["Session bus"]:::comm
+        SUP2["Supervisor"]:::orch
+        SP2["Specialists"]:::orch
+        H2["Harness + tools"]:::tools
+        SB2["Sandbox"]:::sandbox
+        DB2[("Run-local DB")]:::session
+
+        ID2 <--> SUP2
+        ID2 <--> SP2
+        SUP2 --> H2
+        SP2 --> H2
+        H2 --> SB2
         ID2 --> DB2
     end
 
-    subgraph R3["Run C"]
-        ID3["Inner daemon"]
-        P3["supervisor"]
-        A3["specialists"]
-        SB3["sandbox"]
-        DB3[("run-local DB")]
-        ID3 --> P3
-        ID3 --> A3
-        P3 --> SB3
-        A3 --> SB3
+    subgraph S3["Session C (Worker 3)"]
+        ID3["Session bus"]:::comm
+        SUP3["Supervisor"]:::orch
+        SP3["Specialists"]:::orch
+        H3["Harness + tools"]:::tools
+        SB3["Sandbox"]:::sandbox
+        DB3[("Run-local DB")]:::session
+
+        ID3 <--> SUP3
+        ID3 <--> SP3
+        SUP3 --> H3
+        SP3 --> H3
+        H3 --> SB3
         ID3 --> DB3
     end
 
-    W1 --> R1
-    W2 --> R2
-    W3 --> R3
+    MEM -.->|"inject context\nat session start"| ID1
+    MEM -.->|"inject"| ID2
+    MEM -.->|"inject"| ID3
+    DB1 -.->|"export logs,\nartifacts, learnings"| MEM
+    DB2 -.->|"export"| MEM
+    DB3 -.->|"export"| MEM
 
-    DB1 -.->|"export"| OD
-    DB2 -.->|"export"| OD
-    DB3 -.->|"export"| OD
+    classDef session fill:#4A90D9,stroke:#2E5C8A,color:#fff
+    classDef orch fill:#E8A838,stroke:#B07A1A,color:#fff
+    classDef comm fill:#50B86C,stroke:#2D8A45,color:#fff
+    classDef sandbox fill:#E05555,stroke:#A83232,color:#fff
+    classDef memory fill:#9B6FCF,stroke:#6B3FA0,color:#fff
+    classDef tools fill:#3ABAB4,stroke:#1F8A85,color:#fff
 ```
+
+| Interface | Color | What it maps to | Key property |
+|---|---|---|---|
+| **Session** | Blue | Each worker run + its run-local DB | Ephemeral — dies with the worker |
+| **Orchestration** | Amber | Supervisor + specialist agents (LLMs) | Judgment, not code — adapts to roster |
+| **Communication** | Green | Inner daemon / session bus | Routes messages, events, artifacts between agents |
+| **Sandbox** | Red | Isolation boundary around each worker | Deny-by-default, agents cannot self-impose |
+| **Memory** | Purple | Durable storage on outer daemon | Injected at start, exported at end — outlives sessions |
+| **Tools** | Teal | Harness driver + registered tool catalog | Execution routing into sandboxed environments |
 
 The key invariant: **run-local state is disposable, outer state is durable.** The inner daemon optimizes for low-latency coordination between agents during the run. The outer daemon optimizes for persistence — logs for debugging, artifacts for delivery, memory for future runs. The export path between them is what makes ephemeral runs useful beyond their lifetime.
 

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -382,8 +382,15 @@ def main() -> None:
                     log.info("Resuming from idle with %d pending message(s)", len(pending))
                     break
             else:
-                # Idle timeout reached — exit cleanly.
-                log.info("Idle timeout reached (%ds), exiting", idle_timeout)
+                # Idle timeout reached — no specialists reported back.
+                # This is not a successful completion; mark as incomplete
+                # so the session transitions to stalled/needs_human_review.
+                log.info("Idle timeout reached (%ds), marking incomplete", idle_timeout)
+                post_event(
+                    socket_path, session_id, agent_id,
+                    f"agent_status:incomplete",
+                    {"status": "incomplete", "detail": f"Idle timeout after {idle_timeout}s with no specialist response"},
+                )
                 post_event(
                     socket_path, session_id, agent_id,
                     "bridge:finished",

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -388,7 +388,7 @@ def main() -> None:
                 log.info("Idle timeout reached (%ds), marking incomplete", idle_timeout)
                 post_event(
                     socket_path, session_id, agent_id,
-                    f"agent_status:incomplete",
+                    "agent_status:incomplete",
                     {"status": "incomplete", "detail": f"Idle timeout after {idle_timeout}s with no specialist response"},
                 )
                 post_event(

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -29,7 +29,7 @@ except ImportError:
     sys.exit(1)
 
 from hermes_bridge.tools import register_belayer_tools
-from hermes_bridge.callbacks import make_callbacks, post_event
+from hermes_bridge.callbacks import make_callbacks, post_event, start_heartbeat_thread
 from hermes_bridge.stdin_reader import StdinReader
 from hermes_bridge.http_client import unix_get
 
@@ -125,8 +125,8 @@ def main() -> None:
     ephemeral = os.environ.get("BELAYER_EPHEMERAL", "true").lower() != "false"
 
     log.info(
-        "Starting bridge agent=%s session=%s role=%s profile=%s",
-        agent_id, session_id, role, profile or "(none)",
+        "Starting bridge agent=%s session=%s role=%s profile=%s ephemeral=%s",
+        agent_id, session_id, role, profile or "(none)", ephemeral,
     )
 
     # --- Construct AIAgent -------------------------------------------------
@@ -227,6 +227,9 @@ def main() -> None:
     stdin_queue: queue.Queue = queue.Queue()
     stdin_reader = StdinReader(agent, stdin_queue)
     stdin_reader.start()
+
+    # --- Start heartbeat thread -------------------------------------------
+    heartbeat_stop = start_heartbeat_thread(socket_path, session_id, agent_id)
 
     # --- Resume from prior Hermes session if provided ----------------------
     conversation_history: list[dict] | None = None
@@ -398,6 +401,7 @@ def main() -> None:
     if session_usage:
         post_event(socket_path, session_id, agent_id, "bridge:session_usage", session_usage)
 
+    heartbeat_stop.set()
     stdin_reader.stop()
     log.info("Bridge exiting for agent=%s session=%s", agent_id, session_id)
 

--- a/hermes_bridge/callbacks.py
+++ b/hermes_bridge/callbacks.py
@@ -26,13 +26,19 @@ def post_event(socket_path: str, session_id: str, agent_id: str, event_type: str
         data = {}
     data["agent"] = agent_id
 
+    # State-changing events drive session lifecycle; log failures at WARNING.
+    _STATE_EVENTS = ("agent_status:", "bridge:finished", "bridge:failed")
+
     status, body = unix_post(
         socket_path,
         f"/sessions/{session_id}/events",
         {"type": event_type, "data": json.dumps(data)},
     )
     if status not in (200, 201):
-        log.debug("post_event %s -> %d %s", event_type, status, body[:120])
+        if any(event_type.startswith(prefix) for prefix in _STATE_EVENTS):
+            log.warning("post_event %s -> %d %s", event_type, status, body[:120])
+        else:
+            log.debug("post_event %s -> %d %s", event_type, status, body[:120])
 
 
 def make_callbacks(agent_id: str, session_id: str, socket_path: str) -> dict:
@@ -53,7 +59,7 @@ def make_callbacks(agent_id: str, session_id: str, socket_path: str) -> dict:
             state["last_heartbeat"] = now
             post_event(socket_path, session_id, agent_id, "bridge:heartbeat", {})
 
-    # Tools whose first positional arg or 'path' kwarg is a file path.
+    # Tools that accept a file path via dict-style 'path' or 'file_path' kwarg.
     _FILE_TOOLS = frozenset({"read_file", "write_file", "edit_file", "create_file"})
 
     def _extract_path(tool_name: str, tool_args) -> str | None:

--- a/hermes_bridge/callbacks.py
+++ b/hermes_bridge/callbacks.py
@@ -53,28 +53,47 @@ def make_callbacks(agent_id: str, session_id: str, socket_path: str) -> dict:
             state["last_heartbeat"] = now
             post_event(socket_path, session_id, agent_id, "bridge:heartbeat", {})
 
+    # Tools whose first positional arg or 'path' kwarg is a file path.
+    _FILE_TOOLS = frozenset({"read_file", "write_file", "edit_file", "create_file"})
+
+    def _extract_path(tool_name: str, tool_args) -> str | None:
+        """Extract file path from tool args for file operation events."""
+        if tool_name not in _FILE_TOOLS:
+            return None
+        if isinstance(tool_args, dict):
+            return tool_args.get("path") or tool_args.get("file_path")
+        return None
+
     def tool_start_callback(tool_call_id, tool_name, tool_args, **kwargs):
         state["tool_starts"][tool_call_id] = time.monotonic()
+        event_data = {
+            "tool": tool_name,
+            "input_preview": str(tool_args)[:200],
+        }
+        path = _extract_path(tool_name, tool_args)
+        if path:
+            event_data["path"] = path
         post_event(
             socket_path, session_id, agent_id,
             "bridge:tool_started",
-            {
-                "tool": tool_name,
-                "input_preview": str(tool_args)[:200],
-            },
+            event_data,
         )
 
     def tool_complete_callback(tool_call_id, tool_name, tool_args, tool_result, **kwargs):
         started = state["tool_starts"].pop(tool_call_id, None)
         duration_ms = int((time.monotonic() - started) * 1000) if started else 0
+        event_data = {
+            "tool": tool_name,
+            "duration_ms": duration_ms,
+            "result_preview": str(tool_result)[:200],
+        }
+        path = _extract_path(tool_name, tool_args)
+        if path:
+            event_data["path"] = path
         post_event(
             socket_path, session_id, agent_id,
             "bridge:tool_completed",
-            {
-                "tool": tool_name,
-                "duration_ms": duration_ms,
-                "result_preview": str(tool_result)[:200],
-            },
+            event_data,
         )
 
     def step_callback(messages=None, **kwargs):

--- a/hermes_bridge/tools.py
+++ b/hermes_bridge/tools.py
@@ -78,15 +78,19 @@ REPORT_STATUS_SCHEMA = {
     "name": "belayer_report_status",
     "description": (
         "Report your current status to the Belayer session bus. "
-        "Use this for progress updates, marking yourself blocked, or signaling completion."
+        "Use this for progress updates, marking yourself blocked, signaling completion, "
+        "or escalating to a human when you've made progress but cannot finish."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "status": {
                 "type": "string",
-                "enum": ["working", "blocked", "done", "needs-review"],
-                "description": "Your current status",
+                "enum": ["working", "blocked", "done", "needs-review", "incomplete"],
+                "description": (
+                    "Your current status. Use 'incomplete' when you've made progress "
+                    "but are stuck in a loop or cannot finish — this escalates to a human."
+                ),
             },
             "detail": {
                 "type": "string",

--- a/hermes_bridge/tools.py
+++ b/hermes_bridge/tools.py
@@ -78,8 +78,9 @@ REPORT_STATUS_SCHEMA = {
     "name": "belayer_report_status",
     "description": (
         "Report your current status to the Belayer session bus. "
-        "Use this for progress updates, marking yourself blocked, signaling completion, "
-        "or escalating to a human when you've made progress but cannot finish."
+        "Use 'incomplete' to escalate to a human when you've made progress but cannot finish. "
+        "Use 'working', 'blocked', 'done', or 'needs-review' for log-only status updates "
+        "(these are recorded in the event log but do not trigger daemon-side state transitions)."
     ),
     "parameters": {
         "type": "object",
@@ -88,8 +89,9 @@ REPORT_STATUS_SCHEMA = {
                 "type": "string",
                 "enum": ["working", "blocked", "done", "needs-review", "incomplete"],
                 "description": (
-                    "Your current status. Use 'incomplete' when you've made progress "
-                    "but are stuck in a loop or cannot finish — this escalates to a human."
+                    "Your current status. 'incomplete' triggers escalation to a human — "
+                    "use when stuck in a loop or unable to finish. Other values are logged "
+                    "for observability but do not change session state."
                 ),
             },
             "detail": {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -78,6 +79,12 @@ func newRunStartCmd() *cobra.Command {
 			if _, err := c.SendMessage(sess.ID, "supervisor", task, "instruction", true); err != nil {
 				return fmt.Errorf("deliver initial task: %w", err)
 			}
+			// Log the initial prompt as telemetry so post-mortems can see what started the run.
+			initData, _ := json.Marshal(map[string]string{
+				"task":               task,
+				"supervisor_profile": supervisorProfile,
+			})
+			_ = c.LogEvent(sess.ID, "run_initiated", string(initData))
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Run started: %s (%s)\n", sess.ID, sess.Name)
 			fmt.Fprintln(cmd.OutOrStdout(), "Supervisor: supervisor")

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -414,6 +414,9 @@ func (d *Daemon) watchBridgeExit(run store.AgentRun, proc *bridge.Process) {
 			_ = d.broker.Interrupt(run.SessionID, "supervisor", msg)
 		}
 
+		// Check if this was the last active agent (session may be stalled).
+		d.checkSessionStalled(run.SessionID)
+
 		// Clean up process reference.
 		d.bridgeMu.Lock()
 		delete(d.bridgeProcs, bridgeKey(run.SessionID, run.Name))

--- a/internal/daemon/bridge_events.go
+++ b/internal/daemon/bridge_events.go
@@ -62,10 +62,118 @@ func (d *Daemon) handleBridgeFinished(sessionID, agentName string, data map[stri
 	// If the bridge crashes without a clean exit, watchBridgeExit handles
 	// the notification. Auto-generating a state_change here causes duplicate
 	// messages that the supervisor dismisses as noise.
+
+	// Check for supervisor exiting while specialists are still running.
+	if agentName == "supervisor" {
+		d.checkSupervisorExitedEarly(sessionID)
+	}
+
+	// Check if the session is now stalled (all agents done, no completion approval).
+	d.checkSessionStalled(sessionID)
+}
+
+// checkSupervisorExitedEarly emits a warning if the supervisor exits while
+// any specialist agents are still running or starting.
+func (d *Daemon) checkSupervisorExitedEarly(sessionID string) {
+	agents, err := d.store.ListAgentRuns(sessionID)
+	if err != nil {
+		return
+	}
+	for _, a := range agents {
+		if a.Name == "supervisor" {
+			continue
+		}
+		if a.Status == "running" || a.Status == "starting" {
+			log.Printf("WARNING: supervisor exited while %s is still %s in session %s", a.Name, a.Status, sessionID)
+			_ = d.store.LogEvent(store.SessionEvent{
+				SessionID: sessionID,
+				Type:      "warning:supervisor_exited_early",
+				Data: mustJSON(map[string]string{
+					"active_agent": a.Name,
+					"agent_status": a.Status,
+				}),
+			})
+			return // one warning is enough
+		}
+	}
+}
+
+// checkSessionStalled detects when all agents have exited but the session
+// was never completed via the PM gate. Transitions session to "stalled".
+func (d *Daemon) checkSessionStalled(sessionID string) {
+	sess, err := d.store.GetSession(sessionID)
+	if err != nil {
+		return
+	}
+	// Only check sessions that are still "running".
+	if sess.Status != "running" {
+		return
+	}
+
+	agents, err := d.store.ListAgentRuns(sessionID)
+	if err != nil || len(agents) == 0 {
+		return
+	}
+
+	// If any agent is still active, session is not stalled.
+	for _, a := range agents {
+		if a.Status == "running" || a.Status == "starting" {
+			return
+		}
+	}
+
+	// All agents are done/blocked/complete but session is still "running".
+	_ = d.store.UpdateSessionStatus(sessionID, "stalled")
+	_ = d.store.LogEvent(store.SessionEvent{
+		SessionID: sessionID,
+		Type:      "session_stalled",
+		Data: mustJSON(map[string]string{
+			"reason": "all_agents_exited_without_completion",
+		}),
+	})
+	log.Printf("Session %s marked stalled: all agents exited without completion approval", sessionID)
+}
+
+// processAgentStatusEvent handles side effects for agent_status:* events
+// posted by agents via belayer_report_status.
+func (d *Daemon) processAgentStatusEvent(sessionID, eventType, data string) {
+	var eventData map[string]any
+	if data != "" {
+		_ = json.Unmarshal([]byte(data), &eventData)
+	}
+	agentName, _ := eventData["agent"].(string)
+	if agentName == "" {
+		return
+	}
+
+	switch eventType {
+	case "agent_status:incomplete":
+		detail, _ := eventData["detail"].(string)
+		_ = d.store.UpdateAgentRunStatus(sessionID, agentName, "incomplete")
+
+		_ = d.store.LogEvent(store.SessionEvent{
+			SessionID: sessionID,
+			Type:      "agent_escalated",
+			Data: mustJSON(map[string]string{
+				"agent":  agentName,
+				"reason": "incomplete",
+				"detail": detail,
+			}),
+		})
+
+		// If the supervisor reports incomplete, escalate the session.
+		if agentName == "supervisor" {
+			_ = d.store.UpdateSessionStatus(sessionID, "needs_human_review")
+			log.Printf("Session %s escalated to human review: supervisor reported incomplete", sessionID)
+		}
+	}
 }
 
 func (d *Daemon) handleBridgeFailed(sessionID, agentName string, data map[string]any) {
 	_ = d.store.UpdateAgentRunStatus(sessionID, agentName, "blocked")
+
+	// Check if this was the last active agent.
+	d.checkSessionStalled(sessionID)
 
 	if agentName == "supervisor" {
 		return

--- a/internal/daemon/bridge_events.go
+++ b/internal/daemon/bridge_events.go
@@ -55,7 +55,13 @@ func (d *Daemon) handleBridgeStarted(sessionID, agentName string, data map[strin
 }
 
 func (d *Daemon) handleBridgeFinished(sessionID, agentName string, data map[string]any) {
-	_ = d.store.UpdateAgentRunStatus(sessionID, agentName, "complete")
+	// Don't overwrite "incomplete" — the agent already reported it couldn't finish.
+	current, err := d.store.GetAgentRun(sessionID, agentName)
+	if err != nil || current.Status != "incomplete" {
+		if err := d.store.UpdateAgentRunStatus(sessionID, agentName, "complete"); err != nil {
+			log.Printf("ERROR: handleBridgeFinished: failed to update agent %s status in session %s: %v", agentName, sessionID, err)
+		}
+	}
 
 	// No auto-generated message to the supervisor here. The specialist should
 	// have sent its own report via belayer_send_message before exiting.
@@ -77,6 +83,7 @@ func (d *Daemon) handleBridgeFinished(sessionID, agentName string, data map[stri
 func (d *Daemon) checkSupervisorExitedEarly(sessionID string) {
 	agents, err := d.store.ListAgentRuns(sessionID)
 	if err != nil {
+		log.Printf("WARNING: checkSupervisorExitedEarly: ListAgentRuns failed for session %s: %v", sessionID, err)
 		return
 	}
 	for _, a := range agents {
@@ -103,6 +110,7 @@ func (d *Daemon) checkSupervisorExitedEarly(sessionID string) {
 func (d *Daemon) checkSessionStalled(sessionID string) {
 	sess, err := d.store.GetSession(sessionID)
 	if err != nil {
+		log.Printf("WARNING: checkSessionStalled: GetSession failed for session %s: %v", sessionID, err)
 		return
 	}
 	// Only check sessions that are still "running".
@@ -111,26 +119,40 @@ func (d *Daemon) checkSessionStalled(sessionID string) {
 	}
 
 	agents, err := d.store.ListAgentRuns(sessionID)
-	if err != nil || len(agents) == 0 {
+	if err != nil {
+		log.Printf("WARNING: checkSessionStalled: ListAgentRuns failed for session %s: %v", sessionID, err)
+		return
+	}
+	if len(agents) == 0 {
 		return
 	}
 
 	// If any agent is still active, session is not stalled.
 	for _, a := range agents {
-		if a.Status == "running" || a.Status == "starting" {
+		if a.Status == "running" || a.Status == "starting" || a.Status == "pending_verification" {
 			return
 		}
 	}
 
 	// All agents are done/blocked/complete but session is still "running".
-	_ = d.store.UpdateSessionStatus(sessionID, "stalled")
-	_ = d.store.LogEvent(store.SessionEvent{
+	// Use conditional update to avoid race when multiple agents finish concurrently.
+	updated, err := d.store.UpdateSessionStatusIf(sessionID, "running", "stalled")
+	if err != nil {
+		log.Printf("ERROR: checkSessionStalled: failed to mark session %s as stalled: %v", sessionID, err)
+		return
+	}
+	if !updated {
+		return // another goroutine already transitioned this session
+	}
+	if err := d.store.LogEvent(store.SessionEvent{
 		SessionID: sessionID,
 		Type:      "session_stalled",
 		Data: mustJSON(map[string]string{
 			"reason": "all_agents_exited_without_completion",
 		}),
-	})
+	}); err != nil {
+		log.Printf("WARNING: checkSessionStalled: session %s marked stalled but event log failed: %v", sessionID, err)
+	}
 	log.Printf("Session %s marked stalled: all agents exited without completion approval", sessionID)
 }
 
@@ -139,19 +161,25 @@ func (d *Daemon) checkSessionStalled(sessionID string) {
 func (d *Daemon) processAgentStatusEvent(sessionID, eventType, data string) {
 	var eventData map[string]any
 	if data != "" {
-		_ = json.Unmarshal([]byte(data), &eventData)
+		if err := json.Unmarshal([]byte(data), &eventData); err != nil {
+			log.Printf("WARNING: malformed agent_status event data in session %s (type=%s): %v", sessionID, eventType, err)
+			return
+		}
 	}
 	agentName, _ := eventData["agent"].(string)
 	if agentName == "" {
+		log.Printf("WARNING: agent_status event missing agent field in session %s (type=%s)", sessionID, eventType)
 		return
 	}
 
 	switch eventType {
 	case "agent_status:incomplete":
 		detail, _ := eventData["detail"].(string)
-		_ = d.store.UpdateAgentRunStatus(sessionID, agentName, "incomplete")
+		if err := d.store.UpdateAgentRunStatus(sessionID, agentName, "incomplete"); err != nil {
+			log.Printf("ERROR: processAgentStatusEvent: failed to update agent %s to incomplete in session %s: %v", agentName, sessionID, err)
+		}
 
-		_ = d.store.LogEvent(store.SessionEvent{
+		if err := d.store.LogEvent(store.SessionEvent{
 			SessionID: sessionID,
 			Type:      "agent_escalated",
 			Data: mustJSON(map[string]string{
@@ -159,13 +187,21 @@ func (d *Daemon) processAgentStatusEvent(sessionID, eventType, data string) {
 				"reason": "incomplete",
 				"detail": detail,
 			}),
-		})
+		}); err != nil {
+			log.Printf("WARNING: processAgentStatusEvent: failed to log agent_escalated event in session %s: %v", sessionID, err)
+		}
 
 		// If the supervisor reports incomplete, escalate the session.
 		if agentName == "supervisor" {
-			_ = d.store.UpdateSessionStatus(sessionID, "needs_human_review")
-			log.Printf("Session %s escalated to human review: supervisor reported incomplete", sessionID)
+			if err := d.store.UpdateSessionStatus(sessionID, "needs_human_review"); err != nil {
+				log.Printf("ERROR: processAgentStatusEvent: failed to escalate session %s to needs_human_review: %v", sessionID, err)
+			} else {
+				log.Printf("Session %s escalated to human review: supervisor reported incomplete", sessionID)
+			}
 		}
+
+	default:
+		log.Printf("DEBUG: unhandled agent_status event %s for agent %s in session %s (log-only)", eventType, agentName, sessionID)
 	}
 }
 

--- a/internal/daemon/bridge_events_test.go
+++ b/internal/daemon/bridge_events_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/donovan-yohan/belayer/internal/store"
@@ -262,5 +263,266 @@ func TestBridgeClarificationNeededSendsMessageToPlanner(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected input-needed message from worker to supervisor, got %#v", msgs)
+	}
+}
+
+// --- Tests for checkSessionStalled ---
+
+// TestCheckSessionStalledTransitionsWhenAllAgentsDone verifies that when all
+// agents are in a terminal state, the session transitions to "stalled".
+func TestCheckSessionStalledTransitionsWhenAllAgentsDone(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "supervisor", "worker")
+	_ = d.store.UpdateSessionStatus(sessionID, "running")
+
+	// Mark both agents as complete.
+	_ = d.store.UpdateAgentRunStatus(sessionID, "supervisor", "complete")
+	_ = d.store.UpdateAgentRunStatus(sessionID, "worker", "complete")
+
+	d.checkSessionStalled(sessionID)
+
+	sess, err := d.store.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.Status != "stalled" {
+		t.Fatalf("expected session status=stalled, got %q", sess.Status)
+	}
+
+	// Verify session_stalled event was logged.
+	events, _ := d.store.QueryEvents(sessionID)
+	found := false
+	for _, e := range events {
+		if e.Type == "session_stalled" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected session_stalled event to be logged")
+	}
+}
+
+// TestCheckSessionStalledDoesNotTransitionWhenAgentRunning verifies that the
+// session stays "running" when at least one agent is still active.
+func TestCheckSessionStalledDoesNotTransitionWhenAgentRunning(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "supervisor", "worker")
+	_ = d.store.UpdateSessionStatus(sessionID, "running")
+
+	// Only one agent is complete; supervisor still running.
+	_ = d.store.UpdateAgentRunStatus(sessionID, "worker", "complete")
+
+	d.checkSessionStalled(sessionID)
+
+	sess, err := d.store.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.Status != "running" {
+		t.Fatalf("expected session status=running (agent still active), got %q", sess.Status)
+	}
+}
+
+// TestCheckSessionStalledSkipsNonRunningSession verifies that sessions already
+// in a terminal state are not re-transitioned.
+func TestCheckSessionStalledSkipsNonRunningSession(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "supervisor")
+	_ = d.store.UpdateSessionStatus(sessionID, "complete")
+	_ = d.store.UpdateAgentRunStatus(sessionID, "supervisor", "complete")
+
+	d.checkSessionStalled(sessionID)
+
+	sess, err := d.store.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.Status != "complete" {
+		t.Fatalf("expected session to remain complete, got %q", sess.Status)
+	}
+}
+
+// TestCheckSessionStalledRespectsPendingVerification verifies that agents in
+// "pending_verification" are treated as active (session should not stall).
+func TestCheckSessionStalledRespectsPendingVerification(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "supervisor", "pm")
+	_ = d.store.UpdateSessionStatus(sessionID, "running")
+
+	_ = d.store.UpdateAgentRunStatus(sessionID, "supervisor", "pending_verification")
+	_ = d.store.UpdateAgentRunStatus(sessionID, "pm", "complete")
+
+	d.checkSessionStalled(sessionID)
+
+	sess, err := d.store.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.Status != "running" {
+		t.Fatalf("expected session to remain running (supervisor pending_verification), got %q", sess.Status)
+	}
+}
+
+// --- Tests for checkSupervisorExitedEarly ---
+
+// TestCheckSupervisorExitedEarlyWarnsWhenSpecialistRunning verifies that a
+// warning event is logged when the supervisor exits while a specialist is still
+// running.
+func TestCheckSupervisorExitedEarlyWarnsWhenSpecialistRunning(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "supervisor", "worker")
+
+	// Worker is still running when supervisor exits.
+	d.checkSupervisorExitedEarly(sessionID)
+
+	events, _ := d.store.QueryEvents(sessionID)
+	found := false
+	for _, e := range events {
+		if e.Type == "warning:supervisor_exited_early" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected warning:supervisor_exited_early event")
+	}
+}
+
+// TestCheckSupervisorExitedEarlyNoWarningWhenAllDone verifies that no warning
+// is logged when all specialists have already completed.
+func TestCheckSupervisorExitedEarlyNoWarningWhenAllDone(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "supervisor", "worker")
+	_ = d.store.UpdateAgentRunStatus(sessionID, "worker", "complete")
+
+	d.checkSupervisorExitedEarly(sessionID)
+
+	events, _ := d.store.QueryEvents(sessionID)
+	for _, e := range events {
+		if e.Type == "warning:supervisor_exited_early" {
+			t.Fatal("did not expect warning:supervisor_exited_early when all specialists are done")
+		}
+	}
+}
+
+// --- Tests for processAgentStatusEvent ---
+
+// TestProcessAgentStatusIncompleteUpdatesAgent verifies that an
+// agent_status:incomplete event updates the agent's status and logs an
+// agent_escalated event.
+func TestProcessAgentStatusIncompleteUpdatesAgent(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "worker", "supervisor")
+
+	data, _ := json.Marshal(map[string]any{
+		"agent":  "worker",
+		"status": "incomplete",
+		"detail": "stuck in loop",
+	})
+	d.processAgentStatusEvent(sessionID, "agent_status:incomplete", string(data))
+
+	run, err := d.store.GetAgentRun(sessionID, "worker")
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if run.Status != "incomplete" {
+		t.Fatalf("expected agent status=incomplete, got %q", run.Status)
+	}
+
+	events, _ := d.store.QueryEvents(sessionID)
+	found := false
+	for _, e := range events {
+		if e.Type == "agent_escalated" && strings.Contains(e.Data, "worker") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected agent_escalated event for worker")
+	}
+}
+
+// TestProcessAgentStatusIncompleteSupervisorEscalatesSession verifies that when
+// the supervisor reports incomplete, the session transitions to needs_human_review.
+func TestProcessAgentStatusIncompleteSupervisorEscalatesSession(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "supervisor")
+	_ = d.store.UpdateSessionStatus(sessionID, "running")
+
+	data, _ := json.Marshal(map[string]any{
+		"agent":  "supervisor",
+		"status": "incomplete",
+		"detail": "idle timeout",
+	})
+	d.processAgentStatusEvent(sessionID, "agent_status:incomplete", string(data))
+
+	sess, err := d.store.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.Status != "needs_human_review" {
+		t.Fatalf("expected session status=needs_human_review, got %q", sess.Status)
+	}
+}
+
+// TestProcessAgentStatusMalformedJSONDoesNotPanic verifies that malformed event
+// data does not panic and is handled gracefully.
+func TestProcessAgentStatusMalformedJSONDoesNotPanic(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "worker")
+
+	// Should not panic — malformed JSON is logged and returned early.
+	d.processAgentStatusEvent(sessionID, "agent_status:incomplete", "{invalid json")
+}
+
+// TestProcessAgentStatusMissingAgentFieldDoesNotPanic verifies that an event
+// without the agent field is handled gracefully.
+func TestProcessAgentStatusMissingAgentFieldDoesNotPanic(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "worker")
+
+	d.processAgentStatusEvent(sessionID, "agent_status:incomplete", `{"detail":"no agent"}`)
+}
+
+// --- Tests for handleBridgeFinished status overwrite guard ---
+
+// TestBridgeFinishedDoesNotOverwriteIncomplete verifies that when an agent
+// has already been marked incomplete, bridge:finished does not overwrite
+// the status to "complete".
+func TestBridgeFinishedDoesNotOverwriteIncomplete(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "supervisor")
+	_ = d.store.UpdateSessionStatus(sessionID, "running")
+
+	// Simulate the idle timeout sequence: agent_status:incomplete then bridge:finished.
+	data, _ := json.Marshal(map[string]any{
+		"agent":  "supervisor",
+		"status": "incomplete",
+		"detail": "idle timeout",
+	})
+	rr := doRequest(t, d, "POST", "/sessions/"+sessionID+"/events", logEventRequest{
+		Type: "agent_status:incomplete",
+		Data: string(data),
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("agent_status:incomplete: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Now post bridge:finished — should NOT overwrite incomplete.
+	rr = postBridgeEvent(t, d, sessionID, "bridge:finished", map[string]any{
+		"agent":  "supervisor",
+		"reason": "idle_timeout",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("bridge:finished: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	run, err := d.store.GetAgentRun(sessionID, "supervisor")
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if run.Status != "incomplete" {
+		t.Fatalf("expected agent status=incomplete (not overwritten by bridge:finished), got %q", run.Status)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -353,6 +353,11 @@ func (d *Daemon) handleLogEvent(w http.ResponseWriter, r *http.Request) {
 		d.processBridgeEvent(id, req.Type, req.Data)
 	}
 
+	// Process agent_status events for side effects (incomplete → escalation).
+	if strings.HasPrefix(req.Type, "agent_status:") {
+		d.processAgentStatusEvent(id, req.Type, req.Data)
+	}
+
 	writeJSON(w, http.StatusCreated, map[string]string{"status": "logged"})
 }
 

--- a/internal/daemon/messages.go
+++ b/internal/daemon/messages.go
@@ -45,7 +45,7 @@ func (d *Daemon) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 
 	// Reject messages to agents that have exited the session.
 	if target, err := d.store.GetAgentRun(id, req.To); err == nil {
-		if target.Status == "complete" || target.Status == "blocked" {
+		if target.Status == "complete" || target.Status == "blocked" || target.Status == "incomplete" {
 			writeJSON(w, http.StatusGone, map[string]string{
 				"error": "agent '" + req.To + "' has exited (status: " + target.Status + "). Use belayer_spawn_agent to re-spawn with conversation history.",
 			})

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -193,6 +193,25 @@ func (s *Store) UpdateSessionStatus(id, status string) error {
 	return nil
 }
 
+// UpdateSessionStatusIf conditionally updates the session status only if
+// the current status matches expectedStatus. Returns true if the row was
+// updated (i.e., the expected status matched). This prevents race conditions
+// where concurrent callers overwrite each other's transitions.
+func (s *Store) UpdateSessionStatusIf(id, expectedStatus, newStatus string) (bool, error) {
+	result, err := s.db.Exec(
+		`UPDATE sessions SET status = ?, updated_at = ? WHERE id = ? AND status = ?`,
+		newStatus, time.Now().UTC(), id, expectedStatus,
+	)
+	if err != nil {
+		return false, fmt.Errorf("store: conditional update session status: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("store: rows affected: %w", err)
+	}
+	return rows > 0, nil
+}
+
 // UpdateSessionWorkspaceDir updates the workspace_dir and updated_at of a session.
 func (s *Store) UpdateSessionWorkspaceDir(id, workspaceDir string) error {
 	_, err := s.db.Exec(

--- a/templates/backend/system-prompt.md
+++ b/templates/backend/system-prompt.md
@@ -5,3 +5,11 @@ Your workspace at /workspace is the backend repository. You write code, run buil
 When you finish a task, summarize what you changed and any decisions you made, then message the supervisor so they can coordinate next steps.
 
 If you encounter something outside your repo (e.g., the frontend needs a corresponding change), message the supervisor — do not try to modify other repos.
+
+## Code quality rules
+
+These apply to all code you write. Violations here are bugs, not style preferences.
+
+- **Guard variant-specific logic.** If you build something that only works for one variant of a polymorphic input (e.g., one message type, one API version), you need a guard that correctly identifies all representations of that variant AND a graceful fallback for non-matching variants. Never let type-specific parsing throw on unexpected input.
+- **Code in timers must be cheap.** Anything inside periodic cleanup, cron handlers, or polling loops runs repeatedly. Avoid full scans or sorts when a filter or early-exit suffices. Add an early return when the work is unnecessary (e.g., TTL is Infinity, list is empty).
+- **New conditional branch = new test.** If you add a new `if` branch — especially one that deletes data, changes state, or handles an error — write a test that enters it. "Existing tests still pass" means nothing if they don't exercise the new path.

--- a/templates/frontend/system-prompt.md
+++ b/templates/frontend/system-prompt.md
@@ -5,3 +5,19 @@ Your workspace at /workspace is the frontend repository. You write code, run typ
 When you finish a task, summarize what you changed and any decisions you made, then message the supervisor so they can coordinate next steps.
 
 If you encounter something that requires a backend change (e.g., a new endpoint or a contract change), message the supervisor — do not try to modify other repos.
+
+## Code quality rules
+
+These apply to all code you write. Violations here are bugs, not style preferences.
+
+### General
+
+- **Guard variant-specific logic.** If you build something that only works for one variant of a polymorphic input (e.g., one diagram type, one message format), you need a guard that correctly identifies all representations of that variant AND a graceful fallback (return null, skip) for non-matching variants. Never let type-specific parsing throw on unexpected input.
+- **Code in timers must be cheap.** Anything inside `setInterval`, `requestAnimationFrame`, or periodic cleanup runs repeatedly. Avoid full scans or sorts when a filter or early-exit suffices. Add an early return when the work is unnecessary (e.g., TTL is Infinity, list is empty).
+- **New conditional branch = new test.** If you add a new `if` branch — especially one that deletes data, changes state, or handles an error — write a test that enters it. "Existing tests still pass" means nothing if they don't exercise the new path.
+
+### Frontend-specific
+
+- **Separate state per independent UI action.** If two UI elements trigger the same type of action (copy, save, submit) but serve different purposes, each needs its own state variable. "They both copy something" does not mean they share a `copyState`. Ask: can these fire independently? If yes, separate state.
+- **Modal accessibility is not optional.** Every modal needs: `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing to the title element, focus moved into the modal on open, focus returned on close. A modal without these is incomplete, not "missing polish."
+- **Guard onBlur against keyboard-triggered unmount.** `onBlur` and keyboard handlers (Escape, Enter) conflict when both can close a component. Closing via Escape triggers blur, which may commit instead of cancel. Use a ref (e.g., `cancelRef.current = true`) set in the Escape handler and checked in `onBlur`, or only commit on explicit action (Enter/button), never on blur alone.

--- a/templates/reviewer/agents.md
+++ b/templates/reviewer/agents.md
@@ -22,6 +22,18 @@ The supervisor sends you:
 - Are there security concerns (injection, auth bypass, data exposure)?
 - Is there test coverage for the new behavior?
 
+### Specific patterns to check
+
+These are common bugs that pass typecheck and tests but break at runtime:
+
+- **Shared state across unrelated UI actions.** Look for `useState` values referenced in multiple click handlers that serve different purposes (e.g., two copy buttons sharing one `copyState`). Each independent action needs its own state.
+- **Modal/dialog missing accessibility.** Any `div` with modal/overlay behavior (grep for `modal`, `overlay`, `dialog` in className) must have `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, and focus management. Missing these is a blocking issue, not a suggestion.
+- **onBlur + onKeyDown cancel conflict.** Any component with both `onBlur` commit logic and `onKeyDown` Escape/cancel logic. Escape-triggered unmount fires blur, which commits instead of canceling. These always conflict unless explicitly guarded (e.g., a `cancelRef`).
+- **Variant-specific parsing without guard.** Any code that parses or processes a specific subtype (e.g., one diagram type, one message format). Check: what happens with other types? Does the detection cover all aliases/representations? Is there a graceful fallback or does it throw?
+- **Drag/transform math.** Any `onPointerMove`/`onMouseMove` handler that updates position. Verify the formula actually applies the delta (`current = start + delta`, not `current = start`). This class of bug is invisible to CI.
+- **Expensive code in periodic timers.** Any code inside `setInterval`, cleanup loops, or polling. Check the cost of what it calls and whether there's an early-exit when the work is a no-op.
+- **New branches without tests.** Diff any function with new `if`/`else` paths. For each new branch, verify there's a test that enters it. Especially for branches that delete data or change state.
+
 ## Lifecycle
 
 You are ephemeral — spawned for a specific review, terminated when done. Provide your verdict via `belayer message send --to supervisor` and then signal completion. Do not wait for follow-up unless the supervisor messages you with a re-review request.

--- a/templates/supervisor/system-prompt.md
+++ b/templates/supervisor/system-prompt.md
@@ -2,6 +2,12 @@ You are the supervisor agent for this belayer session. You orchestrate — you d
 
 You decompose work, delegate to your team, interpret results, and decide what happens next. How you coordinate your team is your judgment. You may discover effective patterns over time — write observations via `belayer note` so reflection can update your memory for future sessions.
 
+## Reading specs and operator messages
+
+When you receive an operator message or a spec reference, you MUST read the entire document before planning or delegating. Do not truncate, skim, or read partial content. If a file is long, read it in chunks until you reach the end. Plans built from partial specs produce incomplete work.
+
+## Delegating work
+
 When delegating, provide enough context that your agents can succeed without asking clarifying questions: relevant file paths, architectural constraints, what has already been tried, and what success looks like.
 
 When an implementer signals completion, decide whether to route to a reviewer, run integration tests via the workbench, or proceed to the next task. This is your judgment call — not a fixed pipeline.


### PR DESCRIPTION
## Summary
- Fix bridge heartbeat gap (thread existed but was never wired — caused 3.5 min silent gaps during model generation)
- Add stalled session detection, supervisor-exited-early warnings, and "incomplete" agent status for human escalation
- Add top-level `path` field to file operation events for monitoring visibility
- Codify code quality learnings from Copilot review of arielcharts PR #6 into core agent templates

## Context

Post-mortem from two Nightshift runs on arielcharts (sessions `fac16b6c` and `86c41114`) identified:
- **RC1**: Supervisor read partial spec → added explicit "read full spec" rule to supervisor template
- **RC2**: Supervisor exited while specialists still running, no session lifecycle detection → added `stalled` status and `supervisor_exited_early` warning
- **RC3**: No heartbeat during model generation → wired existing `start_heartbeat_thread` (was defined but never called)
- **RC4**: File paths buried in truncated `input_preview` → extract `path` as top-level event field
- **Copilot review learnings**: 10 comments on arielcharts PR #6 distilled into 7 reusable patterns added to frontend, backend, and reviewer templates

Also adds diagnostic logging for an unresolved bug where the supervisor bridge treats itself as ephemeral despite `BELAYER_EPHEMERAL=false` — the startup log will confirm on next run whether the env var is reaching the process.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] Python syntax check passes for all modified bridge files
- [ ] Run a Nightshift session and verify heartbeats appear every 30s during model generation
- [ ] Verify `stalled` session status appears when all agents exit without completion
- [ ] Verify supervisor bridge stderr logs `ephemeral=False` on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)