### PR TITLE
feat(runtime): wire runtime provider selection end-to-end (Phase 5)

### DIFF
--- a/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
+++ b/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
@@ -153,20 +153,104 @@ type Handle struct {
 ### What ships in belayer (open source)
 
 - `internal/sandbox/driver.go` — the `Driver` interface
+- `internal/sandbox/registry.go` — the driver registry with override-injection
 - `internal/sandbox/noop.go` — the noop driver (direct exec, zero overhead)
+- `internal/sandbox/unavailable.go` — explicit "not in this build" stub for known drivers (e.g. clamshell)
 - `internal/runtime/provider.go` — the `Provider` interface
 - `internal/runtime/noop.go` — the noop provider
 - `internal/runtime/command.go` — the command provider (shells out to up/health/down)
 - Default policy YAMLs scaffolded on `belayer init`
+- `daemon.Config` exposes `SandboxDrivers *sandbox.Registry` (and the runtime equivalent) so a different `cmd/` main can wire in additional drivers at compile time
 
 ### What does NOT ship in belayer
 
-- The clamshell driver — lives in the crag/proof infrastructure, not the open-source repo
+- The clamshell driver — lives in a private repo that imports belayer-as-library
 - The crag binary — separate project
 - Specific agent identities — per-repo `.belayer/` or chalk-bag
 - Workspace definitions — crag config
 
-Belayer ships the interfaces. Driver implementations are deployment details. The clamshell driver is the proof that the interface works, not a first-class dependency.
+Belayer ships the interfaces and a registry. Driver implementations are deployment details. Open-source belayer never imports the closed clamshell tool; a private repo (e.g. `cmd/belayerd-extend/main.go`) imports both belayer-as-library and the closed clamshell driver, registers the override, and ships its own binary.
+
+### Driver registry and build-time injection
+
+The mechanism is build-time injection through a registry — same pattern superlemmings uses for `RuntimeAdapter` in `src/deepagents/runtimeAdapters/registry.ts`. Known driver names are listed in OSS belayer's defaults. Names without an in-tree implementation get an `unavailable` stub that fails preflight with a clear "not in this build" error. Private builds override entries by name.
+
+```go
+// internal/sandbox/registry.go (OSS)
+type Registry struct {
+    drivers map[string]Driver
+}
+
+type Override struct {
+    Name   string
+    Driver Driver
+}
+
+func NewRegistry(overrides ...Override) *Registry {
+    drivers := map[string]Driver{
+        "noop":      &Noop{},
+        "clamshell": NewUnavailable("clamshell", "not available in this build"),
+    }
+    for _, o := range overrides {
+        drivers[o.Name] = o.Driver
+    }
+    return &Registry{drivers: drivers}
+}
+
+func (r *Registry) Get(name string) (Driver, error) {
+    d, ok := r.drivers[name]
+    if !ok {
+        return nil, fmt.Errorf("sandbox driver %q is not registered", name)
+    }
+    return d, nil
+}
+```
+
+OSS `cmd/belayer/main.go` constructs the registry with no overrides:
+
+```go
+cfg := daemon.DefaultConfig()
+cfg.SandboxDrivers = sandbox.NewRegistry()  // noop + unavailable-clamshell
+daemon.Run(cfg)
+```
+
+A private build (separate repo, e.g. `extend-belayerd`) wires the closed driver in:
+
+```go
+import (
+    "github.com/donovan-yohan/belayer/internal/daemon"
+    "github.com/donovan-yohan/belayer/internal/sandbox"
+    "github.com/extend-private/clamshell-driver"
+)
+
+func main() {
+    cfg := daemon.DefaultConfig()
+    cfg.SandboxDrivers = sandbox.NewRegistry(
+        sandbox.Override{Name: "clamshell", Driver: clamshell.New()},
+    )
+    daemon.Run(cfg)
+}
+```
+
+`.belayer/config.yaml` selects the driver by name:
+
+```yaml
+sandbox:
+  mode: clamshell
+  policy: .belayer/policies/standard.yaml
+```
+
+When an OSS-belayer session arrives with `sandbox.mode: clamshell`, the registry's `Get("clamshell")` succeeds — `clamshell` IS a known name, registered to the `Unavailable` stub. The first method call on the stub (typically `Create` at session start) returns a clear error: `sandbox driver "clamshell" is unavailable in this build`. The daemon keeps serving other sessions; only the one requesting the missing driver fails, and it fails with a useful message instead of `driver not registered` or a nil-pointer panic. The private build's override replaces the stub with the real driver, and the same session config runs.
+
+Note that the daemon cannot pre-validate at startup — `.belayer/config.yaml` is per-project, so the daemon doesn't know which mode any future session will request. Per-session resolution is the right hook.
+
+Why this shape over alternatives:
+
+- vs. **subprocess driver protocol** (driver = separate binary, JSON-RPC over stdio): rejected as overkill. The constraint is "open belayer doesn't ship clamshell code," not "support third-party drivers in any language." Subprocess adds a versioned wire-protocol surface and stdio plumbing for agent processes, in exchange for crash isolation and hot-swap — neither of which we need at PoC.
+- vs. **Go plugins** (`plugin.Open`): rejected. GOOS/GOARCH lockstep, fragile in practice.
+- vs. **shipping clamshell in-tree behind a build tag**: rejected. Even with the tag, the clamshell driver code lives in the OSS repo, which is exactly what we're trying to avoid.
+
+The cost we accept: drivers must be Go (fine — the only two real drivers are noop and clamshell, both written by us); driver crashes can crash the daemon (fine for PoC; revisit when production hardening demands it).
 
 ### noop driver (ships with belayer)
 
@@ -195,9 +279,9 @@ func (n *Noop) Stop(ctx context.Context, h Handle) error {
 }
 ```
 
-### clamshell driver (proof-of-concept, NOT in belayer repo)
+### clamshell driver (private build, NOT in belayer repo)
 
-Wraps the clamshell CLI. Creates a sandbox at session start, execs agents via `docker exec`. Lives in the crag proof infrastructure.
+Wraps the clamshell CLI. Creates a sandbox at session start, execs agents via `docker exec`. Lives in a private repo and is wired into a private belayer binary via `sandbox.NewRegistry(sandbox.Override{Name: "clamshell", Driver: clamshell.New()})` from that repo's `cmd/belayerd-extend/main.go`. Code shape (satisfies `belayer/internal/sandbox.Driver`):
 
 ```go
 func (c *Clamshell) Create(ctx context.Context, cfg Config) (Handle, error) {
@@ -473,9 +557,20 @@ sandbox:
 - Wire into daemon session start
 - Test: existing behavior unchanged with noop drivers
 
-**Phase 2: Clamshell driver**
-- Implement clamshell sandbox driver
+**Phase 2: Sandbox registry + clamshell driver**
+
+Belayer side (OSS, this repo):
+- Add `internal/sandbox/registry.go` with `Registry`, `Override`, `NewRegistry(...)`, and `Get(name)`
+- Add `internal/sandbox/unavailable.go` with a stub `Driver` that returns a clear "not available in this build" error from every method
+- Pre-register `noop` and `unavailable-clamshell` in `NewRegistry`'s defaults
+- Replace `daemon.Config.Sandbox sandbox.Driver` with `daemon.Config.SandboxDrivers *sandbox.Registry`; resolve the per-session driver by name from `.belayer/config.yaml`'s `sandbox.mode` (default `noop`)
+- Update `cmd/belayer/main.go` to construct `cfg.SandboxDrivers = sandbox.NewRegistry()` (no overrides, behavior preserved)
 - Ship default policies in `.belayer/policies/`
+- Tests: registry returns noop by default; returns unavailable for clamshell with the documented error; accepts overrides; daemon resolves `sandbox.mode` correctly and surfaces the unavailable error at session start
+
+Private side (separate repo, e.g. `extend-belayerd`):
+- Implement the clamshell driver against `belayer/internal/sandbox.Driver` (Create/Exec/Stop per the code sketch above)
+- New `cmd/belayerd-extend/main.go` imports both belayer-as-library and the clamshell driver, wires the override into `cfg.SandboxDrivers`
 - Test in Lima VM: create sandbox, exec agent, verify egress policy
 - Iterate on policy by watching deny events
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -8,11 +8,12 @@ import (
 	"syscall"
 
 	"github.com/donovan-yohan/belayer/internal/daemon"
+	"github.com/donovan-yohan/belayer/internal/runtime"
 	"github.com/spf13/cobra"
 )
 
 func newDaemonCmd() *cobra.Command {
-	var socketPath, dbPath, belayerRoot string
+	var socketPath, dbPath, belayerRoot, workdir string
 
 	cmd := &cobra.Command{
 		Use:   "daemon",
@@ -28,6 +29,25 @@ func newDaemonCmd() *cobra.Command {
 			}
 			if belayerRoot != "" {
 				cfg.BelayerRoot = belayerRoot
+			}
+
+			wd := workdir
+			if wd == "" {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return fmt.Errorf("resolve working directory: %w", err)
+				}
+				wd = cwd
+			}
+			rtCfg, err := runtime.LoadConfig(wd)
+			if err != nil {
+				return err
+			}
+			cfg.Runtime = runtime.NewFromConfig(rtCfg)
+			if rtCfg.Empty() {
+				fmt.Fprintln(cmd.OutOrStdout(), "belayer runtime: noop (no .belayer/config.yaml runtime section found)")
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "belayer runtime: command (loaded from %s/.belayer/config.yaml)\n", wd)
 			}
 
 			d, err := daemon.New(cfg)
@@ -46,5 +66,6 @@ func newDaemonCmd() *cobra.Command {
 	cmd.Flags().StringVar(&socketPath, "socket", "", "Unix socket path (default ~/.belayer/daemon.sock)")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database path (default ~/.belayer/belayer.db)")
 	cmd.Flags().StringVar(&belayerRoot, "belayer-root", "", "Path to belayer repo root (for hermes_bridge PYTHONPATH)")
+	cmd.Flags().StringVar(&workdir, "workdir", "", "Workspace directory (for .belayer/config.yaml lookup; default cwd)")
 	return cmd
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -59,6 +59,12 @@ type Daemon struct {
 	sandbox sandbox.Driver
 	runtime runtime.Provider
 
+	// runtimeEndpoints is the set of endpoints reported by runtime.Up at daemon
+	// startup. Written once from Start before the HTTP server begins serving,
+	// then read from sandbox-creating goroutines. The happens-before relationship
+	// established by server.Serve makes the write visible without an explicit lock.
+	runtimeEndpoints []runtime.Endpoint
+
 	// Context from Start, used as the parent for sandbox/runtime lifecycle
 	// calls so they observe daemon shutdown. Initialized to context.Background
 	// in New so tests that skip Start still work.
@@ -155,10 +161,13 @@ func (d *Daemon) Start(ctx context.Context) error {
 
 	// Provision the runtime before serving. For the noop provider this is a
 	// no-op; the hook exists so future providers (command, clamshell, ...)
-	// can fail fast if the dev stack can't come up.
-	if _, err := d.runtime.Up(ctx); err != nil {
+	// can fail fast if the dev stack can't come up. Captured endpoints flow
+	// into each session's sandbox via ensureSandboxHandle.
+	endpoints, err := d.runtime.Up(ctx)
+	if err != nil {
 		return fmt.Errorf("daemon: runtime up: %w", err)
 	}
+	d.runtimeEndpoints = endpoints
 
 	// Shut down gracefully when ctx is cancelled.
 	go func() {
@@ -214,6 +223,7 @@ func (d *Daemon) ensureSandboxHandle(ctx context.Context, sess store.Session) (s
 	h, err := d.sandbox.Create(ctx, sandbox.Config{
 		Name:      sess.ID,
 		Workspace: sess.WorkspaceDir,
+		Endpoints: runtimeEndpointsToSandbox(d.runtimeEndpoints),
 	})
 	if err != nil {
 		return sandbox.Handle{}, err
@@ -667,4 +677,19 @@ func mustJSON(v any) string {
 // bridgeKey returns the map key for a bridge process given session and agent name.
 func bridgeKey(sessionID, agentName string) string {
 	return sessionID + "/" + agentName
+}
+
+// runtimeEndpointsToSandbox converts provider endpoints into the sandbox's
+// TCPEndpoint type. The shapes are identical today but the packages are
+// deliberately decoupled so a future runtime protocol field doesn't force a
+// matching change in sandbox policy.
+func runtimeEndpointsToSandbox(eps []runtime.Endpoint) []sandbox.TCPEndpoint {
+	if len(eps) == 0 {
+		return nil
+	}
+	out := make([]sandbox.TCPEndpoint, len(eps))
+	for i, e := range eps {
+		out[i] = sandbox.TCPEndpoint{Name: e.Name, Host: e.Host, Port: e.Port}
+	}
+	return out
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -661,10 +662,14 @@ func TestEnsureSandboxHandleNilEndpointsWhenRuntimeReportsNone(t *testing.T) {
 }
 
 // fakeRuntime returns a preset endpoint list from Up and signals Up/Down via
-// channels so tests can establish happens-before without races.
+// channels so tests can establish happens-before without races. sync.Once
+// guards the closes so callers can invoke Up/Down more than once without
+// panicking — useful if a future Start path retries provisioning.
 type fakeRuntime struct {
 	endpoints []runtime.Endpoint
+	upOnce    sync.Once
 	upDone    chan struct{}
+	downOnce  sync.Once
 	downDone  chan struct{}
 }
 
@@ -677,12 +682,12 @@ func newFakeRuntime(eps []runtime.Endpoint) *fakeRuntime {
 }
 
 func (f *fakeRuntime) Up(ctx context.Context) ([]runtime.Endpoint, error) {
-	close(f.upDone)
+	f.upOnce.Do(func() { close(f.upDone) })
 	return f.endpoints, nil
 }
 func (f *fakeRuntime) Health(ctx context.Context) error { return nil }
 func (f *fakeRuntime) Down(ctx context.Context) error {
-	close(f.downDone)
+	f.downOnce.Do(func() { close(f.downDone) })
 	return nil
 }
 
@@ -711,6 +716,7 @@ func TestStartCapturesRuntimeEndpoints(t *testing.T) {
 
 	// Wait until the daemon is accepting connections so we know Start is past
 	// runtime.Up and into Serve. Drain serveErr to surface any fast-fail.
+	ready := false
 	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
 		select {
 		case err := <-serveErr:
@@ -720,9 +726,13 @@ func TestStartCapturesRuntimeEndpoints(t *testing.T) {
 		c, dialErr := net.Dial("unix", socketPath)
 		if dialErr == nil {
 			c.Close()
+			ready = true
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+	if !ready {
+		t.Fatal("daemon never became reachable on its Unix socket")
 	}
 
 	select {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -597,6 +599,153 @@ func TestListMessagesWithoutForReturnsEventLog(t *testing.T) {
 		if !strings.HasPrefix(e.Type, "message_") {
 			t.Errorf("unexpected non-message event type %q in message list", e.Type)
 		}
+	}
+}
+
+// capturingSandbox records the last sandbox.Config passed to Create so tests
+// can assert the daemon populated it correctly.
+type capturingSandbox struct {
+	sandbox.Noop
+	lastCreateConfig sandbox.Config
+}
+
+func (c *capturingSandbox) Create(ctx context.Context, cfg sandbox.Config) (sandbox.Handle, error) {
+	c.lastCreateConfig = cfg
+	return sandbox.Handle{ID: cfg.Name}, nil
+}
+
+func TestEnsureSandboxHandlePassesRuntimeEndpoints(t *testing.T) {
+	d := testDaemon(t)
+	fake := &capturingSandbox{}
+	d.sandbox = fake
+	d.runtimeEndpoints = []runtime.Endpoint{
+		{Name: "api", Host: "localhost", Port: 4000},
+		{Name: "web", Host: "localhost", Port: 3000},
+	}
+
+	sess := store.Session{ID: "sess-1", WorkspaceDir: "/tmp/ws"}
+	if _, err := d.ensureSandboxHandle(context.Background(), sess); err != nil {
+		t.Fatalf("ensureSandboxHandle: %v", err)
+	}
+
+	want := []sandbox.TCPEndpoint{
+		{Name: "api", Host: "localhost", Port: 4000},
+		{Name: "web", Host: "localhost", Port: 3000},
+	}
+	if len(fake.lastCreateConfig.Endpoints) != len(want) {
+		t.Fatalf("sandbox.Create got %d endpoints, want %d", len(fake.lastCreateConfig.Endpoints), len(want))
+	}
+	for i, got := range fake.lastCreateConfig.Endpoints {
+		if got != want[i] {
+			t.Errorf("endpoints[%d] = %+v, want %+v", i, got, want[i])
+		}
+	}
+	if fake.lastCreateConfig.Workspace != "/tmp/ws" {
+		t.Errorf("sandbox.Create workspace = %q, want /tmp/ws", fake.lastCreateConfig.Workspace)
+	}
+}
+
+func TestEnsureSandboxHandleNilEndpointsWhenRuntimeReportsNone(t *testing.T) {
+	d := testDaemon(t)
+	fake := &capturingSandbox{}
+	d.sandbox = fake
+	// d.runtimeEndpoints left nil — mirrors Noop provider's Up return.
+
+	sess := store.Session{ID: "sess-1"}
+	if _, err := d.ensureSandboxHandle(context.Background(), sess); err != nil {
+		t.Fatalf("ensureSandboxHandle: %v", err)
+	}
+	if fake.lastCreateConfig.Endpoints != nil {
+		t.Errorf("sandbox.Create endpoints = %v, want nil", fake.lastCreateConfig.Endpoints)
+	}
+}
+
+// fakeRuntime returns a preset endpoint list from Up and signals Up/Down via
+// channels so tests can establish happens-before without races.
+type fakeRuntime struct {
+	endpoints []runtime.Endpoint
+	upDone    chan struct{}
+	downDone  chan struct{}
+}
+
+func newFakeRuntime(eps []runtime.Endpoint) *fakeRuntime {
+	return &fakeRuntime{
+		endpoints: eps,
+		upDone:    make(chan struct{}),
+		downDone:  make(chan struct{}),
+	}
+}
+
+func (f *fakeRuntime) Up(ctx context.Context) ([]runtime.Endpoint, error) {
+	close(f.upDone)
+	return f.endpoints, nil
+}
+func (f *fakeRuntime) Health(ctx context.Context) error { return nil }
+func (f *fakeRuntime) Down(ctx context.Context) error {
+	close(f.downDone)
+	return nil
+}
+
+func TestStartCapturesRuntimeEndpoints(t *testing.T) {
+	// Start binds a Unix socket; Darwin limits sun_path to 104 bytes so we use
+	// a short /tmp path rather than t.TempDir().
+	socketDir, err := os.MkdirTemp("/tmp", "bl")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "d.sock")
+	dbPath := filepath.Join(t.TempDir(), "belayer.db")
+
+	fake := newFakeRuntime([]runtime.Endpoint{
+		{Name: "api", Host: "localhost", Port: 4000},
+	})
+	d, err := New(Config{SocketPath: socketPath, DBPath: dbPath, Runtime: fake})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- d.Start(ctx) }()
+
+	// Wait until the daemon is accepting connections so we know Start is past
+	// runtime.Up and into Serve. Drain serveErr to surface any fast-fail.
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+		select {
+		case err := <-serveErr:
+			t.Fatalf("Start returned early: %v", err)
+		default:
+		}
+		c, dialErr := net.Dial("unix", socketPath)
+		if dialErr == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	select {
+	case <-fake.upDone:
+	case <-time.After(time.Second):
+		t.Fatal("runtime.Up was not called by Start")
+	}
+
+	cancel()
+	select {
+	case <-serveErr:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+	// After <-serveErr, the Start goroutine has returned, giving happens-before
+	// for the endpoints written during runtime.Up.
+	if len(d.runtimeEndpoints) != 1 || d.runtimeEndpoints[0].Port != 4000 {
+		t.Errorf("runtimeEndpoints = %+v, want single endpoint on :4000", d.runtimeEndpoints)
+	}
+	select {
+	case <-fake.downDone:
+	case <-time.After(2 * time.Second):
+		t.Error("runtime.Down was not called during shutdown")
 	}
 }
 

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -19,6 +19,22 @@ type Config struct {
 	Endpoints []Endpoint `yaml:"endpoints"`
 }
 
+// Empty reports whether the Config has no runtime behavior configured.
+// Callers use this to decide whether to fall back to the Noop provider.
+func (c Config) Empty() bool {
+	return c.Up == "" && c.Health == "" && c.Down == "" && len(c.Endpoints) == 0
+}
+
+// NewFromConfig picks a Provider to match the given Config. An Empty config
+// yields a Noop provider; any other config yields a Command provider wrapping
+// cfg. This is the single construction point the daemon CLI uses.
+func NewFromConfig(cfg Config) Provider {
+	if cfg.Empty() {
+		return &Noop{}
+	}
+	return NewCommand(cfg)
+}
+
 // file is the top-level shape of .belayer/config.yaml.
 // Unknown sections are ignored by yaml.v3's default behavior.
 type file struct {

--- a/internal/runtime/config_test.go
+++ b/internal/runtime/config_test.go
@@ -7,6 +7,42 @@ import (
 	"testing"
 )
 
+func TestConfigEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{"zero value", Config{}, true},
+		{"only up set", Config{Up: "make dev"}, false},
+		{"only health set", Config{Health: "curl -sf /health"}, false},
+		{"only down set", Config{Down: "pkill"}, false},
+		{"only endpoints set", Config{Endpoints: []Endpoint{{Name: "api", Host: "localhost", Port: 8080}}}, false},
+		{"all fields set", Config{Up: "u", Health: "h", Down: "d", Endpoints: []Endpoint{{Port: 1}}}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.Empty(); got != tc.want {
+				t.Errorf("Empty() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewFromConfigEmptyReturnsNoop(t *testing.T) {
+	p := NewFromConfig(Config{})
+	if _, ok := p.(*Noop); !ok {
+		t.Fatalf("NewFromConfig(empty) = %T, want *Noop", p)
+	}
+}
+
+func TestNewFromConfigPopulatedReturnsCommand(t *testing.T) {
+	p := NewFromConfig(Config{Up: "true"})
+	if _, ok := p.(*Command); !ok {
+		t.Fatalf("NewFromConfig(populated) = %T, want *Command", p)
+	}
+}
+
 func writeConfig(t *testing.T, dir, content string) {
 	t.Helper()
 	belayerDir := filepath.Join(dir, ".belayer")


### PR DESCRIPTION
## Summary

Phase 5 of [the sandbox-runtime-and-crag-proof plan](docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md): belayer's daemon now picks a runtime provider from `.belayer/config.yaml` at startup and flows the resulting endpoints into every sandbox it creates.

- **Provider selection**: `runtime.Config.Empty()` + `runtime.NewFromConfig()` — Noop for an empty config, Command for a populated one.
- **CLI wiring**: `belayer daemon --workdir <dir>` (default cwd) loads `.belayer/config.yaml`, builds the provider, and logs which one was selected.
- **Endpoint propagation**: `Daemon.runtimeEndpoints` captures whatever `runtime.Up()` returns at startup and passes it to every `sandbox.Create()` call via `sandbox.Config.Endpoints`. The conversion from `runtime.Endpoint` to `sandbox.TCPEndpoint` lives in a small helper so a future runtime-side protocol field won't force matching changes in sandbox policy.

## Scope (belayer-side)

Phase 5 from the design doc has two halves. This PR does the belayer half:

- ✅ Select noop vs command provider at daemon startup based on `.belayer/config.yaml`
- ✅ Wire `runtime.Up`/`Down` into the daemon lifecycle (already done in #71, now also stores endpoints)

The remaining pieces live elsewhere:

- **Phase 2 (clamshell driver)** — lives in crag / proof infrastructure, not this repo (per the design doc's "What does NOT ship in belayer").
- **Live arielcharts validation** — manual test once clamshell lands.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -race` (all packages green)
- [x] New test: `TestConfigEmpty` + `TestNewFromConfig{Empty,Populated}` cover provider selection
- [x] New test: `TestEnsureSandboxHandlePassesRuntimeEndpoints` + `TestEnsureSandboxHandleNilEndpointsWhenRuntimeReportsNone` cover endpoint propagation via a capturing sandbox
- [x] New test: `TestStartCapturesRuntimeEndpoints` boots a real daemon on a Unix socket with a channel-signalling fake runtime, asserts Up/Down fire and endpoints land on the daemon (race-clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon CLI accepts --workdir and auto-discovers runtime configuration from the workspace.
  * Runtime-reported service endpoints are now propagated into session sandboxes so sessions see resolved endpoints.

* **Documentation**
  * Added design notes describing a sandbox driver registry and build-time handling of a closed "clamshell" driver (OSS defaults to a no-op/unavailable driver).

* **Tests**
  * Added unit and integration tests covering runtime config behavior and endpoint propagation into sandboxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->