### PR TITLE
feat(sandbox): driver registry + clamshell driver (Phase 2)

### DIFF
--- a/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
+++ b/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
@@ -150,107 +150,80 @@ type Handle struct {
 }
 ```
 
-### What ships in belayer (open source)
+### What ships in belayer
 
 - `internal/sandbox/driver.go` — the `Driver` interface
-- `internal/sandbox/registry.go` — the driver registry with override-injection
-- `internal/sandbox/noop.go` — the noop driver (direct exec, zero overhead)
-- `internal/sandbox/unavailable.go` — explicit "not in this build" stub for known drivers (e.g. clamshell)
+- `internal/sandbox/registry.go` — the driver registry (name → `Driver`)
+- `internal/sandbox/noop.go` — the noop driver (direct exec, zero overhead, always built)
+- `internal/sandbox/clamshell.go` — the clamshell driver, behind `//go:build clamshell`
+- `internal/sandbox/clamshell_stub.go` — the "not in this build" stub, behind `//go:build !clamshell`
 - `internal/runtime/provider.go` — the `Provider` interface
 - `internal/runtime/noop.go` — the noop provider
 - `internal/runtime/command.go` — the command provider (shells out to up/health/down)
 - Default policy YAMLs scaffolded on `belayer init`
-- `daemon.Config` exposes `SandboxDrivers *sandbox.Registry` (and the runtime equivalent) so a different `cmd/` main can wire in additional drivers at compile time
+- `daemon.Config.SandboxDrivers *sandbox.Registry` — the daemon resolves drivers by name from `.belayer/config.yaml`'s `sandbox.mode`
 
-### What does NOT ship in belayer
+### What is NOT shipped by default
 
-- The clamshell driver — lives in a private repo that imports belayer-as-library
+- The `clamshell` CLI itself — runtime dependency, not a code dependency. The driver shells out to it; if the CLI isn't installed on the worker, the driver returns a runtime error.
 - The crag binary — separate project
 - Specific agent identities — per-repo `.belayer/` or chalk-bag
 - Workspace definitions — crag config
 
-Belayer ships the interfaces and a registry. Driver implementations are deployment details. Open-source belayer never imports the closed clamshell tool; a private repo (e.g. `cmd/belayerd-extend/main.go`) imports both belayer-as-library and the closed clamshell driver, registers the override, and ships its own binary.
+### Driver selection: build tag, not separate repo
 
-### Driver registry and build-time injection
+The default `go build ./cmd/belayer` produces a binary with only the noop driver wired into the registry. A `clamshell` entry exists in the registry but resolves to a stub that fails session start with a clear "not built with clamshell support" error.
 
-The mechanism is build-time injection through a registry — same pattern superlemmings uses for `RuntimeAdapter` in `src/deepagents/runtimeAdapters/registry.ts`. Known driver names are listed in OSS belayer's defaults. Names without an in-tree implementation get an `unavailable` stub that fails preflight with a clear "not in this build" error. Private builds override entries by name.
+To compile the real clamshell driver in, build with `-tags clamshell`:
+
+```bash
+go build ./cmd/belayer                                # noop only (default)
+go build -tags clamshell ./cmd/belayer                # noop + clamshell
+go install -tags clamshell github.com/.../belayer/cmd/belayer@latest
+```
+
+The mechanism is the standard Go build constraint, not a registry override. Two files share the same `clamshell` registration — only one compiles per build:
 
 ```go
-// internal/sandbox/registry.go (OSS)
-type Registry struct {
-    drivers map[string]Driver
+// internal/sandbox/clamshell.go
+//go:build clamshell
+
+package sandbox
+
+func init() {
+    Register("clamshell", &Clamshell{})  // real driver
 }
 
-type Override struct {
-    Name   string
-    Driver Driver
-}
-
-func NewRegistry(overrides ...Override) *Registry {
-    drivers := map[string]Driver{
-        "noop":      &Noop{},
-        "clamshell": NewUnavailable("clamshell", "not available in this build"),
-    }
-    for _, o := range overrides {
-        drivers[o.Name] = o.Driver
-    }
-    return &Registry{drivers: drivers}
-}
-
-func (r *Registry) Get(name string) (Driver, error) {
-    d, ok := r.drivers[name]
-    if !ok {
-        return nil, fmt.Errorf("sandbox driver %q is not registered", name)
-    }
-    return d, nil
-}
+type Clamshell struct{ /* ... */ }
+// Create/Exec/Stop call into the clamshell CLI
 ```
-
-OSS `cmd/belayer/main.go` constructs the registry with no overrides:
 
 ```go
-cfg := daemon.DefaultConfig()
-cfg.SandboxDrivers = sandbox.NewRegistry()  // noop + unavailable-clamshell
-daemon.Run(cfg)
-```
+// internal/sandbox/clamshell_stub.go
+//go:build !clamshell
 
-A private build (separate repo, e.g. `extend-belayerd`) wires the closed driver in:
+package sandbox
 
-```go
-import (
-    "github.com/donovan-yohan/belayer/internal/daemon"
-    "github.com/donovan-yohan/belayer/internal/sandbox"
-    "github.com/extend-private/clamshell-driver"
-)
-
-func main() {
-    cfg := daemon.DefaultConfig()
-    cfg.SandboxDrivers = sandbox.NewRegistry(
-        sandbox.Override{Name: "clamshell", Driver: clamshell.New()},
-    )
-    daemon.Run(cfg)
+func init() {
+    Register("clamshell", newUnavailable("clamshell",
+        "this binary was built without -tags clamshell"))
 }
 ```
 
-`.belayer/config.yaml` selects the driver by name:
+The registry itself is trivial — a `map[string]Driver` populated by `init()` functions, with a `Get(name) (Driver, error)`. No `Override` parameter, no separate `cmd/` main per build.
 
-```yaml
-sandbox:
-  mode: clamshell
-  policy: .belayer/policies/standard.yaml
-```
+When an OSS-belayer session arrives with `sandbox.mode: clamshell`, `Get("clamshell")` succeeds (the name is registered) but the stub's `Create` returns an error. The daemon keeps serving other sessions; only the one requesting clamshell fails, with a useful message instead of `driver not registered` or a nil-pointer panic. A `-tags clamshell` build replaces the stub with the real driver; the same session config runs.
 
-When an OSS-belayer session arrives with `sandbox.mode: clamshell`, the registry's `Get("clamshell")` succeeds — `clamshell` IS a known name, registered to the `Unavailable` stub. The first method call on the stub (typically `Create` at session start) returns a clear error: `sandbox driver "clamshell" is unavailable in this build`. The daemon keeps serving other sessions; only the one requesting the missing driver fails, and it fails with a useful message instead of `driver not registered` or a nil-pointer panic. The private build's override replaces the stub with the real driver, and the same session config runs.
+The daemon cannot pre-validate at startup — `.belayer/config.yaml` is per-project, so the daemon doesn't know which mode any future session will request. Per-session resolution is the right hook.
 
-Note that the daemon cannot pre-validate at startup — `.belayer/config.yaml` is per-project, so the daemon doesn't know which mode any future session will request. Per-session resolution is the right hook.
+Why build tags over alternatives:
 
-Why this shape over alternatives:
-
-- vs. **subprocess driver protocol** (driver = separate binary, JSON-RPC over stdio): rejected as overkill. The constraint is "open belayer doesn't ship clamshell code," not "support third-party drivers in any language." Subprocess adds a versioned wire-protocol surface and stdio plumbing for agent processes, in exchange for crash isolation and hot-swap — neither of which we need at PoC.
+- vs. **separate `belayer-extend` binary that imports a private clamshell driver package**: rejected. Adds a second repo, version skew between belayer and the extension binary, and registry/override plumbing — all to avoid one file's worth of `os/exec` calls in the public repo. The constraint is "default `go install` produces an unsandboxed binary," not "no clamshell-related code anywhere in the public repo." A build tag satisfies the actual constraint.
+- vs. **subprocess driver protocol** (driver = separate binary, JSON-RPC over stdio): rejected as overkill. Adds a versioned wire-protocol surface and stdio plumbing for agent processes, in exchange for crash isolation and hot-swap — neither of which we need at PoC.
 - vs. **Go plugins** (`plugin.Open`): rejected. GOOS/GOARCH lockstep, fragile in practice.
-- vs. **shipping clamshell in-tree behind a build tag**: rejected. Even with the tag, the clamshell driver code lives in the OSS repo, which is exactly what we're trying to avoid.
+- vs. **shipping clamshell in-tree without a build tag**: rejected. The default `go install` would compile clamshell-CLI references into every binary, including ones run by people who never installed clamshell.
 
-The cost we accept: drivers must be Go (fine — the only two real drivers are noop and clamshell, both written by us); driver crashes can crash the daemon (fine for PoC; revisit when production hardening demands it).
+The cost we accept: anyone can build the clamshell-enabled binary by passing `-tags clamshell` themselves. That's fine — the closed thing is the `clamshell` CLI on the worker, not the wrapper code that calls it. Anyone who has the CLI can use the wrapper; anyone who doesn't gets a runtime error from the CLI itself.
 
 ### noop driver (ships with belayer)
 
@@ -279,9 +252,9 @@ func (n *Noop) Stop(ctx context.Context, h Handle) error {
 }
 ```
 
-### clamshell driver (private build, NOT in belayer repo)
+### clamshell driver (built with `-tags clamshell`)
 
-Wraps the clamshell CLI. Creates a sandbox at session start, execs agents via `docker exec`. Lives in a private repo and is wired into a private belayer binary via `sandbox.NewRegistry(sandbox.Override{Name: "clamshell", Driver: clamshell.New()})` from that repo's `cmd/belayerd-extend/main.go`. Code shape (satisfies `belayer/internal/sandbox.Driver`):
+Wraps the clamshell CLI. Creates a sandbox at session start, execs agents via `docker exec`. Lives in `internal/sandbox/clamshell.go` behind `//go:build clamshell`. Code shape:
 
 ```go
 func (c *Clamshell) Create(ctx context.Context, cfg Config) (Handle, error) {
@@ -557,22 +530,21 @@ sandbox:
 - Wire into daemon session start
 - Test: existing behavior unchanged with noop drivers
 
-**Phase 2: Sandbox registry + clamshell driver**
+**Phase 2: Sandbox registry + clamshell driver (build-tagged)**
 
-Belayer side (OSS, this repo):
-- Add `internal/sandbox/registry.go` with `Registry`, `Override`, `NewRegistry(...)`, and `Get(name)`
-- Add `internal/sandbox/unavailable.go` with a stub `Driver` that returns a clear "not available in this build" error from every method
-- Pre-register `noop` and `unavailable-clamshell` in `NewRegistry`'s defaults
+Default-build work (no build tag, this is what `go install` produces):
+- Add `internal/sandbox/registry.go` with a package-level `map[string]Driver`, `Register(name, driver)`, and `Get(name) (Driver, error)`
+- Add `internal/sandbox/clamshell_stub.go` (`//go:build !clamshell`) that registers `clamshell` to a stub returning "this binary was built without -tags clamshell" from every method
 - Replace `daemon.Config.Sandbox sandbox.Driver` with `daemon.Config.SandboxDrivers *sandbox.Registry`; resolve the per-session driver by name from `.belayer/config.yaml`'s `sandbox.mode` (default `noop`)
-- Update `cmd/belayer/main.go` to construct `cfg.SandboxDrivers = sandbox.NewRegistry()` (no overrides, behavior preserved)
+- `cmd/belayer/main.go` constructs the registry once at startup; `init()` functions in each driver file populate it
 - Ship default policies in `.belayer/policies/`
-- Tests: registry returns noop by default; returns unavailable for clamshell with the documented error; accepts overrides; daemon resolves `sandbox.mode` correctly and surfaces the unavailable error at session start
+- Tests: registry returns noop by default; default build returns the stub for clamshell with the documented error; daemon resolves `sandbox.mode` correctly and surfaces the unavailable error at session start
 
