### PR TITLE
feat: sandbox driver and runtime provider abstraction layer

### DIFF
--- a/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
+++ b/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
@@ -1,0 +1,517 @@
+---
+status: current
+created: 2026-04-16
+branch: master
+supersedes: docs/design-docs/2026-04-16-vm-sandbox-and-template-bootstrap.md
+implemented-by:
+consulted-learnings:
+  - docs/design-docs/2026-04-15-nightshift-v1-deployment-topology.md
+  - docs/design-docs/2026-04-15-git-backed-agent-identity.md
+  - docs/design-docs/2026-04-15-hermes-bridge-sidecar.md
+  - docs/design-docs/2026-04-16-vm-sandbox-and-template-bootstrap.md
+---
+
+# Sandbox, Runtime, and Crag Proof-of-Concept
+
+End-to-end proof: lightweight crag on macOS dispatches a request to a Lima VM worker, which provisions a runtime, creates a sandboxed execution boundary, runs a belayer session against arielcharts, and completes.
+
+## Philosophy: Runtime vs Sandbox
+
+Belayer's original "sandbox" concept was overloaded — it meant both "where agents execute" and "what agents work against." These are two concerns with different lifecycles and different owners.
+
+**Runtime** = the dev stack agents work against. Databases, app servers, mock services. Provisioned before agents spawn. Owned by the project (each repo defines its own `pnpm dev` or `xt up` or `docker compose up`). Lives for the session.
+
+**Sandbox** = the execution boundary agents run inside. Network egress control, credential mediation, filesystem isolation. Owned by the operator (security policy is a deployment concern, not a project concern). Also lives for the session.
+
+They compose: runtime services become allowed TCP endpoints in the sandbox policy. The runtime says "Postgres is on port 5432." The sandbox says "agents may reach port 5432 and nothing else."
+
+```
+┌─────────────────────── Worker ───────────────────────┐
+│                                                       │
+│  Runtime (project-owned)         Sandbox (operator-owned)
+│  ┌─────────────────────┐        ┌────────────────────┐│
+│  │ pnpm dev             │        │ clamshell sandbox  ││
+│  │  → server :4000      │◄──────►│  → agent processes ││
+│  │  → web    :3000      │ shared │  → deny-by-default ││
+│  └─────────────────────┘  mount  │  → policy YAML     ││
+│         host filesystem ─────────│──► /workspace       ││
+│                                  └────────────────────┘│
+└───────────────────────────────────────────────────────┘
+```
+
+The shared filesystem is the connection between runtime and sandbox. When an agent inside the sandbox writes to `/workspace/src/app.tsx`, that write lands on the host filesystem via Docker bind mount. The runtime's hot-reload picks it up. No sync protocol needed.
+
+## Identity: `.belayer/` in the Repo
+
+Agent templates live in `.belayer/templates/` in the repo itself, committed to git.
+
+On first run (`belayer init` or auto-scaffolded), belayer creates:
+
+```
+.belayer/
+  config.yaml
+  templates/
+    supervisor/
+      system-prompt.md       # the supervisor soul
+      agent.yaml             # belayer_tools: [spawn, request_completion]
+    pm/
+      system-prompt.md       # the PM soul
+      agent.yaml             # belayer_tools: [approve, reject]
+  policies/
+    belayer-standard.yaml    # default network egress policy
+```
+
+Users customize from there: edit souls, add new agents (backend, frontend, qa, reviewer), adjust policies. The defaults originate from chalk-bag (copied at belayer build time), but belayer reads only from the repo at runtime.
+
+**chalk-bag's role**: canonical source for developing and versioning shared agent archetypes. Belayer's compiled-in defaults are built from chalk-bag. Users can also copy templates from chalk-bag manually when bootstrapping a new project. But chalk-bag is not a runtime dependency.
+
+### Multi-repo workspaces
+
+For multi-repo setups, `.belayer/config.yaml` can't live in any single repo because the workspace is assembled at session start. Instead, the workspace definition lives in **crag** — the outer daemon that submits requests to workers. Crag is infrastructure (a server with a database), not source code. It knows "extend-fullstack means these repos with this config."
+
+For local dev without crag, pass a workspace config explicitly:
+
+```bash
+belayer run start --workspace ~/.belayer/workspaces/extend-fullstack.yaml --task "..."
+```
+
+Resolution:
+- **Single-repo**: `.belayer/config.yaml` in the repo, auto-discovered
+- **Multi-repo**: workspace definition from crag or `--workspace` flag
+- **No config**: belayer scaffolds defaults (supervisor + PM)
+
+## Worktrees: Coding Tool, Not Integration Surface
+
+Git worktrees are a tool for parallel coding — multiple agents editing different parts of the codebase without file conflicts. They are **not** the integration surface.
+
+One session builds toward one goal. Agents may use worktrees to parallelize work, but real integration, testing, and QA happen against the shared workspace (the main feature branch) after worktree work is merged back. The runtime runs against the shared workspace, not against individual worktrees.
+
+Concretely:
+- Runtime starts from the repo root (the shared workspace)
+- Agents may create worktrees for isolated branch work
+- When an agent's work is ready, it merges to the shared branch
+- Integration tests and QA run against the shared workspace where the runtime is hot-reloading
+- The PM gate verifies the integrated result, not individual worktrees
+
+This means worktree-based agents cannot live-test against the runtime mid-work. They code, merge, then the supervisor or QA agent validates the integrated result. This is intentional — it matches how human teams work with feature branches.
+
+## SandboxDriver Interface
+
+The sandbox driver manages the agent execution boundary. Belayer holds one driver per session.
+
+```go
+// internal/sandbox/driver.go
+package sandbox
+
+type Driver interface {
+    // Create prepares an execution environment for the session.
+    // Called once per session, before any agents spawn.
+    Create(ctx context.Context, cfg Config) (Handle, error)
+
+    // Exec runs a command inside the sandbox. Used for each agent spawn.
+    // The caller manages stdin/stdout/stderr wiring.
+    Exec(ctx context.Context, h Handle, cmd []string, opts ExecOpts) (*os.Process, error)
+
+    // Stop tears down the sandbox. Called when the session ends.
+    Stop(ctx context.Context, h Handle) error
+}
+
+type Config struct {
+    Name       string        // sandbox identifier (typically session ID)
+    Workspace  string        // host path to mount at /workspace
+    Policy     string        // path to policy YAML (driver-specific)
+    Mounts     []Mount       // additional mounts
+    Endpoints  []TCPEndpoint // runtime services to allow through the sandbox
+}
+
+type ExecOpts struct {
+    Env    []string        // environment variables
+    Dir    string          // working directory inside sandbox
+    Stdin  io.Reader
+    Stdout io.Writer
+    Stderr io.Writer
+}
+
+type Mount struct {
+    HostPath    string
+    SandboxPath string
+    ReadOnly    bool
+}
+
+type TCPEndpoint struct {
+    Name string
+    Host string
+    Port int
+}
+
+type Handle struct {
+    ID   string // opaque identifier
+    Meta map[string]string // driver-specific metadata
+}
+```
+
+### What ships in belayer (open source)
+
+- `internal/sandbox/driver.go` — the `Driver` interface
+- `internal/sandbox/noop.go` — the noop driver (direct exec, zero overhead)
+- `internal/runtime/provider.go` — the `Provider` interface
+- `internal/runtime/noop.go` — the noop provider
+- `internal/runtime/command.go` — the command provider (shells out to up/health/down)
+- Default policy YAMLs scaffolded on `belayer init`
+
+### What does NOT ship in belayer
+
+- The clamshell driver — lives in the crag/proof infrastructure, not the open-source repo
+- The crag binary — separate project
+- Specific agent identities — per-repo `.belayer/` or chalk-bag
+- Workspace definitions — crag config
+
+Belayer ships the interfaces. Driver implementations are deployment details. The clamshell driver is the proof that the interface works, not a first-class dependency.
+
+### noop driver (ships with belayer)
+
+Zero overhead, current behavior. No isolation.
+
+```go
+func (n *Noop) Create(ctx context.Context, cfg Config) (Handle, error) {
+    return Handle{ID: cfg.Name}, nil
+}
+
+func (n *Noop) Exec(ctx context.Context, h Handle, cmd []string, opts ExecOpts) (*os.Process, error) {
+    c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+    c.Env = opts.Env
+    c.Dir = opts.Dir
+    c.Stdin = opts.Stdin
+    c.Stdout = opts.Stdout
+    c.Stderr = opts.Stderr
+    if err := c.Start(); err != nil {
+        return nil, err
+    }
+    return c.Process, nil
+}
+
+func (n *Noop) Stop(ctx context.Context, h Handle) error {
+    return nil
+}
+```
+
+### clamshell driver (proof-of-concept, NOT in belayer repo)
+
+Wraps the clamshell CLI. Creates a sandbox at session start, execs agents via `docker exec`. Lives in the crag proof infrastructure.
+
+```go
+func (c *Clamshell) Create(ctx context.Context, cfg Config) (Handle, error) {
+    // 1. Ensure gateway is running
+    //    clamshell gateway start
+    //
+    // 2. Inject runtime endpoints into policy tcp_endpoints
+    //    (read policy YAML, append endpoints, write to temp file)
+    //
+    // 3. Create sandbox
+    //    clamshell sandbox create --name <cfg.Name> --policy <policy> --workspace <cfg.Workspace>
+    //
+    // 4. Discover container name
+    //    clamshell --json sandbox connect <cfg.Name> → extract container ID
+    //
+    // 5. If endpoints use deferred materialization, refresh
+    //    clamshell sandbox refresh <cfg.Name>
+}
+
+func (c *Clamshell) Exec(ctx context.Context, h Handle, cmd []string, opts ExecOpts) (*os.Process, error) {
+    // docker exec -u sandbox -i <container> env KEY=VAL ... sh -lc "<cmd>"
+    // Wire stdin/stdout/stderr through
+}
+
+func (c *Clamshell) Stop(ctx context.Context, h Handle) error {
+    // clamshell sandbox stop <name>
+}
+```
+
+## RuntimeProvider Interface
+
+The runtime provider provisions the dev stack. Belayer calls it before creating the sandbox.
+
+```go
+// internal/runtime/provider.go
+package runtime
+
+type Provider interface {
+    // Up starts the dev stack and returns discovered endpoints.
+    Up(ctx context.Context) ([]Endpoint, error)
+
+    // Health checks whether the dev stack is ready.
+    Health(ctx context.Context) error
+
+    // Down stops the dev stack.
+    Down(ctx context.Context) error
+}
+
+type Endpoint struct {
+    Name string
+    Host string
+    Port int
+}
+```
+
+### noop provider
+
+For projects with no dev stack (pure library, CLI tool, etc.).
+
+### command provider
+
+Reads from `.belayer/config.yaml`:
+
+```yaml
+runtime:
+  up: "pnpm dev &"
+  health: "curl -sf http://localhost:4000/health"
+  down: "pkill -f 'pnpm dev'"
+  endpoints:
+    - {name: server, host: localhost, port: 4000}
+    - {name: web, host: localhost, port: 3000}
+```
+
+`Up` runs the up command, polls health until ready (with timeout), returns the declared endpoints. `Down` runs the down command.
+
+## Integration: Session Start Flow
+
+```go
+func (d *Daemon) startSession(req SessionRequest) error {
+    // 1. Provision runtime
+    endpoints, err := d.runtime.Up(ctx)
+    if err != nil { return err }
+    defer func() {
+        if err != nil { d.runtime.Down(ctx) }
+    }()
+
+    // 2. Wait for runtime health
+    if err := d.runtime.Health(ctx); err != nil { return err }
+
+    // 3. Create sandbox (inject runtime endpoints)
+    handle, err := d.sandbox.Create(ctx, sandbox.Config{
+        Name:      sessionID,
+        Workspace: workspaceDir,
+        Policy:    policyPath,
+        Endpoints: endpoints,
+    })
+    if err != nil { return err }
+
+    // 4. Store handle — all subsequent agent spawns use it
+    d.session.sandboxHandle = handle
+
+    // 5. Spawn supervisor (existing flow, but through sandbox.Exec)
+    return d.spawnBridgeAgent(supervisorReq)
+}
+```
+
+The change to `bridgeLaunchAgent` is minimal — instead of calling `bridge.Spawn(cfg)` which runs `exec.Command` directly, it calls `d.sandbox.Exec(handle, cmd, opts)`. The bridge `Config` assembly (env vars, PYTHONPATH, system prompt loading) is unchanged.
+
+## Bridge Refactor
+
+The current `bridge.Spawn()` both assembles the environment AND runs the process. We split these:
+
+```go
+// bridge.BuildEnv(cfg) → []string        (pure, no side effects)
+// bridge.BuildCmd(cfg) → []string         (pure, no side effects)
+// sandbox.Exec(handle, cmd, env, ...)     (runs the process)
+```
+
+The bridge package becomes a pure environment/command builder. Process execution moves to the sandbox driver.
+
+The existing `bridge.Process` type (stdin pipe, wait, interrupt) still wraps the underlying process. The sandbox driver's `Exec` returns an `*os.Process`, and the bridge `Process` wrapper is constructed from it. This preserves the interrupt/wait/done interface that the daemon depends on — the only change is that the underlying `os.Process` may be a `docker exec` process rather than a direct Python process.
+
+## Hermes Network Policy
+
+Hermes agents make HTTP requests to LLM providers, auth servers, search APIs, and skills hubs. The sandbox policy must allow these.
+
+### Endpoint inventory (from hermes-agent source)
+
+**Always needed:**
+
+| Domain | Purpose |
+|--------|---------|
+| `api.anthropic.com` | Claude API |
+| `api.openai.com` | OpenAI API |
+| `auth.openai.com` | Codex OAuth |
+| `chatgpt.com` | Codex inference |
+| `portal.nousresearch.com` | Nous OAuth + agent keys |
+| `inference-api.nousresearch.com` | Nous inference |
+
+**Common providers:**
+
+| Domain | Purpose |
+|--------|---------|
+| `openrouter.ai` | Multi-model gateway |
+| `api.deepseek.com` | DeepSeek |
+| `api.kimi.com` | Kimi coding |
+| `api.moonshot.cn` | Moonshot |
+
+**Agent tools:**
+
+| Domain | Purpose |
+|--------|---------|
+| `api.github.com`, `github.com` | Git operations, skill fetching |
+| `api.tavily.com` | Web search |
+| `registry.npmjs.org` | npm packages |
+| `pypi.org`, `files.pythonhosted.org` | Python packages |
+
+### Default policies shipped with belayer
+
+**`belayer-minimal.yaml`** — Anthropic + GitHub only. For testing.
+
+**`belayer-standard.yaml`** — Multi-provider + packages + search + skills hub. For typical runs.
+
+**`belayer-workbench.yaml`** — Standard + `tcp_endpoints` section for sidecar services (Postgres, Redis, LocalStack). For runs with a dev stack.
+
+These are scaffolded into `.belayer/policies/` on init. Users can edit them.
+
+## Lightweight Crag
+
+Minimal Go binary that runs on macOS and dispatches to the Lima VM worker.
+
+### What crag does
+
+- Holds named workspace definitions (arielcharts, extend-fullstack)
+- Maintains a request queue (SQLite)
+- Manages one worker: the `devbox` Lima VM
+- Dispatches requests: SSHs into the VM, runs `belayer run start`
+- Polls belayer status until complete
+- Collects results
+
+### CLI surface
+
+```
+crag start                    # start the crag daemon
+crag submit --task "..."      # submit a request (auto-detects workspace from cwd)
+crag submit --workspace extend-fullstack --task "..."
+crag status                   # show active/queued requests
+crag list                     # show request history
+crag workspace add arielcharts ~/arielcharts
+crag workspace list
+```
+
+### Workspace definition
+
+```yaml
+# ~/.crag/workspaces/arielcharts.yaml
+name: arielcharts
+repos:
+  - path: ~/Documents/Programs/personal/arielcharts
+worker:
+  type: lima
+  vm: devbox
+```
+
+```yaml
+# ~/.crag/workspaces/extend-fullstack.yaml
+name: extend-fullstack
+repos:
+  - name: api
+    path: ~/Documents/Programs/work/extend-api
+  - name: app
+    path: ~/Documents/Programs/work/extend-app
+worker:
+  type: lima
+  vm: devbox
+```
+
+### Dispatch flow
+
+```
+1. crag submit --workspace arielcharts --task "Add dark mode"
+2. crag checks worker status: limactl list → devbox Running
+3. crag SSHs into VM:
+   limactl shell devbox -- bash -c '
+     cd ~/Documents/Programs/personal/arielcharts
+     belayer daemon &
+     belayer run start --task "Add dark mode"
+   '
+4. crag polls: limactl shell devbox -- belayer status
+5. On completion, crag records result
+```
+
+Crag doesn't know about sandbox or runtime — those are belayer's concern, configured in `.belayer/config.yaml` in the repo.
+
+## Proof-of-Concept: arielcharts
+
+### Target
+
+arielcharts: real-time collaborative Mermaid diagram editor. pnpm monorepo, Next.js + Node.js server, LevelDB (embedded). No external services needed.
+
+### What we prove
+
+1. **Crag dispatch**: macOS → Lima VM via `limactl shell`
+2. **Runtime provision**: `pnpm dev` starts server + web, health check passes
+3. **Sandbox creation**: clamshell sandbox with standard policy, runtime endpoints allowed
+4. **Agent execution**: supervisor spawns inside sandbox, hermes agent runs, reaches Anthropic API
+5. **Network egress**: deny events are empty (all legitimate traffic allowed, nothing else leaks)
+6. **Code changes**: agent edits files inside sandbox, runtime hot-reloads, changes visible
+7. **Session completion**: PM gate fires, session completes, crag records result
+
+### arielcharts `.belayer/config.yaml`
+
+```yaml
+runtime:
+  up: "pnpm install --frozen-lockfile && pnpm dev &"
+  health: "curl -sf http://localhost:4000/health"
+  down: "pkill -f 'next dev'; pkill -f 'tsx watch'"
+  endpoints:
+    - {name: server, host: localhost, port: 4000}
+    - {name: web, host: localhost, port: 3000}
+
+sandbox:
+  mode: clamshell
+  policy: .belayer/policies/belayer-standard.yaml
+```
+
+### Phases
+
+**Phase 1: SandboxDriver + RuntimeProvider interfaces**
+- Create `internal/sandbox/` and `internal/runtime/` packages
+- Implement noop drivers
+- Refactor bridge.Spawn to separate env building from process execution
+- Wire into daemon session start
+- Test: existing behavior unchanged with noop drivers
+
+**Phase 2: Clamshell driver**
+- Implement clamshell sandbox driver
+- Ship default policies in `.belayer/policies/`
+- Test in Lima VM: create sandbox, exec agent, verify egress policy
+- Iterate on policy by watching deny events
+
+**Phase 3: Command runtime provider**
+- Implement command runtime provider
+- Test with arielcharts: `pnpm dev`, health check, endpoint discovery
+- Verify shared filesystem: agent edits visible to runtime
+
+**Phase 4: Lightweight crag**
+- Minimal Go binary with workspace definitions and request queue
+- Lima VM as single worker
+- Dispatch via `limactl shell`
+- Poll belayer status
+
+**Phase 5: End-to-end**
+- `crag submit --workspace arielcharts --task "Add dark mode toggle"`
+- Full flow: dispatch → runtime → sandbox → agents → PM gate → complete
+- Verify: network locked down, code changes hot-reload, session completes
+
+## Open Questions
+
+### 1. Sandbox stdin/stdout wiring
+
+The bridge uses stdin for daemon→agent interrupts and stdout for logging. When exec'ing via `docker exec`, stdin/stdout piping works but needs care — `docker exec -i` keeps stdin open. Need to verify interrupt delivery works through the Docker exec layer.
+
+### 2. Daemon socket access from sandbox
+
+The bridge communicates with the daemon via Unix socket HTTP. Inside a clamshell sandbox, the socket must be reachable. Options:
+- Mount the socket into the sandbox as an additional mount
+- Use a TCP localhost forward instead of Unix socket
+- The daemon listens on both Unix socket and TCP when sandbox mode is clamshell
+
+### 3. Hermes auth inside sandbox
+
+Hermes needs API keys or OAuth tokens. With clamshell, credentials should flow through the proxy's `inference.local` routing (opaque handles). For the PoC, we can inject `ANTHROPIC_API_KEY` as an env var at exec time and migrate to opaque handles later.
+
+### 4. Crag persistence
+
+SQLite for the PoC. Workspace definitions as YAML files in `~/.crag/workspaces/`. No web UI yet — CLI only.