-Private side (separate repo, e.g. `extend-belayerd`):
-- Implement the clamshell driver against `belayer/internal/sandbox.Driver` (Create/Exec/Stop per the code sketch above)
-- New `cmd/belayerd-extend/main.go` imports both belayer-as-library and the clamshell driver, wires the override into `cfg.SandboxDrivers`
-- Test in Lima VM: create sandbox, exec agent, verify egress policy
-- Iterate on policy by watching deny events
+Tagged-build work (`-tags clamshell`):
+- Add `internal/sandbox/clamshell.go` (`//go:build clamshell`) implementing `Driver` against the `clamshell` CLI (Create/Exec/Stop per the code sketch above)
+- The same `init()`-based registration replaces the stub at compile time when the tag is set
+- Tests guarded by the same tag: build with `-tags clamshell` in CI and exercise the driver against a Lima VM with the CLI installed
+- Manual verification in Lima VM: create sandbox, exec agent, verify egress policy; iterate on policy by watching deny events
 
 **Phase 3: Command runtime provider**
 - Implement `runtime.Config` loader that reads the `runtime:` section of `.belayer/config.yaml`

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/donovan-yohan/belayer/internal/daemon"
 	"github.com/donovan-yohan/belayer/internal/runtime"
+	"github.com/donovan-yohan/belayer/internal/sandbox"
 	"github.com/spf13/cobra"
 )
 
@@ -44,6 +45,9 @@ func newDaemonCmd() *cobra.Command {
 				return err
 			}
 			cfg.Runtime = runtime.NewFromConfig(rtCfg)
+			// Drivers register themselves from init(); hand the daemon the
+			// process-wide registry so per-session sandbox.mode can resolve.
+			cfg.SandboxDrivers = sandbox.Default
 			if rtCfg.Empty() {
 				fmt.Fprintln(cmd.OutOrStdout(), "belayer runtime: noop (no .belayer/config.yaml runtime section found)")
 			} else {

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -403,7 +403,7 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		stderrLog.Close()
 		return nil, fmt.Errorf("load session for sandbox handle: %w", err)
 	}
-	handle, err := d.ensureSandboxHandle(d.startCtx, sess)
+	ss, err := d.ensureSandboxHandle(d.startCtx, sess)
 	if err != nil {
 		stdinR.Close()
 		stdinW.Close()
@@ -412,7 +412,7 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		return nil, fmt.Errorf("ensure sandbox handle: %w", err)
 	}
 
-	osProc, err := d.sandbox.Exec(d.startCtx, handle, argv, sandbox.ExecOpts{
+	osProc, err := ss.driver.Exec(d.startCtx, ss.handle, argv, sandbox.ExecOpts{
 		Env:    env,
 		Dir:    workdir,
 		Stdin:  stdinR,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -30,9 +30,11 @@ type Config struct {
 	DBPath      string
 	BelayerRoot string // directory containing hermes_bridge/ (for PYTHONPATH)
 
-	// Sandbox overrides the driver used for agent execution.
-	// Nil falls back to &sandbox.Noop{}.
-	Sandbox sandbox.Driver
+	// SandboxDrivers is the registry the daemon resolves per-session drivers
+	// against. Each session's driver is chosen by name from .belayer/config.yaml's
+	// sandbox.mode. Nil falls back to a registry containing only the noop driver,
+	// which is what existing tests rely on.
+	SandboxDrivers *sandbox.Registry
 	// Runtime overrides the dev-stack provider.
 	// Nil falls back to &runtime.Noop{}.
 	Runtime runtime.Provider
@@ -56,8 +58,8 @@ type Daemon struct {
 	config   Config
 	broker   broker.Broker
 
-	sandbox sandbox.Driver
-	runtime runtime.Provider
+	sandboxDrivers *sandbox.Registry
+	runtime        runtime.Provider
 
 	// runtimeEndpoints is the set of endpoints reported by runtime.Up at daemon
 	// startup. Written once from Start before the HTTP server begins serving,
@@ -70,10 +72,12 @@ type Daemon struct {
 	// in New so tests that skip Start still work.
 	startCtx context.Context
 
-	// Per-session sandbox handles. Populated lazily on first agent spawn,
-	// cleared on terminal session transitions and during Shutdown.
-	sandboxMu      sync.Mutex
-	sandboxHandles map[string]sandbox.Handle
+	// Per-session sandbox state. Each entry caches the driver resolved from
+	// .belayer/config.yaml's sandbox.mode plus the Handle returned by Create.
+	// Populated lazily on first agent spawn, cleared on terminal session
+	// transitions and during Shutdown.
+	sandboxMu        sync.Mutex
+	sessionSandboxes map[string]sessionSandbox
 
 	spawnBridgeAgent func(req agentSpawnRequest) (*bridge.Process, error)
 
@@ -98,17 +102,22 @@ func New(cfg Config) (*Daemon, error) {
 	}
 
 	d := &Daemon{
-		store:          st,
-		config:         cfg,
-		tools:          make(map[string][]agent.ToolSpec),
-		bridgeProcs:    make(map[string]*bridge.Process),
-		sandboxHandles: make(map[string]sandbox.Handle),
-		startCtx:       context.Background(),
+		store:            st,
+		config:           cfg,
+		tools:            make(map[string][]agent.ToolSpec),
+		bridgeProcs:      make(map[string]*bridge.Process),
+		sessionSandboxes: make(map[string]sessionSandbox),
+		startCtx:         context.Background(),
 	}
-	if cfg.Sandbox != nil {
-		d.sandbox = cfg.Sandbox
+	if cfg.SandboxDrivers != nil {
+		d.sandboxDrivers = cfg.SandboxDrivers
 	} else {
-		d.sandbox = &sandbox.Noop{}
+		// Nil falls back to a registry with only the noop driver so tests that
+		// skip the CLI wiring path still start successfully. Callers that want
+		// the clamshell stub must pass the process-wide sandbox.Default.
+		fallback := &sandbox.Registry{}
+		fallback.Register(sandbox.DefaultMode, &sandbox.Noop{})
+		d.sandboxDrivers = fallback
 	}
 	if cfg.Runtime != nil {
 		d.runtime = cfg.Runtime
@@ -190,11 +199,11 @@ func (d *Daemon) Shutdown(ctx context.Context) error {
 
 	// Tear down any outstanding sandbox handles.
 	d.sandboxMu.Lock()
-	handles := d.sandboxHandles
-	d.sandboxHandles = make(map[string]sandbox.Handle)
+	sessions := d.sessionSandboxes
+	d.sessionSandboxes = make(map[string]sessionSandbox)
 	d.sandboxMu.Unlock()
-	for sessID, h := range handles {
-		if stopErr := d.sandbox.Stop(shutCtx, h); stopErr != nil {
+	for sessID, ss := range sessions {
+		if stopErr := ss.driver.Stop(shutCtx, ss.handle); stopErr != nil {
 			log.Printf("daemon: sandbox stop %s: %v", sessID, stopErr)
 		}
 	}
@@ -208,53 +217,74 @@ func (d *Daemon) Shutdown(ctx context.Context) error {
 	return err
 }
 
-// ensureSandboxHandle returns the session's sandbox handle, creating one on
-// first use. Safe to call from multiple goroutines; the handle is cached per
-// session in d.sandboxHandles.
-func (d *Daemon) ensureSandboxHandle(ctx context.Context, sess store.Session) (sandbox.Handle, error) {
+// sessionSandbox caches the driver (resolved from sandbox.mode per session)
+// alongside the Handle returned by Create, so Exec and Stop go to the same
+// driver that created the handle.
+type sessionSandbox struct {
+	driver sandbox.Driver
+	handle sandbox.Handle
+}
+
+// ensureSandboxHandle returns the session's sandbox state, creating one on
+// first use. The driver is resolved from <sess.WorkspaceDir>/.belayer/config.yaml's
+// sandbox.mode (defaulting to noop). Safe to call from multiple goroutines;
+// the state is cached per session in d.sessionSandboxes.
+func (d *Daemon) ensureSandboxHandle(ctx context.Context, sess store.Session) (sessionSandbox, error) {
 	d.sandboxMu.Lock()
-	if h, ok := d.sandboxHandles[sess.ID]; ok {
+	if ss, ok := d.sessionSandboxes[sess.ID]; ok {
 		d.sandboxMu.Unlock()
-		return h, nil
+		return ss, nil
 	}
 	d.sandboxMu.Unlock()
 
+	settings, err := sandbox.LoadSettings(sess.WorkspaceDir)
+	if err != nil {
+		return sessionSandbox{}, fmt.Errorf("sandbox settings: %w", err)
+	}
+	mode := settings.ModeOrDefault()
+	driver, err := d.sandboxDrivers.Get(mode)
+	if err != nil {
+		return sessionSandbox{}, err
+	}
+
 	// Create outside the lock — Create may block (container pull, VM boot).
-	h, err := d.sandbox.Create(ctx, sandbox.Config{
+	h, err := driver.Create(ctx, sandbox.Config{
 		Name:      sess.ID,
 		Workspace: sess.WorkspaceDir,
+		Policy:    settings.Policy,
 		Endpoints: runtimeEndpointsToSandbox(d.runtimeEndpoints),
 	})
 	if err != nil {
-		return sandbox.Handle{}, err
+		return sessionSandbox{}, err
 	}
 
 	d.sandboxMu.Lock()
 	defer d.sandboxMu.Unlock()
 	// Another goroutine may have raced us; keep whichever is stored first
 	// so callers never see two different handles for one session.
-	if existing, ok := d.sandboxHandles[sess.ID]; ok {
+	if existing, ok := d.sessionSandboxes[sess.ID]; ok {
 		go func() {
-			_ = d.sandbox.Stop(ctx, h)
+			_ = driver.Stop(ctx, h)
 		}()
 		return existing, nil
 	}
-	d.sandboxHandles[sess.ID] = h
-	return h, nil
+	ss := sessionSandbox{driver: driver, handle: h}
+	d.sessionSandboxes[sess.ID] = ss
+	return ss, nil
 }
 
-// terminateSandbox stops and forgets the sandbox handle for sessionID, if any.
+// terminateSandbox stops and forgets the sandbox state for sessionID, if any.
 // Safe to call for sessions that never had a handle.
 func (d *Daemon) terminateSandbox(ctx context.Context, sessionID string) {
 	d.sandboxMu.Lock()
-	h, ok := d.sandboxHandles[sessionID]
+	ss, ok := d.sessionSandboxes[sessionID]
 	if !ok {
 		d.sandboxMu.Unlock()
 		return
 	}
-	delete(d.sandboxHandles, sessionID)
+	delete(d.sessionSandboxes, sessionID)
 	d.sandboxMu.Unlock()
-	if err := d.sandbox.Stop(ctx, h); err != nil {
+	if err := ss.driver.Stop(ctx, ss.handle); err != nil {
 		log.Printf("daemon: sandbox stop %s: %v", sessionID, err)
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -32,15 +32,17 @@ func testDaemon(t *testing.T) *Daemon {
 	}
 	t.Cleanup(func() { st.Close() })
 
+	reg := &sandbox.Registry{}
+	reg.Register(sandbox.DefaultMode, &sandbox.Noop{})
 	d := &Daemon{
-		store:          st,
-		config:         Config{},
-		tools:          make(map[string][]agent.ToolSpec),
-		bridgeProcs:    make(map[string]*bridge.Process),
-		sandboxHandles: make(map[string]sandbox.Handle),
-		sandbox:        &sandbox.Noop{},
-		runtime:        &runtime.Noop{},
-		startCtx:       context.Background(),
+		store:            st,
+		config:           Config{},
+		tools:            make(map[string][]agent.ToolSpec),
+		bridgeProcs:      make(map[string]*bridge.Process),
+		sessionSandboxes: make(map[string]sessionSandbox),
+		sandboxDrivers:   reg,
+		runtime:          &runtime.Noop{},
+		startCtx:         context.Background(),
 	}
 	d.broker = broker.NewMemoryBroker(st)
 	d.spawnBridgeAgent = func(req agentSpawnRequest) (*bridge.Process, error) { return nil, nil }
@@ -618,7 +620,9 @@ func (c *capturingSandbox) Create(ctx context.Context, cfg sandbox.Config) (sand
 func TestEnsureSandboxHandlePassesRuntimeEndpoints(t *testing.T) {
 	d := testDaemon(t)
 	fake := &capturingSandbox{}
-	d.sandbox = fake
+	reg := &sandbox.Registry{}
+	reg.Register(sandbox.DefaultMode, fake)
+	d.sandboxDrivers = reg
 	d.runtimeEndpoints = []runtime.Endpoint{
 		{Name: "api", Host: "localhost", Port: 4000},
 		{Name: "web", Host: "localhost", Port: 3000},
@@ -649,7 +653,9 @@ func TestEnsureSandboxHandlePassesRuntimeEndpoints(t *testing.T) {
 func TestEnsureSandboxHandleNilEndpointsWhenRuntimeReportsNone(t *testing.T) {
 	d := testDaemon(t)
 	fake := &capturingSandbox{}
-	d.sandbox = fake
+	reg := &sandbox.Registry{}
+	reg.Register(sandbox.DefaultMode, fake)
+	d.sandboxDrivers = reg
 	// d.runtimeEndpoints left nil — mirrors Noop provider's Up return.
 
 	sess := store.Session{ID: "sess-1"}
@@ -658,6 +664,122 @@ func TestEnsureSandboxHandleNilEndpointsWhenRuntimeReportsNone(t *testing.T) {
 	}
 	if fake.lastCreateConfig.Endpoints != nil {
 		t.Errorf("sandbox.Create endpoints = %v, want nil", fake.lastCreateConfig.Endpoints)
+	}
+}
+
+// unavailableDriverStub fails every Driver call with a clamshell-style
+// unavailable error, mimicking the default-build clamshell_stub for tests
+// that need to assert the daemon routes errors back to callers without
+// tearing itself down.
+type unavailableDriverStub struct{ msg string }
+
+func (u *unavailableDriverStub) Create(context.Context, sandbox.Config) (sandbox.Handle, error) {
+	return sandbox.Handle{}, errStub(u.msg)
+}
+func (u *unavailableDriverStub) Exec(context.Context, sandbox.Handle, []string, sandbox.ExecOpts) (sandbox.Process, error) {
+	return nil, errStub(u.msg)
+}
+func (u *unavailableDriverStub) Stop(context.Context, sandbox.Handle) error {
+	return errStub(u.msg)
+}
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }
+
+// writeSandboxConfig writes .belayer/config.yaml under workspaceDir with the
+// given sandbox.mode. Used by the resolution tests.
+func writeSandboxConfig(t *testing.T, workspaceDir, mode string) {
+	t.Helper()
+	belayerDir := filepath.Join(workspaceDir, ".belayer")
+	if err := os.MkdirAll(belayerDir, 0o700); err != nil {
+		t.Fatalf("mkdir .belayer: %v", err)
+	}
+	contents := "sandbox:\n  mode: " + mode + "\n"
+	if err := os.WriteFile(filepath.Join(belayerDir, "config.yaml"), []byte(contents), 0o600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+}
+
+func TestEnsureSandboxHandleResolvesModeNoop(t *testing.T) {
+	d := testDaemon(t)
+	fake := &capturingSandbox{}
+	reg := &sandbox.Registry{}
+	reg.Register("noop", fake)
+	reg.Register("clamshell", &unavailableDriverStub{msg: "clamshell not compiled in"})
+	d.sandboxDrivers = reg
+
+	ws := t.TempDir()
+	writeSandboxConfig(t, ws, "noop")
+
+	sess := store.Session{ID: "sess-noop", WorkspaceDir: ws}
+	ss, err := d.ensureSandboxHandle(context.Background(), sess)
+	if err != nil {
+		t.Fatalf("ensureSandboxHandle noop: %v", err)
+	}
+	if ss.handle.ID != "sess-noop" {
+		t.Errorf("handle ID = %q, want sess-noop", ss.handle.ID)
+	}
+	if fake.lastCreateConfig.Name != "sess-noop" {
+		t.Errorf("noop driver was not invoked for sandbox.mode=noop (captured name %q)", fake.lastCreateConfig.Name)
+	}
+}
+
+func TestEnsureSandboxHandleResolvesDefaultWhenConfigMissing(t *testing.T) {
+	d := testDaemon(t)
+	fake := &capturingSandbox{}
+	reg := &sandbox.Registry{}
+	reg.Register("noop", fake)
+	d.sandboxDrivers = reg
+
+	sess := store.Session{ID: "sess-default", WorkspaceDir: t.TempDir()} // no .belayer/config.yaml
+	if _, err := d.ensureSandboxHandle(context.Background(), sess); err != nil {
+		t.Fatalf("ensureSandboxHandle default: %v", err)
+	}
+	if fake.lastCreateConfig.Name != "sess-default" {
+		t.Errorf("default-mode fallback did not route to noop (captured name %q)", fake.lastCreateConfig.Name)
+	}
+}
+
+func TestEnsureSandboxHandleSurfacesUnavailableDriver(t *testing.T) {
+	d := testDaemon(t)
+	reg := &sandbox.Registry{}
+	reg.Register("noop", &sandbox.Noop{})
+	reg.Register("clamshell", &unavailableDriverStub{msg: `sandbox driver "clamshell" is unavailable: this binary was built without -tags clamshell`})
+	d.sandboxDrivers = reg
+
+	// Session A wants clamshell; must fail with the unavailable message.
+	wsA := t.TempDir()
+	writeSandboxConfig(t, wsA, "clamshell")
+	sessA := store.Session{ID: "sess-unavailable", WorkspaceDir: wsA}
+	if _, err := d.ensureSandboxHandle(context.Background(), sessA); err == nil {
+		t.Fatal("ensureSandboxHandle clamshell: expected error, got nil")
+	} else if !strings.Contains(err.Error(), "unavailable") || !strings.Contains(err.Error(), "-tags clamshell") {
+		t.Errorf("error %q missing unavailable / -tags clamshell text", err.Error())
+	}
+
+	// Session B keeps working — one bad session must not poison the daemon.
+	sessB := store.Session{ID: "sess-healthy", WorkspaceDir: t.TempDir()}
+	if _, err := d.ensureSandboxHandle(context.Background(), sessB); err != nil {
+		t.Fatalf("ensureSandboxHandle healthy session after clamshell failure: %v", err)
+	}
+}
+
+func TestEnsureSandboxHandleUnknownModeReturnsError(t *testing.T) {
+	d := testDaemon(t)
+	reg := &sandbox.Registry{}
+	reg.Register("noop", &sandbox.Noop{})
+	d.sandboxDrivers = reg
+
+	ws := t.TempDir()
+	writeSandboxConfig(t, ws, "does-not-exist")
+	sess := store.Session{ID: "sess-unknown", WorkspaceDir: ws}
+	_, err := d.ensureSandboxHandle(context.Background(), sess)
+	if err == nil {
+		t.Fatal("expected not-registered error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not registered") {
+		t.Errorf("error %q does not mention \"not registered\"", err.Error())
 	}
 }
 

--- a/internal/sandbox/clamshell.go
+++ b/internal/sandbox/clamshell.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"go.yaml.in/yaml/v3"
@@ -158,10 +159,40 @@ func (c *Clamshell) Create(ctx context.Context, cfg Config) (Handle, error) {
 	return Handle{
 		ID: cfg.Name,
 		Meta: map[string]string{
-			"container":  connect.Container,
-			"policyFile": policyPath,
+			"container":     connect.Container,
+			"policyFile":    policyPath,
+			"hostWorkspace": cfg.Workspace,
 		},
 	}, nil
+}
+
+// sandboxWorkspace is where Clamshell mounts the host workspace inside the
+// container. The clamshell CLI guarantees this path; Exec rewrites host-side
+// Dir values that fall under it to the container-side equivalent.
+const sandboxWorkspace = "/workspace"
+
+// translateDir rewrites a host-path Dir to the container-side path when it
+// lives under the sandbox's host workspace. Paths that are empty, already
+// container-side, or outside the workspace are returned unchanged so callers
+// that pass raw container paths (or leave Dir empty) still work.
+func translateDir(dir, hostWorkspace string) string {
+	if dir == "" || hostWorkspace == "" {
+		return dir
+	}
+	if !filepath.IsAbs(dir) {
+		return dir
+	}
+	rel, err := filepath.Rel(hostWorkspace, dir)
+	if err != nil {
+		return dir
+	}
+	if rel == "." {
+		return sandboxWorkspace
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return dir
+	}
+	return sandboxWorkspace + "/" + filepath.ToSlash(rel)
 }
 
 // Exec launches cmd inside the sandbox container via `docker exec`.
@@ -192,8 +223,8 @@ func (c *Clamshell) Exec(ctx context.Context, h Handle, cmd []string, opts ExecO
 	args = append(args, container)
 
 	shellCmd := shellJoin(cmd)
-	if opts.Dir != "" {
-		shellCmd = fmt.Sprintf("cd %s && %s", shellQuote(opts.Dir), shellCmd)
+	if dir := translateDir(opts.Dir, h.Meta["hostWorkspace"]); dir != "" {
+		shellCmd = fmt.Sprintf("cd %s && %s", shellQuote(dir), shellCmd)
 	}
 	args = append(args, "sh", "-lc", shellCmd)
 

--- a/internal/sandbox/clamshell.go
+++ b/internal/sandbox/clamshell.go
@@ -129,23 +129,30 @@ func (c *Clamshell) Create(ctx context.Context, cfg Config) (Handle, error) {
 		return Handle{}, fmt.Errorf("sandbox/clamshell: create: %w (stderr: %s)", err, stderr)
 	}
 
+	// After this point the sandbox exists in clamshell. Any failure must tear
+	// it down, otherwise we leak a running sandbox on every bad discovery.
+	cleanupAfterCreate := func(cause error) error {
+		if _, stopStderr, stopErr := c.runner.Run(ctx, c.cli, "sandbox", "stop", cfg.Name); stopErr != nil {
+			cause = fmt.Errorf("%w; additionally, cleanup stop failed: %v (stderr: %s)", cause, stopErr, stopStderr)
+		}
+		_ = os.Remove(policyPath)
+		return cause
+	}
+
 	// 4. Discover the container name so Exec can docker-exec into it. The
 	//    --json form emits a structured response clamshell guarantees stable.
 	connectOut, stderr, err := c.runner.Run(ctx, c.cli, "--json", "sandbox", "connect", cfg.Name)
 	if err != nil {
-		_ = os.Remove(policyPath)
-		return Handle{}, fmt.Errorf("sandbox/clamshell: connect: %w (stderr: %s)", err, stderr)
+		return Handle{}, cleanupAfterCreate(fmt.Errorf("sandbox/clamshell: connect: %w (stderr: %s)", err, stderr))
 	}
 	var connect struct {
 		Container string `json:"container"`
 	}
 	if err := json.Unmarshal(connectOut, &connect); err != nil {
-		_ = os.Remove(policyPath)
-		return Handle{}, fmt.Errorf("sandbox/clamshell: parse connect output: %w (stdout: %s)", err, connectOut)
+		return Handle{}, cleanupAfterCreate(fmt.Errorf("sandbox/clamshell: parse connect output: %w (stdout: %s)", err, connectOut))
 	}
 	if connect.Container == "" {
-		_ = os.Remove(policyPath)
-		return Handle{}, fmt.Errorf("sandbox/clamshell: connect output missing container field: %s", connectOut)
+		return Handle{}, cleanupAfterCreate(fmt.Errorf("sandbox/clamshell: connect output missing container field: %s", connectOut))
 	}
 
 	return Handle{
@@ -158,10 +165,11 @@ func (c *Clamshell) Create(ctx context.Context, cfg Config) (Handle, error) {
 }
 
 // Exec launches cmd inside the sandbox container via `docker exec`.
-// Environment variables are materialized through `env KEY=VAL ...` so we don't
-// depend on docker CLI's -e semantics, and the command runs under
-// `sh -lc` so shell conveniences (pipes, globs, login profile) work as they
-// would in a normal shell session.
+// Environment variables are passed through a mode-0600 env-file referenced by
+// `--env-file` rather than folded into the argv. This keeps secrets out of
+// the host process table (`ps auxe` would otherwise expose them). The command
+// runs under `sh -lc` so shell conveniences (pipes, globs, login profile) work
+// as they would in a normal shell session.
 func (c *Clamshell) Exec(ctx context.Context, h Handle, cmd []string, opts ExecOpts) (Process, error) {
 	if len(cmd) == 0 {
 		return nil, fmt.Errorf("sandbox/clamshell: exec requires at least one argument")
@@ -171,24 +179,102 @@ func (c *Clamshell) Exec(ctx context.Context, h Handle, cmd []string, opts ExecO
 		return nil, fmt.Errorf("sandbox/clamshell: exec handle %q missing container metadata", h.ID)
 	}
 
-	args := []string{"exec", "-u", "sandbox", "-i", container}
+	args := []string{"exec", "-u", "sandbox", "-i"}
+	envFile := ""
 	if len(opts.Env) > 0 {
-		args = append(args, "env")
-		args = append(args, opts.Env...)
+		path, err := writeEnvFile(opts.Env)
+		if err != nil {
+			return nil, err
+		}
+		envFile = path
+		args = append(args, "--env-file", envFile)
 	}
+	args = append(args, container)
+
 	shellCmd := shellJoin(cmd)
 	if opts.Dir != "" {
 		shellCmd = fmt.Sprintf("cd %s && %s", shellQuote(opts.Dir), shellCmd)
 	}
 	args = append(args, "sh", "-lc", shellCmd)
 
-	// Env was folded into the argv via `env`; don't also set it on the
-	// docker process (docker exec won't forward host env to the container).
-	return c.runner.Start(ctx, c.docker, args, ExecOpts{
+	// Env was written to envFile; don't also set it on the docker process
+	// (docker exec won't forward host env to the container anyway).
+	proc, err := c.runner.Start(ctx, c.docker, args, ExecOpts{
 		Stdin:  opts.Stdin,
 		Stdout: opts.Stdout,
 		Stderr: opts.Stderr,
 	})
+	if err != nil {
+		if envFile != "" {
+			_ = os.Remove(envFile)
+		}
+		return nil, err
+	}
+	if envFile != "" {
+		return &envFileProcess{Process: proc, path: envFile}, nil
+	}
+	return proc, nil
+}
+
+// writeEnvFile materializes env ("KEY=VALUE" entries) into a 0600 tempfile
+// suitable for `docker exec --env-file`. Callers must remove the returned
+// path once the referring process has exited.
+func writeEnvFile(env []string) (string, error) {
+	tmp, err := os.CreateTemp("", "belayer-env-*.env")
+	if err != nil {
+		return "", fmt.Errorf("sandbox/clamshell: temp env: %w", err)
+	}
+	// CreateTemp already uses 0600 on Unix, but be explicit so hardened umask
+	// environments (or future filesystems) don't widen it.
+	if err := os.Chmod(tmp.Name(), 0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("sandbox/clamshell: chmod env: %w", err)
+	}
+	body := strings.Join(env, "\n")
+	if len(env) > 0 {
+		body += "\n"
+	}
+	if _, err := tmp.WriteString(body); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("sandbox/clamshell: write env: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("sandbox/clamshell: close env: %w", err)
+	}
+	return tmp.Name(), nil
+}
+
+// envFileProcess wraps a Process to unlink the temporary env file once the
+// underlying process has exited (via Wait) or been killed. Cleanup runs at
+// most once.
+type envFileProcess struct {
+	Process
+	path    string
+	cleaned bool
+}
+
+func (p *envFileProcess) cleanup() {
+	if p.cleaned {
+		return
+	}
+	p.cleaned = true
+	_ = os.Remove(p.path)
+}
+
+func (p *envFileProcess) Wait() error {
+	err := p.Process.Wait()
+	p.cleanup()
+	return err
+}
+
+func (p *envFileProcess) Kill() error {
+	err := p.Process.Kill()
+	// Kill doesn't block on exit; cleanup happens in Wait. But if the caller
+	// Kills without ever Waiting, they still leak — that's on them.
+	return err
 }
 
 // Stop tears down the clamshell sandbox and removes any temp policy file
@@ -219,7 +305,14 @@ func (c *Clamshell) preparePolicy(basePath string, endpoints []TCPEndpoint) (str
 		}
 	}
 	if len(endpoints) > 0 {
-		existing, _ := doc["tcp_endpoints"].([]any)
+		var existing []any
+		if raw, present := doc["tcp_endpoints"]; present && raw != nil {
+			list, ok := raw.([]any)
+			if !ok {
+				return "", fmt.Errorf("sandbox/clamshell: policy %s has non-list tcp_endpoints (%T)", basePath, raw)
+			}
+			existing = list
+		}
 		for _, ep := range endpoints {
 			existing = append(existing, map[string]any{
 				"name": ep.Name,

--- a/internal/sandbox/clamshell.go
+++ b/internal/sandbox/clamshell.go
@@ -1,0 +1,271 @@
+//go:build clamshell
+
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func init() {
+	Register("clamshell", New())
+}
+
+// Clamshell drives the external `clamshell` CLI (plus `docker exec` for agent
+// spawns). It is compiled in only when -tags clamshell is set; the stub in
+// clamshell_stub.go stands in on default builds so sandbox.mode: clamshell
+// surfaces a clear error instead of a "not registered" one.
+type Clamshell struct {
+	// cli is the name (or path) of the clamshell binary. Default "clamshell".
+	cli string
+	// docker is the name (or path) of the docker binary. Default "docker".
+	docker string
+	// runner abstracts process execution so tests can mock the CLI and
+	// docker exec calls without needing a real Lima VM.
+	runner commandRunner
+}
+
+// New builds a Clamshell with production defaults (resolves `clamshell` and
+// `docker` via PATH).
+func New() *Clamshell {
+	return &Clamshell{
+		cli:    "clamshell",
+		docker: "docker",
+		runner: osRunner{},
+	}
+}
+
+// commandRunner abstracts process execution for tests. Production wires this
+// to osRunner; tests inject a fake.
+type commandRunner interface {
+	// Run executes name with args to completion and returns captured
+	// stdout/stderr along with any exit error.
+	Run(ctx context.Context, name string, args ...string) (stdout, stderr []byte, err error)
+	// Start launches name with args, wiring stdio via opts, and returns a
+	// Process the caller can Wait/Kill.
+	Start(ctx context.Context, name string, args []string, opts ExecOpts) (Process, error)
+}
+
+// osRunner is the production commandRunner. It delegates to os/exec.
+type osRunner struct{}
+
+func (osRunner) Run(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
+	var stdout, stderr bytes.Buffer
+	//nolint:gosec // name/args are controlled by Clamshell, not user input
+	c := exec.CommandContext(ctx, name, args...)
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	err := c.Run()
+	return stdout.Bytes(), stderr.Bytes(), err
+}
+
+func (osRunner) Start(ctx context.Context, name string, args []string, opts ExecOpts) (Process, error) {
+	//nolint:gosec // name/args are controlled by Clamshell, not user input
+	c := exec.CommandContext(ctx, name, args...)
+	c.Env = opts.Env
+	c.Dir = opts.Dir
+	c.Stdin = opts.Stdin
+	c.Stdout = opts.Stdout
+	c.Stderr = opts.Stderr
+	if err := c.Start(); err != nil {
+		return nil, err
+	}
+	return &osProcess{cmd: c}, nil
+}
+
+// osProcess wraps *exec.Cmd. We use cmd.Wait (not cmd.Process.Wait) so that
+// any stdio pump goroutines spawned by exec have finished before Wait returns.
+type osProcess struct{ cmd *exec.Cmd }
+
+func (p *osProcess) Pid() int {
+	if p.cmd.Process == nil {
+		return 0
+	}
+	return p.cmd.Process.Pid
+}
+
+func (p *osProcess) Wait() error { return p.cmd.Wait() }
+
+func (p *osProcess) Kill() error {
+	if p.cmd.Process == nil {
+		return nil
+	}
+	return p.cmd.Process.Kill()
+}
+
+// Create provisions a clamshell sandbox. It ensures the clamshell gateway is
+// up, merges runtime endpoints into the supplied policy, creates the sandbox,
+// and then discovers the backing Docker container so Exec can target it.
+func (c *Clamshell) Create(ctx context.Context, cfg Config) (Handle, error) {
+	// 1. Ensure the gateway is running. `clamshell gateway start` is expected
+	//    to be idempotent; surfacing errors here catches misconfigured workers.
+	if _, stderr, err := c.runner.Run(ctx, c.cli, "gateway", "start"); err != nil {
+		return Handle{}, fmt.Errorf("sandbox/clamshell: gateway start: %w (stderr: %s)", err, stderr)
+	}
+
+	// 2. Inject runtime endpoints into the policy's tcp_endpoints section and
+	//    write the merged copy to a temp file. The temp file lives for the
+	//    session — Stop cleans it up via handle.Meta["policyFile"].
+	policyPath, err := c.preparePolicy(cfg.Policy, cfg.Endpoints)
+	if err != nil {
+		return Handle{}, err
+	}
+
+	// 3. Create the sandbox.
+	createArgs := []string{"sandbox", "create",
+		"--name", cfg.Name,
+		"--policy", policyPath,
+		"--workspace", cfg.Workspace,
+	}
+	if _, stderr, err := c.runner.Run(ctx, c.cli, createArgs...); err != nil {
+		_ = os.Remove(policyPath)
+		return Handle{}, fmt.Errorf("sandbox/clamshell: create: %w (stderr: %s)", err, stderr)
+	}
+
+	// 4. Discover the container name so Exec can docker-exec into it. The
+	//    --json form emits a structured response clamshell guarantees stable.
+	connectOut, stderr, err := c.runner.Run(ctx, c.cli, "--json", "sandbox", "connect", cfg.Name)
+	if err != nil {
+		_ = os.Remove(policyPath)
+		return Handle{}, fmt.Errorf("sandbox/clamshell: connect: %w (stderr: %s)", err, stderr)
+	}
+	var connect struct {
+		Container string `json:"container"`
+	}
+	if err := json.Unmarshal(connectOut, &connect); err != nil {
+		_ = os.Remove(policyPath)
+		return Handle{}, fmt.Errorf("sandbox/clamshell: parse connect output: %w (stdout: %s)", err, connectOut)
+	}
+	if connect.Container == "" {
+		_ = os.Remove(policyPath)
+		return Handle{}, fmt.Errorf("sandbox/clamshell: connect output missing container field: %s", connectOut)
+	}
+
+	return Handle{
+		ID: cfg.Name,
+		Meta: map[string]string{
+			"container":  connect.Container,
+			"policyFile": policyPath,
+		},
+	}, nil
+}
+
+// Exec launches cmd inside the sandbox container via `docker exec`.
+// Environment variables are materialized through `env KEY=VAL ...` so we don't
+// depend on docker CLI's -e semantics, and the command runs under
+// `sh -lc` so shell conveniences (pipes, globs, login profile) work as they
+// would in a normal shell session.
+func (c *Clamshell) Exec(ctx context.Context, h Handle, cmd []string, opts ExecOpts) (Process, error) {
+	if len(cmd) == 0 {
+		return nil, fmt.Errorf("sandbox/clamshell: exec requires at least one argument")
+	}
+	container, ok := h.Meta["container"]
+	if !ok || container == "" {
+		return nil, fmt.Errorf("sandbox/clamshell: exec handle %q missing container metadata", h.ID)
+	}
+
+	args := []string{"exec", "-u", "sandbox", "-i", container}
+	if len(opts.Env) > 0 {
+		args = append(args, "env")
+		args = append(args, opts.Env...)
+	}
+	shellCmd := shellJoin(cmd)
+	if opts.Dir != "" {
+		shellCmd = fmt.Sprintf("cd %s && %s", shellQuote(opts.Dir), shellCmd)
+	}
+	args = append(args, "sh", "-lc", shellCmd)
+
+	// Env was folded into the argv via `env`; don't also set it on the
+	// docker process (docker exec won't forward host env to the container).
+	return c.runner.Start(ctx, c.docker, args, ExecOpts{
+		Stdin:  opts.Stdin,
+		Stdout: opts.Stdout,
+		Stderr: opts.Stderr,
+	})
+}
+
+// Stop tears down the clamshell sandbox and removes any temp policy file
+// written during Create.
+func (c *Clamshell) Stop(ctx context.Context, h Handle) error {
+	if policyFile := h.Meta["policyFile"]; policyFile != "" {
+		_ = os.Remove(policyFile)
+	}
+	if _, stderr, err := c.runner.Run(ctx, c.cli, "sandbox", "stop", h.ID); err != nil {
+		return fmt.Errorf("sandbox/clamshell: stop: %w (stderr: %s)", err, stderr)
+	}
+	return nil
+}
+
+// preparePolicy reads basePath (if set), appends endpoints to its
+// tcp_endpoints section, and writes the merged YAML to a temp file. Returns
+// the temp path. Callers are responsible for removing the file when they no
+// longer need it (Stop handles this via handle.Meta["policyFile"]).
+func (c *Clamshell) preparePolicy(basePath string, endpoints []TCPEndpoint) (string, error) {
+	doc := map[string]any{}
+	if basePath != "" {
+		raw, err := os.ReadFile(basePath)
+		if err != nil {
+			return "", fmt.Errorf("sandbox/clamshell: read policy %s: %w", basePath, err)
+		}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			return "", fmt.Errorf("sandbox/clamshell: parse policy %s: %w", basePath, err)
+		}
+	}
+	if len(endpoints) > 0 {
+		existing, _ := doc["tcp_endpoints"].([]any)
+		for _, ep := range endpoints {
+			existing = append(existing, map[string]any{
+				"name": ep.Name,
+				"host": ep.Host,
+				"port": ep.Port,
+			})
+		}
+		doc["tcp_endpoints"] = existing
+	}
+
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("sandbox/clamshell: marshal policy: %w", err)
+	}
+	tmp, err := os.CreateTemp("", "belayer-policy-*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("sandbox/clamshell: temp policy: %w", err)
+	}
+	if _, err := tmp.Write(out); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("sandbox/clamshell: write temp policy: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("sandbox/clamshell: close temp policy: %w", err)
+	}
+	return tmp.Name(), nil
+}
+
+// shellJoin renders argv as a single sh-safe string. We single-quote every
+// element so spaces, quotes, and shell metacharacters in agent argv don't
+// break out of the `sh -lc` wrapper.
+func shellJoin(argv []string) string {
+	parts := make([]string, len(argv))
+	for i, a := range argv {
+		parts[i] = shellQuote(a)
+	}
+	return strings.Join(parts, " ")
+}
+
+// shellQuote wraps s in single quotes, escaping any embedded single quote by
+// closing the quoted region, inserting a literal quote, and reopening.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/sandbox/clamshell_stub.go
+++ b/internal/sandbox/clamshell_stub.go
@@ -1,0 +1,45 @@
+//go:build !clamshell
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+)
+
+// The default build registers the clamshell name against a stub driver whose
+// operations fail with a clear "not built with -tags clamshell" message. The
+// name stays present in the registry so Get("clamshell") succeeds — callers
+// find out the real driver is unavailable at Create time, not via a
+// "not registered" error that implies a config typo.
+
+func init() {
+	Register("clamshell", &unavailableDriver{
+		name:   "clamshell",
+		reason: "this binary was built without -tags clamshell",
+	})
+}
+
+// unavailableDriver is a Driver that reports unavailability from every method.
+// It exists only in non-tagged builds; a -tags clamshell build replaces it
+// with the real driver via clamshell.go's init().
+type unavailableDriver struct {
+	name   string
+	reason string
+}
+
+func (u *unavailableDriver) err() error {
+	return fmt.Errorf("sandbox driver %q is unavailable: %s", u.name, u.reason)
+}
+
+func (u *unavailableDriver) Create(context.Context, Config) (Handle, error) {
+	return Handle{}, u.err()
+}
+
+func (u *unavailableDriver) Exec(context.Context, Handle, []string, ExecOpts) (Process, error) {
+	return nil, u.err()
+}
+
+func (u *unavailableDriver) Stop(context.Context, Handle) error {
+	return u.err()
+}

--- a/internal/sandbox/clamshell_stub_test.go
+++ b/internal/sandbox/clamshell_stub_test.go
@@ -1,0 +1,40 @@
+//go:build !clamshell
+
+package sandbox_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/donovan-yohan/belayer/internal/sandbox"
+)
+
+// TestClamshellStubReportsUnavailable verifies the default-build stub returns
+// a clear "not built with -tags clamshell" error from every Driver method.
+// Under -tags clamshell this file is not compiled in — the real driver's
+// behavior is exercised by clamshell_test.go instead.
+func TestClamshellStubReportsUnavailable(t *testing.T) {
+	d, err := sandbox.Default.Get("clamshell")
+	if err != nil {
+		t.Fatalf("Default.Get(\"clamshell\"): %v", err)
+	}
+
+	_, createErr := d.Create(context.Background(), sandbox.Config{Name: "sess"})
+	if createErr == nil {
+		t.Fatal("stub Create returned nil error; expected unavailable error")
+	}
+	if !strings.Contains(createErr.Error(), "-tags clamshell") {
+		t.Errorf("stub Create error %q does not mention -tags clamshell", createErr.Error())
+	}
+
+	_, execErr := d.Exec(context.Background(), sandbox.Handle{}, []string{"echo"}, sandbox.ExecOpts{})
+	if execErr == nil || !strings.Contains(execErr.Error(), "-tags clamshell") {
+		t.Errorf("stub Exec error %v does not mention -tags clamshell", execErr)
+	}
+
+	stopErr := d.Stop(context.Background(), sandbox.Handle{})
+	if stopErr == nil || !strings.Contains(stopErr.Error(), "-tags clamshell") {
+		t.Errorf("stub Stop error %v does not mention -tags clamshell", stopErr)
+	}
+}

--- a/internal/sandbox/clamshell_test.go
+++ b/internal/sandbox/clamshell_test.go
@@ -235,10 +235,11 @@ func TestClamshellCreateMissingContainerFieldErrors(t *testing.T) {
 
 func TestClamshellExecBuildsDockerArgv(t *testing.T) {
 	c, f := newTestClamshell()
+	f.startProc = &fakeProcess{}
 	var stdout, stderr bytes.Buffer
 	stdin := strings.NewReader("hi")
 
-	_, err := c.Exec(context.Background(),
+	proc, err := c.Exec(context.Background(),
 		Handle{ID: "sess-1", Meta: map[string]string{"container": "sbx-abc"}},
 		[]string{"python3", "-m", "hermes_bridge"},
 		ExecOpts{
@@ -260,18 +261,50 @@ func TestClamshellExecBuildsDockerArgv(t *testing.T) {
 		t.Errorf("runner.Start name = %q, want docker", call.name)
 	}
 
-	// Expected argv prefix: exec -u sandbox -i sbx-abc env ANTHROPIC_API_KEY=secret PYTHONPATH=/belayer sh -lc <cmd>
-	want := []string{
-		"exec", "-u", "sandbox", "-i", "sbx-abc",
-		"env", "ANTHROPIC_API_KEY=secret", "PYTHONPATH=/belayer",
-		"sh", "-lc",
+	// Expected argv shape: exec -u sandbox -i --env-file <tmp> sbx-abc sh -lc <cmd>
+	// The env values live inside <tmp> (mode 0600) rather than in the argv, so
+	// `ps auxe` on the host can't read secrets out of the process table.
+	if len(call.args) != 10 {
+		t.Fatalf("argv length = %d, want 10: %v", len(call.args), call.args)
 	}
-	if len(call.args) != len(want)+1 {
-		t.Fatalf("argv length = %d, want %d: %v", len(call.args), len(want)+1, call.args)
-	}
-	for i, w := range want {
+	prefix := []string{"exec", "-u", "sandbox", "-i", "--env-file"}
+	for i, w := range prefix {
 		if call.args[i] != w {
 			t.Errorf("argv[%d] = %q, want %q (full: %v)", i, call.args[i], w, call.args)
+		}
+	}
+	envFilePath := call.args[5]
+	if envFilePath == "" {
+		t.Fatal("argv missing --env-file path")
+	}
+	if call.args[6] != "sbx-abc" {
+		t.Errorf("argv[6] = %q, want container name sbx-abc", call.args[6])
+	}
+	if call.args[7] != "sh" || call.args[8] != "-lc" {
+		t.Errorf("argv tail = %v, want sh -lc <cmd>", call.args[7:])
+	}
+
+	// env-file contents: exactly the provided KEY=VAL entries, one per line, and
+	// mode must be 0600 so other users on the host can't read secrets.
+	info, statErr := os.Stat(envFilePath)
+	if statErr != nil {
+		t.Fatalf("stat env file: %v", statErr)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("env-file perm = %o, want 0600", perm)
+	}
+	envBody, readErr := os.ReadFile(envFilePath)
+	if readErr != nil {
+		t.Fatalf("read env file: %v", readErr)
+	}
+	wantBody := "ANTHROPIC_API_KEY=secret\nPYTHONPATH=/belayer\n"
+	if string(envBody) != wantBody {
+		t.Errorf("env-file body = %q, want %q", string(envBody), wantBody)
+	}
+	// Secrets must not appear in argv at all.
+	for _, a := range call.args {
+		if strings.Contains(a, "ANTHROPIC_API_KEY") || strings.Contains(a, "secret") {
+			t.Errorf("secret leaked into argv: %q (full: %v)", a, call.args)
 		}
 	}
 
@@ -295,9 +328,71 @@ func TestClamshellExecBuildsDockerArgv(t *testing.T) {
 	if call.opts.Stderr != &stderr {
 		t.Error("Exec did not forward Stderr to docker process")
 	}
-	// Env is folded into argv via `env`; don't also set it on the outer process.
+	// Env lives in the env-file; don't also set it on the outer process.
 	if call.opts.Env != nil {
 		t.Errorf("Exec set opts.Env on docker process = %v, want nil", call.opts.Env)
+	}
+
+	// Waiting on the returned Process must unlink the env-file — otherwise we
+	// accumulate /tmp/belayer-env-*.env files across every agent spawn.
+	if err := proc.Wait(); err != nil {
+		t.Errorf("proc.Wait() = %v, want nil", err)
+	}
+	if _, err := os.Stat(envFilePath); !os.IsNotExist(err) {
+		t.Errorf("env-file %q still exists after Wait: err=%v", envFilePath, err)
+		os.Remove(envFilePath)
+	}
+}
+
+func TestClamshellExecCleansEnvFileOnStartError(t *testing.T) {
+	// If runner.Start fails after we've written the env-file, Exec must still
+	// remove it — the caller won't receive a Process to Wait on.
+	c, f := newTestClamshell()
+	f.startError = fmt.Errorf("boom")
+
+	// Capture the path by intercepting the recorded start args. We can't know
+	// the path in advance, but we can inspect /tmp after the failure and make
+	// sure the specific tempfile referenced in argv is gone.
+	_, err := c.Exec(context.Background(),
+		Handle{ID: "sess-1", Meta: map[string]string{"container": "sbx"}},
+		[]string{"echo"},
+		ExecOpts{Env: []string{"K=V"}},
+	)
+	if err == nil {
+		t.Fatal("expected start error, got nil")
+	}
+	if len(f.starts) != 1 {
+		t.Fatalf("expected 1 start attempt, got %d", len(f.starts))
+	}
+	envFilePath := f.starts[0].args[5]
+	if envFilePath == "" {
+		t.Fatal("argv missing --env-file path")
+	}
+	if _, statErr := os.Stat(envFilePath); !os.IsNotExist(statErr) {
+		t.Errorf("env-file %q still exists after Start error: err=%v", envFilePath, statErr)
+		os.Remove(envFilePath)
+	}
+}
+
+func TestClamshellExecNoEnvSkipsEnvFile(t *testing.T) {
+	// With no env vars there's nothing to hide, so Exec should skip writing an
+	// env-file and keep the argv shorter. Verifies we don't leak empty tempfiles.
+	c, f := newTestClamshell()
+	f.startProc = &fakeProcess{}
+
+	_, err := c.Exec(context.Background(),
+		Handle{ID: "sess-1", Meta: map[string]string{"container": "sbx"}},
+		[]string{"echo", "hi"},
+		ExecOpts{},
+	)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	call := f.starts[0]
+	for _, a := range call.args {
+		if a == "--env-file" {
+			t.Errorf("argv contains --env-file despite empty Env: %v", call.args)
+		}
 	}
 }
 
@@ -365,6 +460,94 @@ func TestClamshellStopPropagatesCLIError(t *testing.T) {
 	err := c.Stop(context.Background(), Handle{ID: "sess-x"})
 	if err == nil {
 		t.Fatal("expected Stop error, got nil")
+	}
+}
+
+// fakeProcess is a Process whose Wait/Kill return immediately. Tests that
+// exercise cleanup hooks (e.g. envFileProcess) use it so they can call Wait
+// without spinning a real subprocess.
+type fakeProcess struct {
+	waitCount int
+	killCount int
+}
+
+func (p *fakeProcess) Pid() int     { return 0 }
+func (p *fakeProcess) Wait() error  { p.waitCount++; return nil }
+func (p *fakeProcess) Kill() error  { p.killCount++; return nil }
+
+func TestPreparePolicyRejectsNonListTCPEndpoints(t *testing.T) {
+	// If a base policy already has a scalar under tcp_endpoints, silently
+	// overwriting it would drop user config on the floor. Exec must refuse
+	// to proceed so the user sees the mistake instead of a confusing missing
+	// allowlist at runtime.
+	baseDir := t.TempDir()
+	basePath := filepath.Join(baseDir, "bad-policy.yaml")
+	badPolicy := `tcp_endpoints: "not-a-list"
+`
+	if err := os.WriteFile(basePath, []byte(badPolicy), 0o600); err != nil {
+		t.Fatalf("write base policy: %v", err)
+	}
+
+	c, _ := newTestClamshell(runResponse{}) // gateway start
+	_, err := c.Create(context.Background(), Config{
+		Name:      "sess-bad",
+		Workspace: "/tmp/ws",
+		Policy:    basePath,
+		Endpoints: []TCPEndpoint{{Name: "api", Host: "localhost", Port: 4000}},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-list tcp_endpoints, got nil")
+	}
+	if !strings.Contains(err.Error(), "non-list tcp_endpoints") {
+		t.Errorf("error %q does not mention non-list tcp_endpoints", err.Error())
+	}
+}
+
+func TestClamshellCreateStopsSandboxOnPostCreateFailure(t *testing.T) {
+	// If `clamshell sandbox create` succeeds but `sandbox connect` fails,
+	// the sandbox is left running. Create must invoke `sandbox stop <name>`
+	// before returning so we don't leak sandboxes on every discovery error.
+	c, f := newTestClamshell(
+		runResponse{},                                         // gateway start → OK
+		runResponse{},                                         // sandbox create → OK
+		runResponse{stderr: []byte("denied"), err: fmt.Errorf("exit 1")}, // connect → fail
+		runResponse{},                                         // sandbox stop cleanup → OK
+	)
+
+	_, err := c.Create(context.Background(), Config{Name: "sess-leak", Workspace: "/tmp/ws"})
+	if err == nil {
+		t.Fatal("expected connect failure error, got nil")
+	}
+
+	if len(f.runs) != 4 {
+		t.Fatalf("expected 4 CLI calls (gateway, create, connect, stop), got %d: %+v", len(f.runs), f.runs)
+	}
+	stopCall := f.runs[3]
+	if !equalSlice(stopCall.args, []string{"sandbox", "stop", "sess-leak"}) {
+		t.Errorf("cleanup call = %v, want sandbox stop sess-leak", stopCall.args)
+	}
+}
+
+func TestClamshellCreateCleanupErrorIsWrapped(t *testing.T) {
+	// If the cleanup stop itself fails, the original cause must still be the
+	// primary error (the user cares why Create failed, not about the cleanup
+	// attempt), but the cleanup failure should be visible.
+	c, _ := newTestClamshell(
+		runResponse{},
+		runResponse{},
+		runResponse{stdout: []byte(`{"container":""}`)}, // triggers missing-container path
+		runResponse{err: fmt.Errorf("stop-failed")},
+	)
+
+	_, err := c.Create(context.Background(), Config{Name: "sess-both-fail", Workspace: "/tmp/ws"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "container field") {
+		t.Errorf("error %q does not mention original cause", err.Error())
+	}
+	if !strings.Contains(err.Error(), "cleanup stop failed") {
+		t.Errorf("error %q does not mention cleanup failure", err.Error())
 	}
 }
 

--- a/internal/sandbox/clamshell_test.go
+++ b/internal/sandbox/clamshell_test.go
@@ -1,0 +1,396 @@
+//go:build clamshell
+
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// fakeRunner records calls and returns scripted outputs. Tests queue scripted
+// Run responses in order; Start is captured but never actually launches a
+// process (tests that care assert on the recorded argv).
+type fakeRunner struct {
+	runs       []runCall
+	starts     []startCall
+	runScript  []runResponse
+	startProc  Process
+	startError error
+}
+
+type runCall struct {
+	name string
+	args []string
+}
+
+type startCall struct {
+	name string
+	args []string
+	opts ExecOpts
+}
+
+type runResponse struct {
+	stdout []byte
+	stderr []byte
+	err    error
+}
+
+func (f *fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, []byte, error) {
+	f.runs = append(f.runs, runCall{name: name, args: append([]string(nil), args...)})
+	if len(f.runScript) == 0 {
+		return nil, nil, nil
+	}
+	resp := f.runScript[0]
+	f.runScript = f.runScript[1:]
+	return resp.stdout, resp.stderr, resp.err
+}
+
+func (f *fakeRunner) Start(_ context.Context, name string, args []string, opts ExecOpts) (Process, error) {
+	f.starts = append(f.starts, startCall{
+		name: name,
+		args: append([]string(nil), args...),
+		opts: opts,
+	})
+	if f.startError != nil {
+		return nil, f.startError
+	}
+	return f.startProc, nil
+}
+
+// newTestClamshell wires up a Clamshell with a fake runner and canned responses.
+func newTestClamshell(runScript ...runResponse) (*Clamshell, *fakeRunner) {
+	f := &fakeRunner{runScript: runScript}
+	return &Clamshell{cli: "clamshell", docker: "docker", runner: f}, f
+}
+
+func TestClamshellCreateInvokesExpectedCLI(t *testing.T) {
+	c, f := newTestClamshell(
+		runResponse{}, // gateway start → OK
+		runResponse{}, // sandbox create → OK
+		runResponse{stdout: []byte(`{"container":"sbx-abc123"}`)}, // connect → container
+	)
+
+	handle, err := c.Create(context.Background(), Config{
+		Name:      "sess-1",
+		Workspace: "/home/user/workspace",
+		Endpoints: []TCPEndpoint{
+			{Name: "api", Host: "localhost", Port: 4000},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() {
+		if p := handle.Meta["policyFile"]; p != "" {
+			os.Remove(p)
+		}
+	})
+
+	if len(f.runs) != 3 {
+		t.Fatalf("expected 3 clamshell CLI calls, got %d: %+v", len(f.runs), f.runs)
+	}
+
+	// Call 0: gateway start
+	if got := f.runs[0]; got.name != "clamshell" || !equalSlice(got.args, []string{"gateway", "start"}) {
+		t.Errorf("gateway call = %v %v, want clamshell gateway start", got.name, got.args)
+	}
+
+	// Call 1: sandbox create
+	create := f.runs[1]
+	if create.name != "clamshell" {
+		t.Errorf("create binary = %q, want clamshell", create.name)
+	}
+	if len(create.args) != 8 ||
+		create.args[0] != "sandbox" || create.args[1] != "create" ||
+		create.args[2] != "--name" || create.args[3] != "sess-1" ||
+		create.args[4] != "--policy" ||
+		create.args[6] != "--workspace" ||
+		create.args[7] != "/home/user/workspace" {
+		t.Errorf("sandbox create args = %v", create.args)
+	}
+
+	// Call 2: --json sandbox connect
+	connect := f.runs[2]
+	if !equalSlice(connect.args, []string{"--json", "sandbox", "connect", "sess-1"}) {
+		t.Errorf("connect args = %v", connect.args)
+	}
+
+	if handle.Meta["container"] != "sbx-abc123" {
+		t.Errorf("handle container = %q, want sbx-abc123", handle.Meta["container"])
+	}
+	if handle.Meta["policyFile"] == "" {
+		t.Error("handle missing policyFile metadata")
+	}
+}
+
+func TestClamshellCreateMergesEndpointsIntoPolicy(t *testing.T) {
+	// Write a base policy with an existing endpoint.
+	baseDir := t.TempDir()
+	basePath := filepath.Join(baseDir, "policy.yaml")
+	basePolicy := `
+allow:
+  - api.anthropic.com
+tcp_endpoints:
+  - {name: postgres, host: localhost, port: 5432}
+`
+	if err := os.WriteFile(basePath, []byte(basePolicy), 0o600); err != nil {
+		t.Fatalf("write base policy: %v", err)
+	}
+
+	c, f := newTestClamshell(
+		runResponse{},
+		runResponse{},
+		runResponse{stdout: []byte(`{"container":"sbx-xyz"}`)},
+	)
+
+	handle, err := c.Create(context.Background(), Config{
+		Name:      "sess-merge",
+		Workspace: "/tmp/ws",
+		Policy:    basePath,
+		Endpoints: []TCPEndpoint{
+			{Name: "api", Host: "localhost", Port: 4000},
+			{Name: "web", Host: "localhost", Port: 3000},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	policyPath := handle.Meta["policyFile"]
+	t.Cleanup(func() { os.Remove(policyPath) })
+
+	// The sandbox create call must point at the temp policy, not the original.
+	createCall := f.runs[1]
+	gotPolicyArg := ""
+	for i, a := range createCall.args {
+		if a == "--policy" && i+1 < len(createCall.args) {
+			gotPolicyArg = createCall.args[i+1]
+		}
+	}
+	if gotPolicyArg != policyPath {
+		t.Errorf("sandbox create policy arg = %q, want %q", gotPolicyArg, policyPath)
+	}
+
+	// And that temp file must contain the merged endpoints.
+	raw, err := os.ReadFile(policyPath)
+	if err != nil {
+		t.Fatalf("read merged policy: %v", err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse merged policy: %v", err)
+	}
+	endpoints, _ := doc["tcp_endpoints"].([]any)
+	if len(endpoints) != 3 {
+		t.Fatalf("expected 3 endpoints after merge, got %d: %+v", len(endpoints), endpoints)
+	}
+	// The base's postgres entry should still be there.
+	names := map[string]bool{}
+	for _, e := range endpoints {
+		m, _ := e.(map[string]any)
+		if n, ok := m["name"].(string); ok {
+			names[n] = true
+		}
+	}
+	for _, want := range []string{"postgres", "api", "web"} {
+		if !names[want] {
+			t.Errorf("merged policy missing endpoint %q; have %v", want, names)
+		}
+	}
+}
+
+func TestClamshellCreateGatewayFailureReturnsError(t *testing.T) {
+	c, _ := newTestClamshell(
+		runResponse{stderr: []byte("boom"), err: fmt.Errorf("exit 1")},
+	)
+	_, err := c.Create(context.Background(), Config{Name: "sess-fail"})
+	if err == nil {
+		t.Fatal("expected gateway failure error, got nil")
+	}
+	if !strings.Contains(err.Error(), "gateway start") {
+		t.Errorf("error %q does not mention gateway start", err.Error())
+	}
+}
+
+func TestClamshellCreateMissingContainerFieldErrors(t *testing.T) {
+	c, _ := newTestClamshell(
+		runResponse{},
+		runResponse{},
+		runResponse{stdout: []byte(`{"container":""}`)},
+	)
+	_, err := c.Create(context.Background(), Config{Name: "sess-missing"})
+	if err == nil {
+		t.Fatal("expected missing-container error, got nil")
+	}
+	if !strings.Contains(err.Error(), "container field") {
+		t.Errorf("error %q does not mention container field", err.Error())
+	}
+}
+
+func TestClamshellExecBuildsDockerArgv(t *testing.T) {
+	c, f := newTestClamshell()
+	var stdout, stderr bytes.Buffer
+	stdin := strings.NewReader("hi")
+
+	_, err := c.Exec(context.Background(),
+		Handle{ID: "sess-1", Meta: map[string]string{"container": "sbx-abc"}},
+		[]string{"python3", "-m", "hermes_bridge"},
+		ExecOpts{
+			Env:    []string{"ANTHROPIC_API_KEY=secret", "PYTHONPATH=/belayer"},
+			Dir:    "/workspace/arielcharts",
+			Stdin:  stdin,
+			Stdout: &stdout,
+			Stderr: &stderr,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if len(f.starts) != 1 {
+		t.Fatalf("expected 1 docker start, got %d", len(f.starts))
+	}
+	call := f.starts[0]
+	if call.name != "docker" {
+		t.Errorf("runner.Start name = %q, want docker", call.name)
+	}
+
+	// Expected argv prefix: exec -u sandbox -i sbx-abc env ANTHROPIC_API_KEY=secret PYTHONPATH=/belayer sh -lc <cmd>
+	want := []string{
+		"exec", "-u", "sandbox", "-i", "sbx-abc",
+		"env", "ANTHROPIC_API_KEY=secret", "PYTHONPATH=/belayer",
+		"sh", "-lc",
+	}
+	if len(call.args) != len(want)+1 {
+		t.Fatalf("argv length = %d, want %d: %v", len(call.args), len(want)+1, call.args)
+	}
+	for i, w := range want {
+		if call.args[i] != w {
+			t.Errorf("argv[%d] = %q, want %q (full: %v)", i, call.args[i], w, call.args)
+		}
+	}
+
+	// The final arg should be the shell-joined command with a cd prefix.
+	shellCmd := call.args[len(call.args)-1]
+	if !strings.Contains(shellCmd, "cd '/workspace/arielcharts'") {
+		t.Errorf("shell cmd does not cd into Dir: %q", shellCmd)
+	}
+	if !strings.Contains(shellCmd, "'python3' '-m' 'hermes_bridge'") {
+		t.Errorf("shell cmd does not shell-quote argv: %q", shellCmd)
+	}
+
+	// Stdio must be passed through — the daemon depends on stdin for interrupts
+	// and stdout for log capture.
+	if call.opts.Stdin != stdin {
+		t.Error("Exec did not forward Stdin to docker process")
+	}
+	if call.opts.Stdout != &stdout {
+		t.Error("Exec did not forward Stdout to docker process")
+	}
+	if call.opts.Stderr != &stderr {
+		t.Error("Exec did not forward Stderr to docker process")
+	}
+	// Env is folded into argv via `env`; don't also set it on the outer process.
+	if call.opts.Env != nil {
+		t.Errorf("Exec set opts.Env on docker process = %v, want nil", call.opts.Env)
+	}
+}
+
+func TestClamshellExecEmptyCmdErrors(t *testing.T) {
+	c, _ := newTestClamshell()
+	_, err := c.Exec(context.Background(),
+		Handle{ID: "x", Meta: map[string]string{"container": "c"}},
+		[]string{},
+		ExecOpts{},
+	)
+	if err == nil {
+		t.Fatal("expected error for empty cmd, got nil")
+	}
+}
+
+func TestClamshellExecMissingContainerErrors(t *testing.T) {
+	c, _ := newTestClamshell()
+	_, err := c.Exec(context.Background(),
+		Handle{ID: "sess-1", Meta: map[string]string{}},
+		[]string{"echo", "hi"},
+		ExecOpts{},
+	)
+	if err == nil {
+		t.Fatal("expected error for missing container metadata, got nil")
+	}
+	if !strings.Contains(err.Error(), "container") {
+		t.Errorf("error %q does not mention container", err.Error())
+	}
+}
+
+func TestClamshellStopCallsCLIAndRemovesPolicyFile(t *testing.T) {
+	// Create a real temp file so we can verify Stop removes it.
+	tmp, err := os.CreateTemp("", "belayer-test-policy-*.yaml")
+	if err != nil {
+		t.Fatalf("create temp policy: %v", err)
+	}
+	tmp.Close()
+	policyPath := tmp.Name()
+
+	c, f := newTestClamshell(runResponse{}) // sandbox stop → OK
+	err = c.Stop(context.Background(), Handle{
+		ID:   "sess-1",
+		Meta: map[string]string{"policyFile": policyPath},
+	})
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	if len(f.runs) != 1 {
+		t.Fatalf("expected 1 CLI call, got %d", len(f.runs))
+	}
+	if !equalSlice(f.runs[0].args, []string{"sandbox", "stop", "sess-1"}) {
+		t.Errorf("stop args = %v", f.runs[0].args)
+	}
+	if _, err := os.Stat(policyPath); !os.IsNotExist(err) {
+		t.Errorf("policy file still exists after Stop: err=%v", err)
+		os.Remove(policyPath)
+	}
+}
+
+func TestClamshellStopPropagatesCLIError(t *testing.T) {
+	c, _ := newTestClamshell(
+		runResponse{stderr: []byte("not found"), err: fmt.Errorf("exit 2")},
+	)
+	err := c.Stop(context.Background(), Handle{ID: "sess-x"})
+	if err == nil {
+		t.Fatal("expected Stop error, got nil")
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestClamshellInitRegistersRealDriver proves the tagged build replaces the
+// stub. With -tags clamshell set, Default.Get("clamshell") should return a
+// *Clamshell (not the !clamshell stub) and Create should require real CLI
+// availability rather than returning the "built without -tags clamshell"
+// error. We don't actually invoke Create here — just assert the type.
+func TestClamshellInitRegistersRealDriver(t *testing.T) {
+	d, err := Default.Get("clamshell")
+	if err != nil {
+		t.Fatalf("Default.Get(\"clamshell\"): %v", err)
+	}
+	if _, ok := d.(*Clamshell); !ok {
+		t.Errorf("Default.Get(\"clamshell\") = %T, want *Clamshell", d)
+	}
+}

--- a/internal/sandbox/clamshell_test.go
+++ b/internal/sandbox/clamshell_test.go
@@ -396,6 +396,79 @@ func TestClamshellExecNoEnvSkipsEnvFile(t *testing.T) {
 	}
 }
 
+func TestClamshellExecTranslatesHostWorkdirToContainerPath(t *testing.T) {
+	// The daemon passes ExecOpts.Dir as a host-side path (e.g. the absolute
+	// workspace path). Inside the clamshell container the workspace is
+	// mounted at /workspace, so host paths produce a broken `cd`. Exec must
+	// rewrite paths that live under the handle's hostWorkspace.
+	c, f := newTestClamshell()
+	f.startProc = &fakeProcess{}
+
+	_, err := c.Exec(context.Background(),
+		Handle{ID: "sess-1", Meta: map[string]string{
+			"container":     "sbx",
+			"hostWorkspace": "/home/user/workspace",
+		}},
+		[]string{"echo", "hi"},
+		ExecOpts{Dir: "/home/user/workspace/repo/src"},
+	)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	shellCmd := f.starts[0].args[len(f.starts[0].args)-1]
+	if !strings.Contains(shellCmd, "cd '/workspace/repo/src'") {
+		t.Errorf("shell cmd did not translate host workdir: %q", shellCmd)
+	}
+	if strings.Contains(shellCmd, "/home/user/workspace") {
+		t.Errorf("host workspace path leaked into container: %q", shellCmd)
+	}
+}
+
+func TestClamshellExecWorkdirAtWorkspaceRoot(t *testing.T) {
+	c, f := newTestClamshell()
+	f.startProc = &fakeProcess{}
+
+	_, err := c.Exec(context.Background(),
+		Handle{ID: "sess-1", Meta: map[string]string{
+			"container":     "sbx",
+			"hostWorkspace": "/home/user/workspace",
+		}},
+		[]string{"echo", "hi"},
+		ExecOpts{Dir: "/home/user/workspace"},
+	)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	shellCmd := f.starts[0].args[len(f.starts[0].args)-1]
+	if !strings.Contains(shellCmd, "cd '/workspace'") {
+		t.Errorf("workspace root did not translate to /workspace: %q", shellCmd)
+	}
+}
+
+func TestClamshellExecContainerPathPassesThrough(t *testing.T) {
+	// Callers that already compute container-side paths (or the daemon once
+	// it gains mount-aware planning) must still work. Paths outside the host
+	// workspace are preserved verbatim.
+	c, f := newTestClamshell()
+	f.startProc = &fakeProcess{}
+
+	_, err := c.Exec(context.Background(),
+		Handle{ID: "sess-1", Meta: map[string]string{
+			"container":     "sbx",
+			"hostWorkspace": "/home/user/workspace",
+		}},
+		[]string{"echo", "hi"},
+		ExecOpts{Dir: "/workspace/nested"},
+	)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	shellCmd := f.starts[0].args[len(f.starts[0].args)-1]
+	if !strings.Contains(shellCmd, "cd '/workspace/nested'") {
+		t.Errorf("container path not preserved: %q", shellCmd)
+	}
+}
+
 func TestClamshellExecEmptyCmdErrors(t *testing.T) {
 	c, _ := newTestClamshell()
 	_, err := c.Exec(context.Background(),

--- a/internal/sandbox/noop.go
+++ b/internal/sandbox/noop.go
@@ -6,6 +6,10 @@ import (
 	"os/exec"
 )
 
+func init() {
+	Register("noop", &Noop{})
+}
+
 // Noop is a no-isolation driver that runs commands via direct exec.
 // It has zero overhead and is the default driver for Belayer.
 // Use this when no sandbox isolation is needed.

--- a/internal/sandbox/registry.go
+++ b/internal/sandbox/registry.go
@@ -25,8 +25,17 @@ func Register(name string, d Driver) {
 	Default.Register(name, d)
 }
 
-// Register installs d under name in this registry.
+// Register installs d under name in this registry. Panics on empty name or
+// nil driver: Register is only called from driver init() functions, so a bad
+// registration is a programmer error that should surface immediately rather
+// than as a nil-deref from Get at session-create time.
 func (r *Registry) Register(name string, d Driver) {
+	if name == "" {
+		panic("sandbox.Registry.Register: empty driver name")
+	}
+	if d == nil {
+		panic(fmt.Sprintf("sandbox.Registry.Register: nil driver for %q", name))
+	}
 	if r.drivers == nil {
 		r.drivers = map[string]Driver{}
 	}

--- a/internal/sandbox/registry.go
+++ b/internal/sandbox/registry.go
@@ -1,0 +1,49 @@
+package sandbox
+
+import "fmt"
+
+// Registry maps driver names to Driver implementations. Drivers register
+// themselves via the package-level Register function from their init(), so
+// every non-tagged-out driver file contributes exactly one entry to Default.
+//
+// The daemon resolves a per-session driver by asking Get(mode), where mode
+// comes from .belayer/config.yaml's sandbox.mode. A missing registration
+// surfaces as a clear error; this is how the clamshell stub turns
+// sandbox.mode: clamshell into a useful message when the real driver wasn't
+// compiled in.
+type Registry struct {
+	drivers map[string]Driver
+}
+
+// Default is the process-wide registry populated by driver init() functions.
+// cmd/belayer hands this to daemon.Config.SandboxDrivers.
+var Default = &Registry{drivers: map[string]Driver{}}
+
+// Register installs d under name in the Default registry. Intended to be
+// called from init() functions of driver files.
+func Register(name string, d Driver) {
+	Default.Register(name, d)
+}
+
+// Register installs d under name in this registry.
+func (r *Registry) Register(name string, d Driver) {
+	if r.drivers == nil {
+		r.drivers = map[string]Driver{}
+	}
+	r.drivers[name] = d
+}
+
+// Get returns the driver registered for name, or an error naming it when
+// nothing is registered. A driver registration with a stub (e.g. the
+// clamshell_stub on default builds) is NOT a Get error — Get only fails on
+// missing names. The stub reports unavailability from Create/Exec/Stop.
+func (r *Registry) Get(name string) (Driver, error) {
+	if r == nil || r.drivers == nil {
+		return nil, fmt.Errorf("sandbox driver %q is not registered", name)
+	}
+	d, ok := r.drivers[name]
+	if !ok {
+		return nil, fmt.Errorf("sandbox driver %q is not registered", name)
+	}
+	return d, nil
+}

--- a/internal/sandbox/registry_test.go
+++ b/internal/sandbox/registry_test.go
@@ -1,0 +1,78 @@
+package sandbox_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/donovan-yohan/belayer/internal/sandbox"
+)
+
+func TestDefaultRegistryResolvesNoop(t *testing.T) {
+	d, err := sandbox.Default.Get("noop")
+	if err != nil {
+		t.Fatalf("Default.Get(\"noop\") returned error: %v", err)
+	}
+	if d == nil {
+		t.Fatal("Default.Get(\"noop\") returned nil driver")
+	}
+	if _, ok := d.(*sandbox.Noop); !ok {
+		t.Errorf("Default.Get(\"noop\") returned %T, want *sandbox.Noop", d)
+	}
+}
+
+func TestDefaultRegistryResolvesClamshellStub(t *testing.T) {
+	// The clamshell name is registered in all builds — the !clamshell stub
+	// on default builds, the real driver when -tags clamshell is set.
+	// Get must succeed either way; the stub surfaces unavailability from
+	// its methods, not from registry lookup.
+	d, err := sandbox.Default.Get("clamshell")
+	if err != nil {
+		t.Fatalf("Default.Get(\"clamshell\") returned error: %v", err)
+	}
+	if d == nil {
+		t.Fatal("Default.Get(\"clamshell\") returned nil driver")
+	}
+}
+
+func TestDefaultRegistryReturnsErrorForUnknownName(t *testing.T) {
+	_, err := sandbox.Default.Get("does-not-exist")
+	if err == nil {
+		t.Fatal("Default.Get(\"does-not-exist\") returned nil error, want not-registered error")
+	}
+	if !strings.Contains(err.Error(), "not registered") {
+		t.Errorf("error %q does not mention \"not registered\"", err.Error())
+	}
+	if !strings.Contains(err.Error(), "does-not-exist") {
+		t.Errorf("error %q does not name the missing driver", err.Error())
+	}
+}
+
+func TestRegistryRegisterAndGet(t *testing.T) {
+	reg := &sandbox.Registry{}
+	reg.Register("fake", &sandbox.Noop{})
+
+	d, err := reg.Get("fake")
+	if err != nil {
+		t.Fatalf("Get(\"fake\") returned error: %v", err)
+	}
+	if d == nil {
+		t.Fatal("Get(\"fake\") returned nil driver")
+	}
+}
+
+func TestRegistryNilGetReturnsError(t *testing.T) {
+	var reg *sandbox.Registry
+	_, err := reg.Get("anything")
+	if err == nil {
+		t.Fatal("nil Registry Get returned nil error, want not-registered error")
+	}
+}
+
+func TestRegistryEmptyGetReturnsError(t *testing.T) {
+	reg := &sandbox.Registry{}
+	_, err := reg.Get("anything")
+	if err == nil {
+		t.Fatal("empty Registry Get returned nil error, want not-registered error")
+	}
+}
+

--- a/internal/sandbox/registry_test.go
+++ b/internal/sandbox/registry_test.go
@@ -76,3 +76,23 @@ func TestRegistryEmptyGetReturnsError(t *testing.T) {
 	}
 }
 
+func TestRegistryRegisterEmptyNamePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Register with empty name did not panic")
+		}
+	}()
+	reg := &sandbox.Registry{}
+	reg.Register("", &sandbox.Noop{})
+}
+
+func TestRegistryRegisterNilDriverPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Register with nil driver did not panic")
+		}
+	}()
+	reg := &sandbox.Registry{}
+	reg.Register("fake", nil)
+}
+

--- a/internal/sandbox/settings.go
+++ b/internal/sandbox/settings.go
@@ -52,5 +52,11 @@ func LoadSettings(workdir string) (Settings, error) {
 	if err := yaml.Unmarshal(data, &f); err != nil {
 		return Settings{}, fmt.Errorf("sandbox: parse config: %w", err)
 	}
+	// Policy paths in config.yaml are written relative to the workspace root
+	// (e.g. ".belayer/policies/default.yaml"). The daemon's cwd is unrelated,
+	// so anchor non-absolute paths to workdir before handing them to drivers.
+	if f.Sandbox.Policy != "" && !filepath.IsAbs(f.Sandbox.Policy) {
+		f.Sandbox.Policy = filepath.Join(workdir, f.Sandbox.Policy)
+	}
 	return f.Sandbox, nil
 }

--- a/internal/sandbox/settings.go
+++ b/internal/sandbox/settings.go
@@ -1,0 +1,56 @@
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// DefaultMode is the driver name resolved when .belayer/config.yaml has no
+// sandbox section (or no sandbox.mode). The noop driver ships with belayer
+// and is registered unconditionally.
+const DefaultMode = "noop"
+
+// Settings holds the sandbox section of .belayer/config.yaml. A zero Settings
+// signals default-noop behavior; see Settings.ModeOrDefault.
+type Settings struct {
+	Mode   string `yaml:"mode"`
+	Policy string `yaml:"policy"`
+}
+
+// ModeOrDefault returns Mode when non-empty, or DefaultMode otherwise.
+func (s Settings) ModeOrDefault() string {
+	if s.Mode == "" {
+		return DefaultMode
+	}
+	return s.Mode
+}
+
+type settingsFile struct {
+	Sandbox Settings `yaml:"sandbox"`
+}
+
+// LoadSettings reads the sandbox section from <workdir>/.belayer/config.yaml.
+// A missing file, empty workdir, or missing section returns a zero Settings
+// and nil error; callers treat an empty Mode as DefaultMode via ModeOrDefault.
+func LoadSettings(workdir string) (Settings, error) {
+	if workdir == "" {
+		return Settings{}, nil
+	}
+	path := filepath.Join(workdir, ".belayer", "config.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Settings{}, nil
+		}
+		return Settings{}, fmt.Errorf("sandbox: read config: %w", err)
+	}
+	var f settingsFile
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return Settings{}, fmt.Errorf("sandbox: parse config: %w", err)
+	}
+	return f.Sandbox, nil
+}

--- a/internal/sandbox/settings_test.go
+++ b/internal/sandbox/settings_test.go
@@ -48,8 +48,11 @@ sandbox:
 	if s.Mode != "clamshell" {
 		t.Errorf("Mode = %q, want clamshell", s.Mode)
 	}
-	if s.Policy != ".belayer/policies/belayer-standard.yaml" {
-		t.Errorf("Policy = %q, want .belayer/policies/belayer-standard.yaml", s.Policy)
+	// Relative Policy paths in config.yaml must be anchored to workdir so
+	// drivers can os.ReadFile them regardless of the daemon's cwd.
+	wantPolicy := filepath.Join(dir, ".belayer/policies/belayer-standard.yaml")
+	if s.Policy != wantPolicy {
+		t.Errorf("Policy = %q, want %q", s.Policy, wantPolicy)
 	}
 	if got := s.ModeOrDefault(); got != "clamshell" {
 		t.Errorf("ModeOrDefault = %q, want clamshell", got)
@@ -72,6 +75,22 @@ runtime:
 	}
 	if got := s.ModeOrDefault(); got != sandbox.DefaultMode {
 		t.Errorf("ModeOrDefault = %q, want %q", got, sandbox.DefaultMode)
+	}
+}
+
+func TestLoadSettingsAbsolutePolicyIsPreserved(t *testing.T) {
+	dir := t.TempDir()
+	writeConfigYAML(t, dir, `
+sandbox:
+  mode: clamshell
+  policy: /etc/belayer/strict.yaml
+`)
+	s, err := sandbox.LoadSettings(dir)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if s.Policy != "/etc/belayer/strict.yaml" {
+		t.Errorf("absolute Policy = %q, want unchanged", s.Policy)
 	}
 }
 

--- a/internal/sandbox/settings_test.go
+++ b/internal/sandbox/settings_test.go
@@ -1,0 +1,96 @@
+package sandbox_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/donovan-yohan/belayer/internal/sandbox"
+)
+
+func TestLoadSettingsMissingFileReturnsZero(t *testing.T) {
+	s, err := sandbox.LoadSettings(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadSettings with no config.yaml returned error: %v", err)
+	}
+	if s.Mode != "" || s.Policy != "" {
+		t.Errorf("expected zero Settings, got %+v", s)
+	}
+	if got := s.ModeOrDefault(); got != sandbox.DefaultMode {
+		t.Errorf("ModeOrDefault on zero Settings = %q, want %q", got, sandbox.DefaultMode)
+	}
+}
+
+func TestLoadSettingsEmptyWorkdirReturnsZero(t *testing.T) {
+	s, err := sandbox.LoadSettings("")
+	if err != nil {
+		t.Fatalf("LoadSettings(\"\") returned error: %v", err)
+	}
+	if s.Mode != "" {
+		t.Errorf("expected empty Mode, got %q", s.Mode)
+	}
+}
+
+func TestLoadSettingsParsesSandboxSection(t *testing.T) {
+	dir := t.TempDir()
+	writeConfigYAML(t, dir, `
+runtime:
+  up: "pnpm dev"
+sandbox:
+  mode: clamshell
+  policy: .belayer/policies/belayer-standard.yaml
+`)
+
+	s, err := sandbox.LoadSettings(dir)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if s.Mode != "clamshell" {
+		t.Errorf("Mode = %q, want clamshell", s.Mode)
+	}
+	if s.Policy != ".belayer/policies/belayer-standard.yaml" {
+		t.Errorf("Policy = %q, want .belayer/policies/belayer-standard.yaml", s.Policy)
+	}
+	if got := s.ModeOrDefault(); got != "clamshell" {
+		t.Errorf("ModeOrDefault = %q, want clamshell", got)
+	}
+}
+
+func TestLoadSettingsMissingSectionYieldsDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeConfigYAML(t, dir, `
+runtime:
+  up: "pnpm dev"
+`)
+
+	s, err := sandbox.LoadSettings(dir)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if s.Mode != "" {
+		t.Errorf("Mode = %q, want empty", s.Mode)
+	}
+	if got := s.ModeOrDefault(); got != sandbox.DefaultMode {
+		t.Errorf("ModeOrDefault = %q, want %q", got, sandbox.DefaultMode)
+	}
+}
+
+func TestLoadSettingsInvalidYAMLReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeConfigYAML(t, dir, "sandbox: [not-a-map\n")
+	_, err := sandbox.LoadSettings(dir)
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+}
+
+func writeConfigYAML(t *testing.T, dir, contents string) {
+	t.Helper()
+	belayerDir := filepath.Join(dir, ".belayer")
+	if err := os.MkdirAll(belayerDir, 0o700); err != nil {
+		t.Fatalf("mkdir .belayer: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(belayerDir, "config.yaml"), []byte(contents), 0o600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of `docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md` — the sandbox driver registry plus a build-tagged clamshell driver.

- Replaces the daemon-wide `sandbox.Driver` with a name-keyed `Registry` populated by each driver's `init()`. Sessions resolve their driver from `.belayer/config.yaml`'s `sandbox.mode`, defaulting to `noop`.
- Adds the clamshell driver behind `//go:build clamshell`. Default builds get a stub at the same registration that returns `sandbox driver "clamshell" is unavailable: this binary was built without -tags clamshell` — the daemon keeps running for other sessions.
- Clamshell driver wraps the `clamshell` CLI (gateway/create/connect/stop) and uses `docker exec -u sandbox -i <container> env … sh -lc …` for agent spawns, with a `commandRunner` abstraction so Create/Exec/Stop are unit-testable without a Lima VM.

## Branching

Stacked on top of `feat/runtime-phase5-wiring` so the Phase 5 runtime wiring stays separate. Two commits split the review: (1) registry + stub + daemon plumbing + default-build tests + design-doc refinement, (2) clamshell driver + tagged tests.

## Test plan
- [x] `go build ./...`
- [x] `go build -tags clamshell ./...`
- [x] `go vet ./...`
- [x] `go vet -tags clamshell ./...`
- [x] `go test ./...`
- [x] `go test -tags clamshell ./...`
- [x] Default binary contains the "built without -tags clamshell" stub text and no `sandbox/clamshell: gateway` call strings; tagged binary is the mirror.
- [ ] Manual: Lima VM with `clamshell` CLI installed — exercise Create/Exec/Stop end-to-end (deferred to Phase 5 integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)