--- a/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
+++ b/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
@@ -515,3 +515,7 @@ Hermes needs API keys or OAuth tokens. With clamshell, credentials should flow t
 ### 4. Crag persistence
 
 SQLite for the PoC. Workspace definitions as YAML files in `~/.crag/workspaces/`. No web UI yet — CLI only.
+
+### 5. `runtime.Endpoint` shape (deferred)
+
+`Endpoint` currently carries only `Name`/`Host`/`Port`. A protocol/scheme field plus a `URL()` helper was raised in code review (2026-04-16, CodeRabbit on PR #71) — it would help once endpoints drive sandbox egress policy or get injected as env vars for agents. Deferred until a real provider lands so we design the shape around concrete needs (e.g., does the clamshell policy need a protocol discriminator, or is host/port enough?). Revisit when implementing the command provider's endpoint wiring in Phase 5.

--- a/docs/design-docs/2026-04-16-vm-sandbox-and-template-bootstrap.md
+++ b/docs/design-docs/2026-04-16-vm-sandbox-and-template-bootstrap.md
@@ -1,0 +1,821 @@
+---
+status: superseded
+created: 2026-04-16
+supersedes:
+implemented-by:
+consulted-learnings:
+  - docs/design-docs/2026-04-15-nightshift-v1-deployment-topology.md
+  - docs/design-docs/2026-04-15-git-backed-agent-identity.md
+  - docs/design-docs/2026-04-15-hermes-bridge-sidecar.md
+---
+
+# VM Sandbox, Network Policy, and Template Bootstrap
+
+Prove that Belayer can run inside a Lima VM, agents execute through Hermes with managed network egress, and chalk-bag provides the permanent skill/template home for ephemeral sessions.
+
+## Three goals
+
+1. **VM testbed** — use the existing `devbox` Lima VM as the execution environment for belayer + hermes agents
+2. **Network sandbox** — manage agent egress so only declared endpoints are reachable, with clamshell as an optional enforcement layer
+3. **Template bootstrap** — use `chalk-bag` as the permanent, git-backed home for agent templates, skills, and tool definitions that get materialized into ephemeral hermes sessions
+
+---
+
+## Part 1: Lima VM as Testbed
+
+### What we have
+
+```
+$ limactl list
+NAME        STATUS   CPUS  MEMORY  DISK
+devbox      Stopped  8     16GiB   100GiB
+```
+
+- Ubuntu 24.04 LTS (ARM64, Apple VZ with Rosetta)
+- `~/Documents/Programs` mounted writable via virtiofs
+- Port forwards: 3000-3100, 5432, 6379, 8080, 9000
+- Provisioned with: build-essential, git, Node.js 20, Python 3, tmux, ripgrep, etc.
+
+### What we need to install in the VM
+
+```bash
+# 1. Go (for building belayer)
+sudo snap install go --classic  # or wget + /usr/local/go
+
+# 2. Hermes agent
+# Clone or pip install hermes-agent into ~/.hermes/hermes-agent/
+python3 -m venv ~/.hermes/hermes-agent/venv
+~/.hermes/hermes-agent/venv/bin/pip install hermes-agent
+
+# 3. Hermes CLI (for profile/auth management)
+# Same venv or separate
+~/.hermes/hermes-agent/venv/bin/pip install hermes-cli
+
+# 4. Docker (for clamshell, optional)
+sudo apt-get install docker.io docker-compose-plugin
+sudo usermod -aG docker $USER
+
+# 5. Belayer binary
+cd ~/Documents/Programs/personal/belayer
+go build -o ~/.local/bin/belayer ./cmd/belayer
+
+# 6. chalk-bag (clone if not already mounted)
+# Already at ~/Documents/Programs/personal/chalk-bag via virtiofs mount
+```
+
+### VM bootstrap script
+
+```bash
+#!/usr/bin/env bash
+# belayer-devbox-setup.sh — run inside limactl shell devbox
+set -euo pipefail
+
+echo "=== Installing Go ==="
+if ! command -v go &>/dev/null; then
+  sudo snap install go --classic
+fi
+
+echo "=== Setting up Hermes venv ==="
+HERMES_HOME="$HOME/.hermes"
+VENV="$HERMES_HOME/hermes-agent/venv"
+mkdir -p "$HERMES_HOME/hermes-agent" "$HERMES_HOME/profiles"
+if [ ! -d "$VENV" ]; then
+  python3 -m venv "$VENV"
+fi
+"$VENV/bin/pip" install --upgrade pip
+"$VENV/bin/pip" install hermes-agent hermes-cli
+
+echo "=== Building Belayer ==="
+BELAYER_ROOT="$HOME/Documents/Programs/personal/belayer"
+cd "$BELAYER_ROOT"
+go build -o "$HOME/.local/bin/belayer" ./cmd/belayer
+
+echo "=== Verifying ==="
+belayer --version || echo "belayer not on PATH, add ~/.local/bin"
+"$VENV/bin/python3" -c "from hermes_agent import AIAgent; print('hermes OK')"
+
+echo "=== Done ==="
+```
+
+### Why the VM matters
+
+The devbox VM proves the deployment topology from the Nightshift v1 design doc:
+
+- **Host (macOS)** = operator workstation
+- **VM** = simulated Nightshift worker node
+- **One request, one worker, one belayer session** — the v1 constraint
+
+If belayer + hermes agents run correctly inside the VM, the same topology works on a real Linux worker node.
+
+---
+
+## Part 2: Network Sandbox — With or Without Clamshell
+
+### Design: two enforcement modes
+
+The user wants clamshell to be **optional**. This means belayer needs an abstraction layer:
+
+```
+┌─────────────────────────────────┐
+│         Belayer Daemon          │
+│                                 │
+│  bridge.Spawn(cfg) ────────────┼──► Python subprocess
+│                                 │
+│  cfg.SandboxMode:              │
+│    "none"     → direct exec    │
+│    "clamshell" → clamshell     │
+│                sandbox create  │
+└─────────────────────────────────┘
+```
+
+### Mode: `none` (current behavior, zero overhead)
+
+- Bridge subprocess runs directly via `python3 -m hermes_bridge`
+- Agent inherits host/VM environment, network, credentials
+- No isolation whatsoever
+- Good for: local dev, trusted environments, quick iteration
+
+### Mode: `clamshell` (sandboxed, managed egress)
+
+- Belayer daemon calls `clamshell sandbox create` before spawning the bridge
+- Bridge subprocess runs inside the sandbox container
+- Network egress is deny-by-default, governed by policy YAML
+- Credentials mediated through clamshell proxy (opaque handles)
+- Good for: production workers, untrusted agent code, compliance
+
+### Complexity assessment: how much does dual-mode add?
+
+**Low complexity.** Here's why:
+
+1. **The bridge interface doesn't change.** Whether running natively or in clamshell, the bridge is still `python3 -m hermes_bridge` with the same env vars. Clamshell wraps the execution environment, not the protocol.
+
+2. **Config is a single field.** `SandboxMode` in the bridge config (already extensible). The spawn path branches once: direct exec vs clamshell create + exec-inside.
+
+3. **Policy files are standalone.** They don't need to be compiled into belayer. They're YAML files shipped alongside templates. Clamshell reads them directly.
+
+4. **No code in the hot path.** The sandbox setup happens once at agent spawn, not per-turn. The ongoing bridge<->daemon communication is identical in both modes (Unix socket HTTP).
+
+**What it costs:**
+- ~50 lines in `internal/bridge/bridge.go` for the clamshell spawn path
+- A `sandbox_mode` field in `.belayer/config.yaml` and per-environment overrides
+- Policy YAML files shipped in the belayer repo (already started: `.belayer/policies/`)
+- Documentation for both modes
+
+**What it does NOT cost:**
+- No abstraction layer or plugin interface needed
+- No runtime behavioral differences (bridge protocol is identical)
+- No conditional logic in hermes_bridge Python code
+- No changes to the daemon HTTP API
+
+### Implementation sketch
+
+```go
+// internal/bridge/bridge.go
+
+func (b *Bridge) Spawn(cfg Config) (*Process, error) {
+    switch cfg.SandboxMode {
+    case "clamshell":
+        return b.spawnViaClamshell(cfg)
+    default: // "none" or empty
+        return b.spawnDirect(cfg)
+    }
+}
+
+func (b *Bridge) spawnViaClamshell(cfg Config) (*Process, error) {
+    // 1. Ensure clamshell gateway is running
+    // 2. Create sandbox with policy from cfg.PolicyPath
+    // 3. Bootstrap: clone chalk-bag, set up hermes profile
+    // 4. Execute bridge inside sandbox
+    // 5. Set up port forward for daemon Unix socket
+    // Returns Process handle that wraps clamshell sandbox lifecycle
+}
+```
+
+### Configuration
+
+```yaml
+# .belayer/config.yaml
+sandbox:
+  mode: none           # "none" | "clamshell"
+  policy: .belayer/policies/default.yaml
+  clamshell:
+    gateway_url: http://127.0.0.1:8787
+    providers:
+      - github=github-main
+      - anthropic=anthropic-main
+```
+
+Override per environment:
+
+```yaml
+# .belayer/environments/extend-fullstack.yaml
+sandbox:
+  mode: clamshell
+  policy: .belayer/policies/extend-fullstack.yaml
+```
+
+---
+
+## Part 3: Hermes Network Policy — What Agents Actually Need
+
+### Hermes network surface (empirically derived)
+
+From the hermes-agent source code, here are ALL the network endpoints a running agent might contact:
+
+#### Tier 1: Always needed (LLM inference)
+
+| Domain | Port | Purpose | Binary |
+|--------|------|---------|--------|
+| `api.anthropic.com` | 443 | Claude API | python3 |
+| `api.openai.com` | 443 | OpenAI/GPT API | python3 |
+| `auth.openai.com` | 443 | Codex OAuth token refresh | python3 |
+| `chatgpt.com` | 443 | Codex inference endpoint | python3 |
+| `ab.chatgpt.com` | 443 | Codex inference (alt) | python3 |
+| `inference-api.nousresearch.com` | 443 | Nous/Hermes inference | python3 |
+| `portal.nousresearch.com` | 443 | Nous OAuth + agent keys | python3 |
+
+#### Tier 2: Common providers (model routing)
+
+| Domain | Port | Purpose | Binary |
+|--------|------|---------|--------|
+| `openrouter.ai` | 443 | OpenRouter multi-model | python3 |
+| `api.deepseek.com` | 443 | DeepSeek | python3 |
+| `api.moonshot.cn` | 443 | Moonshot/Kimi | python3 |
+| `api.kimi.com` | 443 | Kimi coding API | python3 |
+| `generativelanguage.googleapis.com` | 443 | Google Gemini | python3 |
+
+#### Tier 3: Agent tools (used by hermes built-in tools)
+
+| Domain | Port | Purpose | Binary |
+|--------|------|---------|--------|
+| `api.github.com` | 443 | GitHub API (skills, repos) | python3, git, gh |
+| `github.com` | 443 | Git clone/fetch | git |
+| `api.tavily.com` | 443 | Web search tool | python3 |
+| `api.firecrawl.dev` | 443 | Web crawl tool | python3 |
+| `api.osv.dev` | 443 | Vulnerability scanning | python3 |
+
+#### Tier 4: Package managers (workspace setup)
+
+| Domain | Port | Purpose | Binary |
+|--------|------|---------|--------|
+| `registry.npmjs.org` | 443 | npm packages | npm, npx |
+| `pypi.org` | 443 | Python packages | pip, pip3 |
+| `files.pythonhosted.org` | 443 | Python package files | pip, pip3 |
+
+#### Tier 5: Skills hub (hermes-specific)
+
+| Domain | Port | Purpose | Binary |
+|--------|------|---------|--------|
+| `hermes-agent.nousresearch.com` | 443 | Skills index | python3 |
+| `skills.sh` | 443 | Skills.sh marketplace | python3 |
+| `clawhub.ai` | 443 | ClawHub marketplace | python3 |
+
+#### Tier 6: Chat platforms (NOT needed for belayer)
+
+Discord, Slack, Telegram, etc. — these are gateway features, not relevant for coding agents.
+
+### Default policy set for Belayer
+
+We ship three policies:
+
+#### 1. `belayer-minimal.yaml` — Anthropic-only, no tools
+
+For: testing, simple single-provider runs.
+
+```yaml
+version: 5
+
+sandbox:
+  user: sandbox
+  group: sandbox
+  work_dir: /workspace
+  runtime_dir: /run/agent
+  artifact_outbox: /run/agent/outbox
+  read_only_paths: [/usr, /lib, /lib64, /bin, /sbin, /etc, /var/log, /app]
+  read_write_paths: [/tmp, /workspace, /run/agent, /run/agent/outbox]
+  masked_paths: [/proc/kcore, /proc/latency_stats, /proc/timer_list, /sys/firmware]
+  tmpfs_paths: [/tmp]
+
+process:
+  seccomp_profile: ./etc/seccomp-default.json
+  no_new_privileges: true
+  drop_capabilities: ['ALL']
+  memory_limit: 2048m
+  pids_limit: 256
+  cpu_quota: 200000
+  read_only_rootfs: true
+
+network:
+  mode: proxy
+  proxy_listen: 3128
+  allow_http: false
+  providers:
+    anthropic_api: true
+    github: true
+  localhost: []
+```
+
+#### 2. `belayer-standard.yaml` — Multi-provider + packages
+
+For: typical development runs with multiple LLM providers and package managers.
+
+```yaml
+version: 5
+
+sandbox:
+  user: sandbox
+  group: sandbox
+  work_dir: /workspace
+  runtime_dir: /run/agent
+  artifact_outbox: /run/agent/outbox
+  read_only_paths: [/usr, /lib, /lib64, /bin, /sbin, /etc, /var/log, /app]
+  read_write_paths: [/tmp, /workspace, /run/agent, /run/agent/outbox]
+  masked_paths: [/proc/kcore, /proc/latency_stats, /proc/timer_list, /sys/firmware]
+  tmpfs_paths: [/tmp]
+
+process:
+  seccomp_profile: ./etc/seccomp-default.json
+  no_new_privileges: true
+  drop_capabilities: ['ALL']
+  memory_limit: 2048m
+  pids_limit: 512
+  cpu_quota: 200000
+  read_only_rootfs: true
+
+network:
+  mode: proxy
+  proxy_listen: 3128
+  allow_http: false
+  providers:
+    # LLM APIs
+    anthropic_api: true
+    openai_api: true
+    # Version control
+    github: true
+    # Package managers
+    npm: true
+    pypi: true
+  custom_endpoints:
+    # Hermes-specific: Nous portal (OAuth + inference)
+    - host: portal.nousresearch.com
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Hermes Nous OAuth and agent key minting"
+    - host: inference-api.nousresearch.com
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Hermes Nous inference API"
+    # Hermes-specific: Kimi/Moonshot (if using kimi models)
+    - host: api.kimi.com
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Kimi coding inference (Hermes provider)"
+    - host: api.moonshot.cn
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Moonshot inference (Hermes provider)"
+    # OpenRouter (multi-model gateway, common for hermes users)
+    - host: openrouter.ai
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "OpenRouter multi-model inference"
+    # Web search (hermes built-in tool)
+    - host: api.tavily.com
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Tavily search API (hermes web_search tool)"
+    # Skills hub
+    - host: hermes-agent.nousresearch.com
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Hermes skills index"
+  localhost: []
+```
+
+#### 3. `belayer-workbench.yaml` — Standard + sidecar services
+
+For: runs with database, localstack, etc. Extends standard with tcp_endpoints.
+
+```yaml
+version: 5
+
+sandbox:
+  user: sandbox
+  group: sandbox
+  work_dir: /workspace
+  runtime_dir: /run/agent
+  artifact_outbox: /run/agent/outbox
+  read_only_paths: [/usr, /lib, /lib64, /bin, /sbin, /etc, /var/log, /app]
+  read_write_paths: [/tmp, /workspace, /run/agent, /run/agent/outbox]
+  masked_paths: [/proc/kcore, /proc/latency_stats, /proc/timer_list, /sys/firmware]
+  tmpfs_paths: [/tmp]
+
+process:
+  seccomp_profile: ./etc/seccomp-default.json
+  no_new_privileges: true
+  drop_capabilities: ['ALL']
+  memory_limit: 2048m
+  pids_limit: 512
+  cpu_quota: 200000
+  read_only_rootfs: true
+
+network:
+  mode: proxy
+  proxy_listen: 3128
+  allow_http: false
+  providers:
+    anthropic_api: true
+    openai_api: true
+    github: true
+    npm: true
+    pypi: true
+  custom_endpoints:
+    # Same hermes endpoints as standard...
+    - host: portal.nousresearch.com
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Hermes Nous OAuth and agent key minting"
+    - host: inference-api.nousresearch.com
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Hermes Nous inference API"
+    - host: api.kimi.com
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Kimi coding inference"
+    - host: api.moonshot.cn
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Moonshot inference"
+    - host: openrouter.ai
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "OpenRouter multi-model inference"
+    - host: api.tavily.com
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Tavily search API"
+    - host: hermes-agent.nousresearch.com
+      ports: [443]
+      protocol: rest
+      enforcement: enforce
+      tls: auto
+      note: "Hermes skills index"
+  localhost:
+    - host: "127.0.0.1"
+      ports: [8080]
+      note: "Local dev server"
+  tcp_endpoints:
+    - host: belayer-postgres
+      ports: [5432]
+      allowed_ips: ["172.16.0.0/12", "192.168.0.0/16"]
+      materialization: deferred
+      note: "Session-local Postgres"
+    - host: belayer-redis
+      ports: [6379]
+      allowed_ips: ["172.16.0.0/12", "192.168.0.0/16"]
+      materialization: deferred
+      note: "Session-local Redis"
+    - host: belayer-localstack
+      ports: [4566]
+      allowed_ips: ["172.16.0.0/12", "192.168.0.0/16"]
+      materialization: deferred
+      note: "LocalStack AWS mock"
+```
+
+### Policy discovery and validation workflow
+
+The proof-of-concept should:
+
+1. Start a belayer session in the VM with `sandbox: clamshell` and `belayer-standard.yaml`
+2. Spawn a supervisor agent that uses Anthropic Claude
+3. Have the supervisor spawn a specialist that uses a different provider (Kimi, OpenRouter, etc.)
+4. Watch for deny events in `~/.extend-clamshell/runtime/*/host/events/deny-events.json`
+5. Iterate on the policy until all legitimate requests succeed and nothing else leaks
+
+This is the "loop to see network requests block" workflow the user asked for.
+
+---
+
+## Part 4: chalk-bag as Permanent Template Home
+
+### The problem
+
+Belayer templates currently live in `belayer/templates/`. This works for the belayer repo itself, but:
+
+1. **Templates are reusable across projects.** The supervisor soul, PM gate, reviewer prompt — these aren't belayer-specific. They're general agent archetypes.
+2. **Skills need a home.** Hermes skills (from chalk-bag's harness/pr plugins) need to be discoverable by agents at runtime.
+3. **Ephemeral sessions need bootstrapping.** When a hermes agent spawns inside a clamshell sandbox, it starts with a bare environment. It needs skills, templates, and capabilities injected.
+4. **chalk-bag already has the infrastructure.** Plugin manifests, command files, agent definitions, reference docs — all in markdown with YAML frontmatter. Already has a `docs/hermes.md` integration guide.
+
+### The solution
+
+chalk-bag becomes the **canonical template repository** referenced by belayer. Belayer content lives at the top level — not inside `plugins/` — because it's infrastructure consumed by the daemon, not a Claude Code marketplace plugin.
+
+```
+chalk-bag/
+  plugins/
+    harness/          # existing: Claude Code marketplace plugin
+    pr/               # existing: Claude Code marketplace plugin
+  belayer/            # NEW: top-level domain, NOT a plugin
+    templates/
+      supervisor/
+        soul.md           # was: system-prompt.md
+        capabilities.yaml # was: agent.yaml (expanded)
+        agents.md         # operating instructions
+      pm/
+        soul.md
+        capabilities.yaml
+        agents.md
+      backend/
+        ...
+      frontend/
+        ...
+      reviewer/
+        ...
+      qa/
+        ...
+      sprite/
+        ...
+    policies/
+      belayer-minimal.yaml
+      belayer-standard.yaml
+      belayer-workbench.yaml
+    references/
+      hermes-network-surface.md
+```
+
+**Why top-level, not a plugin:** The `plugins/` directory is for Claude Code marketplace distribution — harness and pr belong there because users invoke them as `/harness:brainstorm` or `/pr:review`. Belayer templates are infrastructure that the daemon reads at spawn time. They don't have commands, agents in the plugin sense, or skill triggers. Forcing them into the plugin format would add a `plugin.json` and `.claude-plugin/` scaffolding that nothing consumes.
+
+### Migration: templates/ → chalk-bag
+
+| Current (belayer) | New (chalk-bag) | Notes |
+|---|---|---|
+| `templates/supervisor/system-prompt.md` | `belayer/templates/supervisor/soul.md` | Rename to match identity design doc |
+| `templates/supervisor/agent.yaml` | `belayer/templates/supervisor/capabilities.yaml` | Expand with hermes profile, MCP, etc. |
+| `templates/supervisor/agents.md` | `belayer/templates/supervisor/agents.md` | Move as-is |
+| `.belayer/policies/*.yaml` | `belayer/policies/*.yaml` | Centralize policies |
+
+Belayer repo keeps a **fallback copy** of minimal templates for zero-config local dev (the existing `builtinTemplates` pattern). But the canonical source is chalk-bag.
+
+### capabilities.yaml evolution
+
+The current `agent.yaml` is minimal:
+
+```yaml
+# Current (belayer/templates/supervisor/agent.yaml)
+belayer_tools:
+  - belayer_spawn_agent
+  - belayer_request_completion
+```
+
+The new `capabilities.yaml` in chalk-bag covers the full identity spec:
+
+```yaml
+# New (chalk-bag/belayer/templates/supervisor/capabilities.yaml)
+
+# Identity metadata
+vendor: anthropic
+model: claude-sonnet-4-20250514
+tier: orchestrator
+ephemeral: false
+
+# Belayer tools (role-gated)
+belayer_tools:
+  - belayer_spawn_agent
+  - belayer_request_completion
+
+# Hermes profile configuration (materialized at spawn time)
+hermes:
+  plugins:
+    - harness   # resolved from chalk-bag/plugins/harness
+  skills:
+    - brainstorm
+    - plan
+    - orchestrate
+
+# MCP servers needed
+mcp_servers: []
+
+# Runtime dependencies
+runtime: []
+
+# Network policy tier (references policy file)
+network_tier: standard  # maps to belayer-standard.yaml
+```
+
+### Bootstrapping into ephemeral hermes sessions
+
+When belayer spawns an agent (with or without clamshell), it needs to materialize a hermes profile. The flow:
+
+```
+1. Belayer reads capabilities.yaml from chalk-bag
+2. Belayer creates a temporary Hermes profile directory:
+   ~/.hermes/profiles/belayer-{sessionID}-{agentName}/
+3. Belayer writes:
+   - config.yaml (model, provider, api_key/base_url)
+   - plugins/ symlinks to chalk-bag/plugins/ (harness, pr)
+   - skills/ loaded from capabilities.yaml declarations
+4. Belayer sets HERMES_HOME to the materialized profile dir
+5. Bridge subprocess uses the materialized profile
+6. On agent exit, profile directory is cleaned up (ephemeral)
+```
+
+This solves the **profile bootstrap TODO** from AGENT_ARCHITECTURE.md.
+
+### chalk-bag reference in belayer config
+
+```yaml
+# .belayer/config.yaml
+templates:
+  source: git                          # "builtin" | "local" | "git"
+  repo: git@github.com:donovan-yohan/chalk-bag.git
+  ref: main
+  path: belayer/templates                # within the repo
+  local_path: ~/Documents/Programs/personal/chalk-bag/belayer/templates  # for dev
+
+# For local dev, shortcut:
+templates:
+  source: local
+  local_path: ~/Documents/Programs/personal/chalk-bag/belayer/templates
+```
+
+At run start, belayer resolves templates from the configured source. The `builtin` source falls back to the compiled-in defaults (current behavior).
+
+---
+
+## Part 5: Proof-of-Concept Plan
+
+### Phase 1: VM Setup (day 1)
+
+1. Start the devbox VM: `limactl start devbox`
+2. Run the bootstrap script (Go, Hermes, Belayer binary)
+3. Configure hermes auth inside the VM (`hermes auth` for at least one provider)
+4. Run `belayer daemon` + `belayer run start` inside the VM with `sandbox: none`
+5. **Success criteria**: supervisor spawns, sends a message, agents communicate through the session bus inside the VM
+
+### Phase 2: Network Policy Discovery (day 1-2)
+
+6. Install clamshell inside the VM (clone extend-clamshell, `pip install -e .`)
+7. Start clamshell gateway: `clamshell gateway start`
+8. Create a provider: `clamshell provider create --name anthropic-main --type anthropic ...`
+9. Create a sandbox with `belayer-minimal.yaml` policy
+10. Run a simple hermes agent inside the sandbox (not through belayer yet — direct)
+11. **Watch deny events**: `tail -f ~/.extend-clamshell/runtime/*/host/events/deny-events.json`
+12. Iterate: find blocked requests, add to policy, recreate sandbox, retest
+13. **Success criteria**: agent completes a simple task (e.g., "write hello world to a file") with no unexpected deny events
+
+### Phase 3: Belayer + Clamshell Integration (day 2-3)
+
+14. Add `SandboxMode` field to bridge Config
+15. Implement `spawnViaClamshell()` in bridge.go
+16. Wire up `.belayer/config.yaml` sandbox configuration
+17. Run `belayer run start` with `sandbox: clamshell`
+18. Verify: supervisor spawns inside sandbox, can reach Anthropic API, can communicate with daemon
+19. Verify: specialists spawn in separate sandboxes (or same sandbox, TBD)
+20. **Success criteria**: full belayer run completes inside clamshell with policy-managed egress
+
+### Phase 4: chalk-bag Template Bootstrap (day 3-4)
+
+21. Create `belayer/` directory in chalk-bag (top-level, not under plugins/)
+22. Migrate templates from belayer repo to chalk-bag
+23. Write capabilities.yaml files (expanded from agent.yaml)
+24. Implement profile materialization in belayer (write temp hermes profile from capabilities)
+25. Configure belayer to read templates from local chalk-bag path
+26. Run a session using chalk-bag templates
+27. **Success criteria**: agent spawns with soul loaded from chalk-bag, hermes profile materialized from capabilities.yaml
+
+### Phase 5: End-to-End Validation (day 4-5)
+
+28. Full integration: VM + clamshell + chalk-bag templates + multi-agent session
+29. Run a real task: e.g., "create a simple REST API with tests"
+30. Supervisor (Anthropic) spawns backend specialist (Kimi or other)
+31. Watch network: only declared endpoints reachable, credentials mediated
+32. PM gate fires, verifies work
+33. **Success criteria**: complete session with sandboxed agents, managed egress, and chalk-bag-sourced templates
+
+---
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────── macOS Host ──────────────────────────────┐
+│                                                                         │
+│  ~/Documents/Programs/personal/                                         │
+│    ├── belayer/          (source, mounted in VM via virtiofs)            │
+│    └── chalk-bag/        (templates + skills, mounted in VM)            │
+│                                                                         │
+│  limactl start devbox                                                   │
+│  ┌───────────────────── Lima VM (devbox) ────────────────────────────┐  │
+│  │                                                                    │  │
+│  │  belayer daemon (Go, Unix socket)                                  │  │
+│  │    │                                                               │  │
+│  │    ├─── sandbox: none ──────────────────────────┐                  │  │
+│  │    │    python3 -m hermes_bridge                 │                  │  │
+│  │    │    (direct exec, full network access)       │                  │  │
+│  │    │                                             │                  │  │
+│  │    └─── sandbox: clamshell ─────────────────┐    │                  │  │
+│  │         clamshell gateway (localhost:8787)   │    │                  │  │
+│  │         │                                    │    │                  │  │
+│  │         ├── sandbox: supervisor              │    │                  │  │
+│  │         │   ├── proxy (deny-by-default)      │    │                  │  │
+│  │         │   ├── python3 -m hermes_bridge     │    │                  │  │
+│  │         │   └── policy: belayer-standard     │    │                  │  │
+│  │         │                                    │    │                  │  │
+│  │         ├── sandbox: backend-specialist      │    │                  │  │
+│  │         │   ├── proxy (deny-by-default)      │    │                  │  │
+│  │         │   ├── python3 -m hermes_bridge     │    │                  │  │
+│  │         │   └── policy: belayer-standard     │    │                  │  │
+│  │         │                                    │    │                  │  │
+│  │         └── sandbox: pm                      │    │                  │  │
+│  │             ├── proxy (deny-by-default)      │    │                  │  │
+│  │             ├── python3 -m hermes_bridge     │    │                  │  │
+│  │             └── policy: belayer-minimal      │    │                  │  │
+│  │                                                                    │  │
+│  │  chalk-bag/ (mounted from host)                                    │  │
+│  │    ├── belayer/templates/   (top-level, not a plugin)              │  │
+│  │    │    ├── supervisor/soul.md + capabilities.yaml                 │  │
+│  │    │    ├── pm/soul.md + capabilities.yaml                         │  │
+│  │    │    └── backend/soul.md + capabilities.yaml                    │  │
+│  │    └── plugins/             (harness, pr — marketplace plugins)    │  │
+│  │                                                                    │  │
+│  └────────────────────────────────────────────────────────────────────┘  │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Open Questions
+
+### 1. One sandbox per agent or one sandbox per session?
+
+**Per-agent** (superlemmings model): each agent gets its own sandbox with its own policy. More isolation, more overhead, cleaner credential separation.
+
+**Per-session** (simpler): all agents in one sandbox, share workspace. Less overhead, but agents can interfere with each other's files.
+
+**Recommendation**: Start with per-session for the PoC (simpler). Evolve to per-agent when credential separation matters (e.g., different providers per agent need different opaque handles).
+
+### 2. How does the daemon communicate with sandboxed agents?
+
+The daemon runs outside the sandbox. The bridge inside the sandbox needs to reach the daemon's Unix socket.
+
+**Options**:
+- `clamshell forward` — forward Unix socket into sandbox
+- Mount the socket read-write into the sandbox (Docker volume mount)
+- TCP socket on localhost with port forward
+
+**Recommendation**: Use clamshell's bootstrap mechanism to mount the daemon socket into the sandbox at a known path. Add a localhost rule for the daemon socket if needed.
+
+### 3. How do credentials flow to sandboxed agents?
+
+Today: agents inherit the host's `~/.hermes/auth.json` and environment API keys.
+
+With clamshell: credentials should flow through the proxy's `inference.local` routing or through clamshell provider attachment (opaque handles).
+
+**For the PoC**: use environment variable injection at sandbox creation time (`ANTHROPIC_API_KEY` passed through clamshell). This is less secure but proves the path. Migrate to opaque handles later.
+
+### 4. How does chalk-bag get into the sandbox?
+
+**Options**:
+- Git clone during sandbox bootstrap (`--bootstrap-repo`)
+- Mount from host (Docker volume, read-only)
+- Pre-bake into sandbox image
+
+**Recommendation**: Mount from host read-only for dev. Clone via `--bootstrap-repo` for production workers.
+
+---
+
+## What This Spec Does NOT Cover
+
+- Crag (outer daemon) integration — that's a separate design doc
+- Multi-worker orchestration — v1 is one request per worker
+- Production credential management (vault, rotating tokens) — deferred
+- Custom MCP server provisioning inside sandboxes — deferred
+- Hermes gateway mode inside sandbox — not needed for v1

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -7,3 +7,5 @@
 - [Git-backed agent identity](2026-04-15-git-backed-agent-identity.md) — Forward-looking: soul + capabilities materialization
 - [Product manager agent](2026-04-16-product-manager-agent.md) — PM completion gate: adversarial spec-vs-reality verification
 - [Tool catalog and identity](2026-04-16-tool-catalog-and-identity.md) — Co-locate belayer tools with agent templates, role-based tool gating
+- ~~[VM sandbox and template bootstrap](2026-04-16-vm-sandbox-and-template-bootstrap.md)~~ — Superseded by sandbox-runtime-and-crag-proof
+- [Sandbox, runtime, and crag proof](2026-04-16-sandbox-runtime-and-crag-proof.md) — SandboxDriver + RuntimeProvider interfaces, lightweight crag, arielcharts E2E proof

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -53,29 +53,28 @@ type Config struct {
 // Process wraps a running bridge subprocess.
 type Process struct {
 	cmd     *exec.Cmd
+	proc    *os.Process // set by NewProcess; used for kill when cmd is nil
 	stdin   io.WriteCloser
 	done    chan struct{} // closed when process exits
 	exitErr error        // set before done is closed
 	mu      sync.Mutex
 }
 
-// Spawn starts a hermes-bridge subprocess with the given config.
-// Stdout and stderr from the subprocess are tee'd to log files in RunDir.
-// Returns a Process handle for monitoring and communication.
-func Spawn(cfg Config) (*Process, error) {
-	if err := os.MkdirAll(cfg.RunDir, 0o700); err != nil {
-		return nil, fmt.Errorf("bridge: create run dir: %w", err)
+// BuildCmd returns the argv slice to use when launching the bridge subprocess.
+// If cfg.Cmd is non-empty it is returned as-is; otherwise the default python
+// command (Hermes venv python3 -m hermes_bridge) is returned.
+func BuildCmd(cfg Config) []string {
+	if len(cfg.Cmd) > 0 {
+		return cfg.Cmd
 	}
+	return defaultPythonCmd()
+}
 
-	argv := cfg.Cmd
-	if len(argv) == 0 {
-		argv = defaultPythonCmd()
-	}
-
-	//nolint:gosec // argv is controlled by internal callers, not user input
-	cmd := exec.Command(argv[0], argv[1:]...)
-	cmd.Dir = cfg.Workdir
-
+// BuildEnv builds the complete environment variable slice for the bridge
+// subprocess. It inherits the parent process environment, then layers
+// PYTHONPATH (hermes-agent path + BelayerRoot + existing PYTHONPATH) and all
+// BELAYER_* variables derived from cfg.
+func BuildEnv(cfg Config) []string {
 	// Build environment: inherit parent env, then layer bridge-specific vars.
 	env := os.Environ()
 
@@ -118,7 +117,47 @@ func Spawn(cfg Config) (*Process, error) {
 	if len(cfg.BelayerTools) > 0 {
 		env = appendEnv(env, "BELAYER_TOOLS", strings.Join(cfg.BelayerTools, ","))
 	}
-	cmd.Env = env
+	return env
+}
+
+// NewProcess creates a Process that wraps an already-started os.Process.
+// This is used when process execution is handled by an external sandbox driver
+// rather than by Spawn().
+func NewProcess(proc *os.Process, stdin io.WriteCloser) *Process {
+	p := &Process{
+		proc:  proc,
+		stdin: stdin,
+		done:  make(chan struct{}),
+	}
+	go func() {
+		state, err := proc.Wait()
+		p.mu.Lock()
+		if err != nil {
+			p.exitErr = err
+		} else if state != nil && !state.Success() {
+			p.exitErr = &exec.ExitError{ProcessState: state}
+		}
+		p.mu.Unlock()
+		close(p.done)
+	}()
+	return p
+}
+
+// Spawn starts a hermes-bridge subprocess with the given config.
+// Stdout and stderr from the subprocess are tee'd to log files in RunDir.
+// Returns a Process handle for monitoring and communication.
+func Spawn(cfg Config) (*Process, error) {
+	if err := os.MkdirAll(cfg.RunDir, 0o700); err != nil {
+		return nil, fmt.Errorf("bridge: create run dir: %w", err)
+	}
+
+	argv := BuildCmd(cfg)
+
+	//nolint:gosec // argv is controlled by internal callers, not user input
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Dir = cfg.Workdir
+
+	cmd.Env = BuildEnv(cfg)
 
 	// Pipe stdin so the daemon can send interrupt/stop commands.
 	stdinPipe, err := cmd.StdinPipe()
@@ -215,7 +254,13 @@ func (p *Process) Stop(timeout time.Duration) error {
 		return err
 	case <-ctx.Done():
 		// Graceful wait timed out — force kill.
-		if killErr := p.cmd.Process.Kill(); killErr != nil {
+		var proc *os.Process
+		if p.cmd != nil {
+			proc = p.cmd.Process
+		} else {
+			proc = p.proc
+		}
+		if killErr := proc.Kill(); killErr != nil {
 			return fmt.Errorf("bridge: kill after stop timeout: %w", killErr)
 		}
 		<-p.done

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -50,13 +50,22 @@ type Config struct {
 	Cmd []string
 }
 
+// ProcessHandle is the minimal contract bridge.NewProcess needs from a process
+// started by an external driver (e.g. sandbox.Process). Wait must block until
+// the process has fully exited — including any stdio pump goroutines — so the
+// daemon can safely close log writers once Wait returns.
+type ProcessHandle interface {
+	Wait() error
+	Kill() error
+}
+
 // Process wraps a running bridge subprocess.
 type Process struct {
 	cmd     *exec.Cmd
-	proc    *os.Process // set by NewProcess; used for kill when cmd is nil
+	handle  ProcessHandle // set by NewProcess; drives Wait/Kill when cmd is nil
 	stdin   io.WriteCloser
 	done    chan struct{} // closed when process exits
-	exitErr error        // set before done is closed
+	exitErr error         // set before done is closed
 	mu      sync.Mutex
 }
 
@@ -120,23 +129,20 @@ func BuildEnv(cfg Config) []string {
 	return env
 }
 
-// NewProcess creates a Process that wraps an already-started os.Process.
+// NewProcess creates a Process that wraps an already-started ProcessHandle.
 // This is used when process execution is handled by an external sandbox driver
-// rather than by Spawn().
-func NewProcess(proc *os.Process, stdin io.WriteCloser) *Process {
+// rather than by Spawn(). The handle's Wait is expected to synchronize with
+// stdio pumps so the caller can close log writers after Done fires.
+func NewProcess(handle ProcessHandle, stdin io.WriteCloser) *Process {
 	p := &Process{
-		proc:  proc,
-		stdin: stdin,
-		done:  make(chan struct{}),
+		handle: handle,
+		stdin:  stdin,
+		done:   make(chan struct{}),
 	}
 	go func() {
-		state, err := proc.Wait()
+		waitErr := handle.Wait()
 		p.mu.Lock()
-		if err != nil {
-			p.exitErr = err
-		} else if state != nil && !state.Success() {
-			p.exitErr = &exec.ExitError{ProcessState: state}
-		}
+		p.exitErr = waitErr
 		p.mu.Unlock()
 		close(p.done)
 	}()
@@ -253,14 +259,16 @@ func (p *Process) Stop(timeout time.Duration) error {
 		p.mu.Unlock()
 		return err
 	case <-ctx.Done():
-		// Graceful wait timed out — force kill.
-		var proc *os.Process
-		if p.cmd != nil {
-			proc = p.cmd.Process
-		} else {
-			proc = p.proc
+		// Graceful wait timed out — force kill via whichever backend owns
+		// the process.
+		var killErr error
+		switch {
+		case p.handle != nil:
+			killErr = p.handle.Kill()
+		case p.cmd != nil && p.cmd.Process != nil:
+			killErr = p.cmd.Process.Kill()
 		}
-		if killErr := proc.Kill(); killErr != nil {
+		if killErr != nil {
 			return fmt.Errorf("bridge: kill after stop timeout: %w", killErr)
 		}
 		<-p.done

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -382,6 +382,125 @@ func TestBelayerToolsEnvVarInjected(t *testing.T) {
 	}
 }
 
+// TestBuildCmdDefault verifies that BuildCmd with an empty Cmd field returns a
+// python3 command.
+func TestBuildCmdDefault(t *testing.T) {
+	cfg := Config{} // Cmd is nil/empty
+	argv := BuildCmd(cfg)
+	if len(argv) == 0 {
+		t.Fatal("BuildCmd returned empty slice")
+	}
+	// The first element must be a python3 binary (either full venv path or system).
+	if !strings.Contains(argv[0], "python3") {
+		t.Errorf("expected argv[0] to contain 'python3', got %q", argv[0])
+	}
+	if len(argv) < 3 || argv[1] != "-m" || argv[2] != "hermes_bridge" {
+		t.Errorf("expected argv to end with '-m hermes_bridge', got %v", argv)
+	}
+}
+
+// TestBuildCmdOverride verifies that BuildCmd returns cfg.Cmd when it is set.
+func TestBuildCmdOverride(t *testing.T) {
+	want := []string{"my-custom-python", "--flag", "value"}
+	cfg := Config{Cmd: want}
+	got := BuildCmd(cfg)
+	if len(got) != len(want) {
+		t.Fatalf("BuildCmd returned %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("argv[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestBuildEnvContainsBelayerVars verifies that BuildEnv sets all expected
+// BELAYER_* environment variables.
+func TestBuildEnvContainsBelayerVars(t *testing.T) {
+	cfg := Config{
+		SessionID:       "sess-build",
+		AgentID:         "agent-build",
+		Role:            "supervisor",
+		Profile:         "nightshift-supervisor",
+		SocketPath:      "/tmp/build.sock",
+		RunDir:          t.TempDir(),
+		Model:           "claude-opus-4",
+		Message:         "build message",
+		SystemPrompt:    "you are helpful",
+		HermesSessionID: "hermes-build-789",
+		BelayerTools:    []string{"tool_a", "tool_b"},
+	}
+
+	env := BuildEnv(cfg)
+	envMap := make(map[string]string, len(env))
+	for _, e := range env {
+		if idx := strings.IndexByte(e, '='); idx >= 0 {
+			envMap[e[:idx]] = e[idx+1:]
+		}
+	}
+
+	checks := map[string]string{
+		"BELAYER_SESSION_ID":        "sess-build",
+		"BELAYER_AGENT_ID":          "agent-build",
+		"BELAYER_ROLE":              "supervisor",
+		"BELAYER_PROFILE":           "nightshift-supervisor",
+		"BELAYER_SOCKET":            "/tmp/build.sock",
+		"BELAYER_RUN_DIR":           cfg.RunDir,
+		"BELAYER_MODEL":             "claude-opus-4",
+		"BELAYER_MESSAGE":           "build message",
+		"BELAYER_SYSTEM_PROMPT":     "you are helpful",
+		"BELAYER_HERMES_SESSION_ID": "hermes-build-789",
+		"BELAYER_TOOLS":             "tool_a,tool_b",
+	}
+	for key, want := range checks {
+		if got, ok := envMap[key]; !ok {
+			t.Errorf("expected %s to be set in env", key)
+		} else if got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+
+	// PYTHONPATH must be present.
+	if _, ok := envMap["PYTHONPATH"]; !ok {
+		t.Error("expected PYTHONPATH to be set in env")
+	}
+}
+
+// TestBuildEnvOmitsOptionalVars verifies that empty optional fields (Model,
+// Message, SystemPrompt, HermesSessionID, BelayerTools) are not added to the
+// environment.
+func TestBuildEnvOmitsOptionalVars(t *testing.T) {
+	cfg := Config{
+		SessionID:  "sess-omit",
+		AgentID:    "agent-omit",
+		Role:       "implementer",
+		Profile:    "nightshift",
+		SocketPath: "/tmp/omit.sock",
+		RunDir:     t.TempDir(),
+		// Model, Message, SystemPrompt, HermesSessionID, BelayerTools all zero-value
+	}
+
+	env := BuildEnv(cfg)
+	envMap := make(map[string]string, len(env))
+	for _, e := range env {
+		if idx := strings.IndexByte(e, '='); idx >= 0 {
+			envMap[e[:idx]] = e[idx+1:]
+		}
+	}
+
+	for _, key := range []string{
+		"BELAYER_MODEL",
+		"BELAYER_MESSAGE",
+		"BELAYER_SYSTEM_PROMPT",
+		"BELAYER_HERMES_SESSION_ID",
+		"BELAYER_TOOLS",
+	} {
+		if _, ok := envMap[key]; ok {
+			t.Errorf("expected %s to be absent from env, but it was set", key)
+		}
+	}
+}
+
 // TestBelayerToolsEnvVarOmittedWhenEmpty verifies that BELAYER_TOOLS is not
 // set when the tool list is empty (baseline-only agents).
 func TestBelayerToolsEnvVarOmittedWhenEmpty(t *testing.T) {

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -1,8 +1,10 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/donovan-yohan/belayer/internal/bridge"
 	"github.com/donovan-yohan/belayer/internal/broker"
+	"github.com/donovan-yohan/belayer/internal/sandbox"
 	"github.com/donovan-yohan/belayer/internal/store"
 )
 
@@ -367,10 +370,61 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 	}
 	_ = worktreePath // stored in DB; cleanup handled separately
 
-	proc, err := bridge.Spawn(cfg)
+	// Build command and environment using bridge pure functions.
+	argv := bridge.BuildCmd(cfg)
+	env := bridge.BuildEnv(cfg)
+
+	// Set up stdin pipe for daemon→agent communication.
+	stdinR, stdinW, err := os.Pipe()
 	if err != nil {
-		return nil, fmt.Errorf("bridge spawn: %w", err)
+		return nil, fmt.Errorf("create stdin pipe: %w", err)
 	}
+
+	// Set up stdout/stderr log files.
+	stdoutLog, err := os.OpenFile(filepath.Join(runDir, "bridge-stdout.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		stdinR.Close()
+		stdinW.Close()
+		return nil, fmt.Errorf("open stdout log: %w", err)
+	}
+	stderrLog, err := os.OpenFile(filepath.Join(runDir, "bridge-stderr.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		stdinR.Close()
+		stdinW.Close()
+		stdoutLog.Close()
+		return nil, fmt.Errorf("open stderr log: %w", err)
+	}
+
+	// Get or create sandbox handle for the session.
+	handle := sandbox.Handle{ID: req.SessionID}
+
+	osProc, err := d.sandbox.Exec(context.Background(), handle, argv, sandbox.ExecOpts{
+		Env:    env,
+		Dir:    workdir,
+		Stdin:  stdinR,
+		Stdout: io.MultiWriter(os.Stdout, stdoutLog),
+		Stderr: io.MultiWriter(os.Stderr, stderrLog),
+	})
+	if err != nil {
+		stdinR.Close()
+		stdinW.Close()
+		stdoutLog.Close()
+		stderrLog.Close()
+		return nil, fmt.Errorf("sandbox exec: %w", err)
+	}
+
+	// Close read end — it's been inherited by the child process.
+	stdinR.Close()
+
+	proc := bridge.NewProcess(osProc, stdinW)
+
+	// Close log files when process exits.
+	go func() {
+		<-proc.Done()
+		stdoutLog.Close()
+		stderrLog.Close()
+	}()
+
 	return proc, nil
 }
 

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -396,9 +395,24 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 	}
 
 	// Get or create sandbox handle for the session.
-	handle := sandbox.Handle{ID: req.SessionID}
+	sess, err := d.store.GetSession(req.SessionID)
+	if err != nil {
+		stdinR.Close()
+		stdinW.Close()
+		stdoutLog.Close()
+		stderrLog.Close()
+		return nil, fmt.Errorf("load session for sandbox handle: %w", err)
+	}
+	handle, err := d.ensureSandboxHandle(d.startCtx, sess)
+	if err != nil {
+		stdinR.Close()
+		stdinW.Close()
+		stdoutLog.Close()
+		stderrLog.Close()
+		return nil, fmt.Errorf("ensure sandbox handle: %w", err)
+	}
 
-	osProc, err := d.sandbox.Exec(context.Background(), handle, argv, sandbox.ExecOpts{
+	osProc, err := d.sandbox.Exec(d.startCtx, handle, argv, sandbox.ExecOpts{
 		Env:    env,
 		Dir:    workdir,
 		Stdin:  stdinR,
@@ -418,9 +432,12 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 
 	proc := bridge.NewProcess(osProc, stdinW)
 
-	// Close log files when process exits.
+	// Close log files and stdin writer when process exits. stdinW is our
+	// handle for sending interrupts; once the process is gone it's a pipe to
+	// nowhere, so closing it avoids leaking file descriptors.
 	go func() {
 		<-proc.Done()
+		stdinW.Close()
 		stdoutLog.Close()
 		stderrLog.Close()
 	}()

--- a/internal/daemon/bridge_events.go
+++ b/internal/daemon/bridge_events.go
@@ -197,6 +197,7 @@ func (d *Daemon) processAgentStatusEvent(sessionID, eventType, data string) {
 				log.Printf("ERROR: processAgentStatusEvent: failed to escalate session %s to needs_human_review: %v", sessionID, err)
 			} else {
 				log.Printf("Session %s escalated to human review: supervisor reported incomplete", sessionID)
+				d.terminateSandbox(d.startCtx, sessionID)
 			}
 		}
 
@@ -408,6 +409,7 @@ func (d *Daemon) handleBridgeCompletionApproved(sessionID, agentName string, dat
 			"report":      report[:min(len(report), 1000)],
 		}),
 	})
+	d.terminateSandbox(d.startCtx, sessionID)
 
 	log.Printf("Session %s marked complete (approved by %s)", sessionID, agentName)
 }
@@ -454,6 +456,7 @@ func (d *Daemon) handleBridgeCompletionRejected(sessionID, agentName string, dat
 				"rejections": fmt.Sprintf("%d", rejectionCount),
 			}),
 		})
+		d.terminateSandbox(d.startCtx, sessionID)
 		// Notify supervisor of escalation.
 		msg := broker.Message{
 			ID:          uuid.New().String(),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -28,6 +29,13 @@ type Config struct {
 	SocketPath  string
 	DBPath      string
 	BelayerRoot string // directory containing hermes_bridge/ (for PYTHONPATH)
+
+	// Sandbox overrides the driver used for agent execution.
+	// Nil falls back to &sandbox.Noop{}.
+	Sandbox sandbox.Driver
+	// Runtime overrides the dev-stack provider.
+	// Nil falls back to &runtime.Noop{}.
+	Runtime runtime.Provider
 }
 
 // DefaultConfig returns config using ~/.belayer/ paths.
@@ -50,6 +58,16 @@ type Daemon struct {
 
 	sandbox sandbox.Driver
 	runtime runtime.Provider
+
+	// Context from Start, used as the parent for sandbox/runtime lifecycle
+	// calls so they observe daemon shutdown. Initialized to context.Background
+	// in New so tests that skip Start still work.
+	startCtx context.Context
+
+	// Per-session sandbox handles. Populated lazily on first agent spawn,
+	// cleared on terminal session transitions and during Shutdown.
+	sandboxMu      sync.Mutex
+	sandboxHandles map[string]sandbox.Handle
 
 	spawnBridgeAgent func(req agentSpawnRequest) (*bridge.Process, error)
 
@@ -74,13 +92,23 @@ func New(cfg Config) (*Daemon, error) {
 	}
 
 	d := &Daemon{
-		store:       st,
-		config:      cfg,
-		tools:       make(map[string][]agent.ToolSpec),
-		bridgeProcs: make(map[string]*bridge.Process),
+		store:          st,
+		config:         cfg,
+		tools:          make(map[string][]agent.ToolSpec),
+		bridgeProcs:    make(map[string]*bridge.Process),
+		sandboxHandles: make(map[string]sandbox.Handle),
+		startCtx:       context.Background(),
 	}
-	d.sandbox = &sandbox.Noop{}
-	d.runtime = &runtime.Noop{}
+	if cfg.Sandbox != nil {
+		d.sandbox = cfg.Sandbox
+	} else {
+		d.sandbox = &sandbox.Noop{}
+	}
+	if cfg.Runtime != nil {
+		d.runtime = cfg.Runtime
+	} else {
+		d.runtime = &runtime.Noop{}
+	}
 	d.broker = broker.NewMemoryBroker(st)
 	d.spawnBridgeAgent = d.bridgeLaunchAgent
 	mux := http.NewServeMux()
@@ -123,6 +151,14 @@ func (d *Daemon) Start(ctx context.Context) error {
 	}
 	os.Chmod(d.config.SocketPath, 0o600)
 	d.listener = ln
+	d.startCtx = ctx
+
+	// Provision the runtime before serving. For the noop provider this is a
+	// no-op; the hook exists so future providers (command, clamshell, ...)
+	// can fail fast if the dev stack can't come up.
+	if _, err := d.runtime.Up(ctx); err != nil {
+		return fmt.Errorf("daemon: runtime up: %w", err)
+	}
 
 	// Shut down gracefully when ctx is cancelled.
 	go func() {
@@ -142,9 +178,85 @@ func (d *Daemon) Shutdown(ctx context.Context) error {
 	defer cancel()
 
 	err := d.server.Shutdown(shutCtx)
+
+	// Tear down any outstanding sandbox handles.
+	d.sandboxMu.Lock()
+	handles := d.sandboxHandles
+	d.sandboxHandles = make(map[string]sandbox.Handle)
+	d.sandboxMu.Unlock()
+	for sessID, h := range handles {
+		if stopErr := d.sandbox.Stop(shutCtx, h); stopErr != nil {
+			log.Printf("daemon: sandbox stop %s: %v", sessID, stopErr)
+		}
+	}
+
+	if downErr := d.runtime.Down(shutCtx); downErr != nil {
+		log.Printf("daemon: runtime down: %v", downErr)
+	}
+
 	d.store.Close()
 	os.Remove(d.config.SocketPath)
 	return err
+}
+
+// ensureSandboxHandle returns the session's sandbox handle, creating one on
+// first use. Safe to call from multiple goroutines; the handle is cached per
+// session in d.sandboxHandles.
+func (d *Daemon) ensureSandboxHandle(ctx context.Context, sess store.Session) (sandbox.Handle, error) {
+	d.sandboxMu.Lock()
+	if h, ok := d.sandboxHandles[sess.ID]; ok {
+		d.sandboxMu.Unlock()
+		return h, nil
+	}
+	d.sandboxMu.Unlock()
+
+	// Create outside the lock — Create may block (container pull, VM boot).
+	h, err := d.sandbox.Create(ctx, sandbox.Config{
+		Name:      sess.ID,
+		Workspace: sess.WorkspaceDir,
+	})
+	if err != nil {
+		return sandbox.Handle{}, err
+	}
+
+	d.sandboxMu.Lock()
+	defer d.sandboxMu.Unlock()
+	// Another goroutine may have raced us; keep whichever is stored first
+	// so callers never see two different handles for one session.
+	if existing, ok := d.sandboxHandles[sess.ID]; ok {
+		go func() {
+			_ = d.sandbox.Stop(ctx, h)
+		}()
+		return existing, nil
+	}
+	d.sandboxHandles[sess.ID] = h
+	return h, nil
+}
+
+// terminateSandbox stops and forgets the sandbox handle for sessionID, if any.
+// Safe to call for sessions that never had a handle.
+func (d *Daemon) terminateSandbox(ctx context.Context, sessionID string) {
+	d.sandboxMu.Lock()
+	h, ok := d.sandboxHandles[sessionID]
+	if !ok {
+		d.sandboxMu.Unlock()
+		return
+	}
+	delete(d.sandboxHandles, sessionID)
+	d.sandboxMu.Unlock()
+	if err := d.sandbox.Stop(ctx, h); err != nil {
+		log.Printf("daemon: sandbox stop %s: %v", sessionID, err)
+	}
+}
+
+// isTerminalSessionStatus reports whether a session status means the session
+// is finished and its sandbox can be torn down.
+func isTerminalSessionStatus(status string) bool {
+	switch status {
+	case "complete", "blocked", "failed", "cancelled", "needs_human_review":
+		return true
+	}
+	return false
 }
 
 // --- HTTP handlers ---
@@ -295,6 +407,9 @@ func (d *Daemon) handleUpdateSession(w http.ResponseWriter, r *http.Request) {
 			Type:      "session_status_changed",
 			Data:      mustJSON(map[string]string{"status": req.Status}),
 		})
+		if isTerminalSessionStatus(req.Status) {
+			d.terminateSandbox(r.Context(), id)
+		}
 	}
 
 	if req.WorkspaceDir != "" {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -18,6 +18,8 @@ import (
 	"github.com/donovan-yohan/belayer/internal/agent"
 	"github.com/donovan-yohan/belayer/internal/bridge"
 	"github.com/donovan-yohan/belayer/internal/broker"
+	"github.com/donovan-yohan/belayer/internal/runtime"
+	"github.com/donovan-yohan/belayer/internal/sandbox"
 	"github.com/donovan-yohan/belayer/internal/store"
 )
 
@@ -45,6 +47,9 @@ type Daemon struct {
 	server   *http.Server
 	config   Config
 	broker   broker.Broker
+
+	sandbox sandbox.Driver
+	runtime runtime.Provider
 
 	spawnBridgeAgent func(req agentSpawnRequest) (*bridge.Process, error)
 
@@ -74,6 +79,8 @@ func New(cfg Config) (*Daemon, error) {
 		tools:       make(map[string][]agent.ToolSpec),
 		bridgeProcs: make(map[string]*bridge.Process),
 	}
+	d.sandbox = &sandbox.Noop{}
+	d.runtime = &runtime.Noop{}
 	d.broker = broker.NewMemoryBroker(st)
 	d.spawnBridgeAgent = d.bridgeLaunchAgent
 	mux := http.NewServeMux()

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/donovan-yohan/belayer/internal/agent"
 	"github.com/donovan-yohan/belayer/internal/bridge"
 	"github.com/donovan-yohan/belayer/internal/broker"
+	"github.com/donovan-yohan/belayer/internal/runtime"
+	"github.com/donovan-yohan/belayer/internal/sandbox"
 	"github.com/donovan-yohan/belayer/internal/store"
 )
 
@@ -28,10 +30,14 @@ func testDaemon(t *testing.T) *Daemon {
 	t.Cleanup(func() { st.Close() })
 
 	d := &Daemon{
-		store:       st,
-		config:      Config{},
-		tools:       make(map[string][]agent.ToolSpec),
-		bridgeProcs: make(map[string]*bridge.Process),
+		store:          st,
+		config:         Config{},
+		tools:          make(map[string][]agent.ToolSpec),
+		bridgeProcs:    make(map[string]*bridge.Process),
+		sandboxHandles: make(map[string]sandbox.Handle),
+		sandbox:        &sandbox.Noop{},
+		runtime:        &runtime.Noop{},
+		startCtx:       context.Background(),
 	}
 	d.broker = broker.NewMemoryBroker(st)
 	d.spawnBridgeAgent = func(req agentSpawnRequest) (*bridge.Process, error) { return nil, nil }

--- a/internal/runtime/noop.go
+++ b/internal/runtime/noop.go
@@ -1,0 +1,22 @@
+package runtime
+
+import "context"
+
+// Noop is a Provider for projects with no dev stack (pure library, CLI tool, etc.).
+// All methods are no-ops.
+type Noop struct{}
+
+// Up returns nil endpoints and nil error.
+func (n *Noop) Up(_ context.Context) ([]Endpoint, error) {
+	return nil, nil
+}
+
+// Health returns nil.
+func (n *Noop) Health(_ context.Context) error {
+	return nil
+}
+
+// Down returns nil.
+func (n *Noop) Down(_ context.Context) error {
+	return nil
+}

--- a/internal/runtime/noop_test.go
+++ b/internal/runtime/noop_test.go
@@ -1,0 +1,34 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+)
+
+// Compile-time check: Noop must satisfy Provider.
+var _ Provider = (*Noop)(nil)
+
+func TestNoopUp(t *testing.T) {
+	n := &Noop{}
+	endpoints, err := n.Up(context.Background())
+	if err != nil {
+		t.Fatalf("Up() returned unexpected error: %v", err)
+	}
+	if len(endpoints) != 0 {
+		t.Fatalf("Up() returned %d endpoints, want 0", len(endpoints))
+	}
+}
+
+func TestNoopHealth(t *testing.T) {
+	n := &Noop{}
+	if err := n.Health(context.Background()); err != nil {
+		t.Fatalf("Health() returned unexpected error: %v", err)
+	}
+}
+
+func TestNoopDown(t *testing.T) {
+	n := &Noop{}
+	if err := n.Down(context.Background()); err != nil {
+		t.Fatalf("Down() returned unexpected error: %v", err)
+	}
+}

--- a/internal/runtime/provider.go
+++ b/internal/runtime/provider.go
@@ -1,0 +1,24 @@
+package runtime
+
+import "context"
+
+// Provider provisions the dev stack that agents work against.
+// Called before sandbox creation — runtime endpoints become allowed
+// TCP destinations in the sandbox policy.
+type Provider interface {
+	// Up starts the dev stack and returns discovered endpoints.
+	Up(ctx context.Context) ([]Endpoint, error)
+
+	// Health checks whether the dev stack is ready.
+	Health(ctx context.Context) error
+
+	// Down stops the dev stack.
+	Down(ctx context.Context) error
+}
+
+// Endpoint describes a runtime service available to agents.
+type Endpoint struct {
+	Name string
+	Host string
+	Port int
+}

--- a/internal/sandbox/driver.go
+++ b/internal/sandbox/driver.go
@@ -1,0 +1,62 @@
+// Package sandbox defines the Driver interface for agent execution boundaries.
+// Belayer holds one driver per session. The noop driver (direct exec) is the
+// default. Isolation drivers (e.g. clamshell/Docker) implement the same interface.
+package sandbox
+
+import (
+	"context"
+	"io"
+	"os"
+)
+
+// Driver manages the agent execution boundary. Belayer holds one driver per session.
+type Driver interface {
+	// Create prepares an execution environment for the session.
+	// Called once per session, before any agents spawn.
+	Create(ctx context.Context, cfg Config) (Handle, error)
+
+	// Exec runs a command inside the sandbox. Used for each agent spawn.
+	// The caller manages stdin/stdout/stderr wiring.
+	Exec(ctx context.Context, h Handle, cmd []string, opts ExecOpts) (*os.Process, error)
+
+	// Stop tears down the sandbox. Called when the session ends.
+	Stop(ctx context.Context, h Handle) error
+}
+
+// Config holds the parameters used to create a sandbox environment.
+type Config struct {
+	Name      string        // sandbox identifier (typically session ID)
+	Workspace string        // host path to mount at /workspace
+	Policy    string        // path to policy YAML (driver-specific)
+	Mounts    []Mount       // additional mounts
+	Endpoints []TCPEndpoint // runtime services to allow through the sandbox
+}
+
+// ExecOpts configures how a command is executed inside the sandbox.
+type ExecOpts struct {
+	Env    []string  // environment variables
+	Dir    string    // working directory inside sandbox
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Mount describes a host path to expose inside the sandbox.
+type Mount struct {
+	HostPath    string
+	SandboxPath string
+	ReadOnly    bool
+}
+
+// TCPEndpoint describes a runtime service reachable through the sandbox boundary.
+type TCPEndpoint struct {
+	Name string
+	Host string
+	Port int
+}
+
+// Handle is an opaque reference to a running sandbox environment.
+type Handle struct {
+	ID   string            // opaque identifier
+	Meta map[string]string // driver-specific metadata
+}

--- a/internal/sandbox/driver.go
+++ b/internal/sandbox/driver.go
@@ -6,7 +6,6 @@ package sandbox
 import (
 	"context"
 	"io"
-	"os"
 )
 
 // Driver manages the agent execution boundary. Belayer holds one driver per session.
@@ -16,11 +15,26 @@ type Driver interface {
 	Create(ctx context.Context, cfg Config) (Handle, error)
 
 	// Exec runs a command inside the sandbox. Used for each agent spawn.
-	// The caller manages stdin/stdout/stderr wiring.
-	Exec(ctx context.Context, h Handle, cmd []string, opts ExecOpts) (*os.Process, error)
+	// The caller manages stdin/stdout/stderr wiring via ExecOpts and waits on
+	// the returned Process.
+	Exec(ctx context.Context, h Handle, cmd []string, opts ExecOpts) (Process, error)
 
 	// Stop tears down the sandbox. Called when the session ends.
 	Stop(ctx context.Context, h Handle) error
+}
+
+// Process is a running process started by a Driver. Wait must block until the
+// process has exited and any stdio pump goroutines have finished, so callers
+// can safely close non-*os.File writers (e.g. io.MultiWriter) passed via
+// ExecOpts once Wait returns.
+type Process interface {
+	// Pid returns the underlying OS process id, or 0 if unavailable.
+	Pid() int
+	// Wait blocks until the process exits and returns the exit error
+	// (nil on success, typically *exec.ExitError on non-zero exit).
+	Wait() error
+	// Kill forcibly terminates the process.
+	Kill() error
 }
 
 // Config holds the parameters used to create a sandbox environment.

--- a/internal/sandbox/noop.go
+++ b/internal/sandbox/noop.go
@@ -3,7 +3,6 @@ package sandbox
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 )
 
@@ -18,10 +17,10 @@ func (n *Noop) Create(_ context.Context, cfg Config) (Handle, error) {
 	return Handle{ID: cfg.Name}, nil
 }
 
-// Exec runs cmd directly on the host using exec.CommandContext.
-// The process is started and its *os.Process is returned; the caller is
-// responsible for waiting on it.
-func (n *Noop) Exec(ctx context.Context, _ Handle, cmd []string, opts ExecOpts) (*os.Process, error) {
+// Exec runs cmd directly on the host using exec.CommandContext and returns
+// a Process that wraps the *exec.Cmd so callers get cmd.Wait() semantics
+// (stdio pumps drained, CommandContext watcher released).
+func (n *Noop) Exec(ctx context.Context, _ Handle, cmd []string, opts ExecOpts) (Process, error) {
 	if len(cmd) == 0 {
 		return nil, fmt.Errorf("sandbox/noop: exec requires at least one argument")
 	}
@@ -37,10 +36,36 @@ func (n *Noop) Exec(ctx context.Context, _ Handle, cmd []string, opts ExecOpts) 
 	if err := c.Start(); err != nil {
 		return nil, fmt.Errorf("sandbox/noop: start process: %w", err)
 	}
-	return c.Process, nil
+	return &noopProcess{cmd: c}, nil
 }
 
 // Stop is a no-op for the noop driver — there is no sandbox environment to tear down.
 func (n *Noop) Stop(_ context.Context, _ Handle) error {
 	return nil
+}
+
+// noopProcess wraps *exec.Cmd to satisfy Process. Using cmd.Wait (rather than
+// cmd.Process.Wait) is required so that stdout/stderr copy goroutines spawned
+// by exec when Stdout/Stderr are non-*os.File writers have finished before
+// Wait returns.
+type noopProcess struct {
+	cmd *exec.Cmd
+}
+
+func (p *noopProcess) Pid() int {
+	if p.cmd.Process == nil {
+		return 0
+	}
+	return p.cmd.Process.Pid
+}
+
+func (p *noopProcess) Wait() error {
+	return p.cmd.Wait()
+}
+
+func (p *noopProcess) Kill() error {
+	if p.cmd.Process == nil {
+		return nil
+	}
+	return p.cmd.Process.Kill()
 }

--- a/internal/sandbox/noop.go
+++ b/internal/sandbox/noop.go
@@ -1,0 +1,46 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// Noop is a no-isolation driver that runs commands via direct exec.
+// It has zero overhead and is the default driver for Belayer.
+// Use this when no sandbox isolation is needed.
+type Noop struct{}
+
+// Create returns a handle immediately using the config name as the ID.
+// No environment is actually provisioned — direct exec needs no setup.
+func (n *Noop) Create(_ context.Context, cfg Config) (Handle, error) {
+	return Handle{ID: cfg.Name}, nil
+}
+
+// Exec runs cmd directly on the host using exec.CommandContext.
+// The process is started and its *os.Process is returned; the caller is
+// responsible for waiting on it.
+func (n *Noop) Exec(ctx context.Context, _ Handle, cmd []string, opts ExecOpts) (*os.Process, error) {
+	if len(cmd) == 0 {
+		return nil, fmt.Errorf("sandbox/noop: exec requires at least one argument")
+	}
+
+	//nolint:gosec // cmd is controlled by internal callers, not user input
+	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	c.Env = opts.Env
+	c.Dir = opts.Dir
+	c.Stdin = opts.Stdin
+	c.Stdout = opts.Stdout
+	c.Stderr = opts.Stderr
+
+	if err := c.Start(); err != nil {
+		return nil, fmt.Errorf("sandbox/noop: start process: %w", err)
+	}
+	return c.Process, nil
+}
+
+// Stop is a no-op for the noop driver — there is no sandbox environment to tear down.
+func (n *Noop) Stop(_ context.Context, _ Handle) error {
+	return nil
+}

--- a/internal/sandbox/noop_test.go
+++ b/internal/sandbox/noop_test.go
@@ -1,0 +1,134 @@
+package sandbox_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/donovan-yohan/belayer/internal/sandbox"
+)
+
+func TestNoopCreate(t *testing.T) {
+	var d sandbox.Noop
+	h, err := d.Create(context.Background(), sandbox.Config{Name: "test-session"})
+	if err != nil {
+		t.Fatalf("Create returned unexpected error: %v", err)
+	}
+	if h.ID != "test-session" {
+		t.Errorf("expected handle ID %q, got %q", "test-session", h.ID)
+	}
+}
+
+func TestNoopStop(t *testing.T) {
+	var d sandbox.Noop
+	h := sandbox.Handle{ID: "test-session"}
+	if err := d.Stop(context.Background(), h); err != nil {
+		t.Fatalf("Stop returned unexpected error: %v", err)
+	}
+}
+
+func TestNoopExecSimpleCommand(t *testing.T) {
+	var d sandbox.Noop
+	h := sandbox.Handle{ID: "test-session"}
+
+	var stdout bytes.Buffer
+	proc, err := d.Exec(context.Background(), h, []string{"echo", "hello"}, sandbox.ExecOpts{
+		Stdout: &stdout,
+	})
+	if err != nil {
+		t.Fatalf("Exec returned unexpected error: %v", err)
+	}
+
+	state, err := proc.Wait()
+	if err != nil {
+		t.Fatalf("Wait returned unexpected error: %v", err)
+	}
+	if !state.Success() {
+		t.Errorf("expected process to exit successfully, got: %v", state)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "hello" {
+		t.Errorf("expected stdout %q, got %q", "hello", got)
+	}
+}
+
+func TestNoopExecEnvVars(t *testing.T) {
+	var d sandbox.Noop
+	h := sandbox.Handle{ID: "test-session"}
+
+	var stdout bytes.Buffer
+	proc, err := d.Exec(context.Background(), h, []string{"env"}, sandbox.ExecOpts{
+		Env:    []string{"BELAYER_TEST_VAR=sandwich"},
+		Stdout: &stdout,
+	})
+	if err != nil {
+		t.Fatalf("Exec returned unexpected error: %v", err)
+	}
+
+	state, err := proc.Wait()
+	if err != nil {
+		t.Fatalf("Wait returned unexpected error: %v", err)
+	}
+	if !state.Success() {
+		t.Errorf("expected process to exit successfully, got: %v", state)
+	}
+	if !strings.Contains(stdout.String(), "BELAYER_TEST_VAR=sandwich") {
+		t.Errorf("expected env output to contain BELAYER_TEST_VAR=sandwich, got:\n%s", stdout.String())
+	}
+}
+
+func TestNoopExecWorkingDirectory(t *testing.T) {
+	var d sandbox.Noop
+	h := sandbox.Handle{ID: "test-session"}
+
+	dir := t.TempDir()
+
+	var stdout bytes.Buffer
+	proc, err := d.Exec(context.Background(), h, []string{"pwd"}, sandbox.ExecOpts{
+		Dir:    dir,
+		Stdout: &stdout,
+	})
+	if err != nil {
+		t.Fatalf("Exec returned unexpected error: %v", err)
+	}
+
+	state, err := proc.Wait()
+	if err != nil {
+		t.Fatalf("Wait returned unexpected error: %v", err)
+	}
+	if !state.Success() {
+		t.Errorf("expected process to exit successfully, got: %v", state)
+	}
+
+	// Resolve symlinks so we can compare cleanly (macOS /var -> /private/var).
+	resolvedDir, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat temp dir: %v", err)
+	}
+	_ = resolvedDir
+
+	got := strings.TrimSpace(stdout.String())
+	// The printed dir may differ from dir due to symlinks; compare via os.SameFile.
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("stat pwd output %q: %v", got, err)
+	}
+	wantInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat expected dir %q: %v", dir, err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Errorf("expected working directory %q, got %q", dir, got)
+	}
+}
+
+func TestNoopExecEmptyCommandReturnsError(t *testing.T) {
+	var d sandbox.Noop
+	h := sandbox.Handle{ID: "test-session"}
+
+	_, err := d.Exec(context.Background(), h, []string{}, sandbox.ExecOpts{})
+	if err == nil {
+		t.Fatal("expected error for empty command, got nil")
+	}
+}

--- a/internal/sandbox/noop_test.go
+++ b/internal/sandbox/noop_test.go
@@ -41,12 +41,8 @@ func TestNoopExecSimpleCommand(t *testing.T) {
 		t.Fatalf("Exec returned unexpected error: %v", err)
 	}
 
-	state, err := proc.Wait()
-	if err != nil {
+	if err := proc.Wait(); err != nil {
 		t.Fatalf("Wait returned unexpected error: %v", err)
-	}
-	if !state.Success() {
-		t.Errorf("expected process to exit successfully, got: %v", state)
 	}
 	if got := strings.TrimSpace(stdout.String()); got != "hello" {
 		t.Errorf("expected stdout %q, got %q", "hello", got)
@@ -66,12 +62,8 @@ func TestNoopExecEnvVars(t *testing.T) {
 		t.Fatalf("Exec returned unexpected error: %v", err)
 	}
 
-	state, err := proc.Wait()
-	if err != nil {
+	if err := proc.Wait(); err != nil {
 		t.Fatalf("Wait returned unexpected error: %v", err)
-	}
-	if !state.Success() {
-		t.Errorf("expected process to exit successfully, got: %v", state)
 	}
 	if !strings.Contains(stdout.String(), "BELAYER_TEST_VAR=sandwich") {
 		t.Errorf("expected env output to contain BELAYER_TEST_VAR=sandwich, got:\n%s", stdout.String())
@@ -93,23 +85,13 @@ func TestNoopExecWorkingDirectory(t *testing.T) {
 		t.Fatalf("Exec returned unexpected error: %v", err)
 	}
 
-	state, err := proc.Wait()
-	if err != nil {
+	if err := proc.Wait(); err != nil {
 		t.Fatalf("Wait returned unexpected error: %v", err)
 	}
-	if !state.Success() {
-		t.Errorf("expected process to exit successfully, got: %v", state)
-	}
 
-	// Resolve symlinks so we can compare cleanly (macOS /var -> /private/var).
-	resolvedDir, err := os.Stat(dir)
-	if err != nil {
-		t.Fatalf("stat temp dir: %v", err)
-	}
-	_ = resolvedDir
-
+	// pwd may differ from dir due to symlinks (e.g. macOS /var -> /private/var),
+	// so compare via os.SameFile rather than string equality.
 	got := strings.TrimSpace(stdout.String())
-	// The printed dir may differ from dir due to symlinks; compare via os.SameFile.
 	gotInfo, err := os.Stat(got)
 	if err != nil {
 		t.Fatalf("stat pwd output %q: %v", got, err)


### PR DESCRIPTION
## Summary

- Introduces `SandboxDriver` and `RuntimeProvider` interfaces as the abstraction layer between belayer's agent launch logic and the execution environment
- Ships noop implementations (direct exec, no dev stack) as defaults — preserves existing behavior with zero overhead
- Refactors `bridge.Spawn()` to separate env/cmd building (pure functions) from process execution, enabling the daemon to route through `sandbox.Exec()` instead
- Includes the design spec documenting the runtime vs sandbox philosophy split, interface definitions, and the end-to-end PoC plan

### New packages
- `internal/sandbox/` — `Driver` interface (Create/Exec/Stop) + `Noop` driver
- `internal/runtime/` — `Provider` interface (Up/Health/Down) + `Noop` provider

### Bridge refactor
- `bridge.BuildEnv(cfg)` and `bridge.BuildCmd(cfg)` extracted as pure functions
- `bridge.NewProcess()` constructor for wrapping externally-started processes (sandbox driver path)

### Daemon wiring
- `Daemon` struct holds `sandbox.Driver` + `runtime.Provider`, defaulting to noop
- `bridgeLaunchAgent()` routes through `d.sandbox.Exec()` instead of `bridge.Spawn()` directly

## Test plan

- [ ] All existing tests pass unchanged (`go test ./...` — 10 packages, 0 failures)
- [ ] New sandbox tests verify noop Create/Exec/Stop, env passthrough, working directory
- [ ] New runtime tests verify noop Up/Health/Down
- [ ] New bridge tests verify BuildEnv/BuildCmd produce correct output
- [ ] Confirm `belayer daemon` + `belayer run start` still works end-to-end with noop defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added end-to-end design docs describing sandboxed execution, runtime provisioning, policy scaffolding, and a lightweight VM workflow for local development.

* **New Features / Refactor**
  * Support for pluggable runtime and sandbox providers so sessions provision a runtime, create a sandbox with injected endpoints, then run agents inside the sandbox.
  * Agent launch now uses reusable command/env builders and explicit sandbox-backed execution with managed stdio and logging.

* **Tests**
  * Added unit and integration tests covering sandbox and runtime provider behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->