### PR TITLE
feat(run): rename --task to --spec, persist as SPEC.md artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ go build ./cmd/belayer
 belayer daemon
 
 # Launch a run (creates session, spawns planner via Hermes bridge)
-belayer run start --task "Add rate limiting to /api/v1/cards" --workdir /path/to/repo
+belayer run start --spec "Add rate limiting to /api/v1/cards" --workdir /path/to/repo
 
 # Monitor
 belayer status

--- a/agents/pm/agents.md
+++ b/agents/pm/agents.md
@@ -10,9 +10,14 @@ You receive a verification request with:
 ## Verification Process
 
 1. Read the spec. The operator's spec is always registered as `kind: spec`,
-   `producer: operator` — it lives at `.belayer/runs/<session-id>/SPEC.md`.
-   If the supervisor named a more detailed spec_artifact, read that too and
-   treat the operator SPEC.md as the authoritative source of intent.
+   `producer: operator` — locate it in the registered artifacts list and read
+   it using the path the daemon registered. Do not assume a hardcoded relative
+   path such as `.belayer/runs/<session-id>/SPEC.md` from your current working
+   directory; in multi-repo runs your cwd is inside the provisioned workspace
+   and that path will not resolve. A workspace-local `SPEC.md` copy may also be
+   reachable at cwd root as a convenience. If the supervisor named a more
+   detailed spec_artifact, read that too and treat the operator spec artifact
+   as the authoritative source of intent.
 2. Use `git diff` or `git log` to see what changed during this run
 3. Walk through the spec section by section — for each requirement, find evidence in the code
 4. Check for deferred work: TODO comments, placeholder implementations, empty test bodies

--- a/agents/pm/agents.md
+++ b/agents/pm/agents.md
@@ -4,12 +4,15 @@
 
 You receive a verification request with:
 1. The supervisor's summary of what was accomplished
-2. The spec artifact path (if registered)
+2. The spec artifact path (if the supervisor named one explicitly)
 3. A list of all registered artifacts in the session
 
 ## Verification Process
 
-1. Read the spec artifact (or find the spec in the workspace if none was registered)
+1. Read the spec. The operator's spec is always registered as `kind: spec`,
+   `producer: operator` — it lives at `.belayer/runs/<session-id>/SPEC.md`.
+   If the supervisor named a more detailed spec_artifact, read that too and
+   treat the operator SPEC.md as the authoritative source of intent.
 2. Use `git diff` or `git log` to see what changed during this run
 3. Walk through the spec section by section — for each requirement, find evidence in the code
 4. Check for deferred work: TODO comments, placeholder implementations, empty test bodies

--- a/agents/supervisor/system-prompt.md
+++ b/agents/supervisor/system-prompt.md
@@ -4,12 +4,16 @@ You decompose work, delegate to your team, interpret results, and decide what ha
 
 ## Reading specs and operator messages
 
-The operator's spec for this run is always written to
-`.belayer/runs/<session-id>/SPEC.md` and registered as an artifact with
-`kind: spec`, `producer: operator`. Your first instruction message contains the
-same text inline for convenience, but SPEC.md is the canonical source of truth —
-the PM will verify against it, and any specialists you spawn should be pointed
-at it rather than handed re-summarized fragments.
+The operator's spec for this run is registered as an artifact with
+`kind: spec`, `producer: operator` — look it up in the session's artifact
+registry and read it using the `path` the daemon registered. That registered
+path is the canonical source of truth. Your first instruction message contains
+the same text inline for convenience, and a workspace-local `SPEC.md` copy may
+also be reachable from your cwd, but do not rely on a hardcoded relative path
+such as `.belayer/runs/<session-id>/SPEC.md` — in multi-repo runs your cwd is
+inside the provisioned workspace and that path will not resolve. The PM will
+verify against the registered spec artifact, and any specialists you spawn
+should be pointed at it rather than handed re-summarized fragments.
 
 When you receive an operator message or a spec reference, you MUST read the entire document before planning or delegating. Do not truncate, skim, or read partial content. If a file is long, read it in chunks until you reach the end. Plans built from partial specs produce incomplete work.
 

--- a/agents/supervisor/system-prompt.md
+++ b/agents/supervisor/system-prompt.md
@@ -4,6 +4,13 @@ You decompose work, delegate to your team, interpret results, and decide what ha
 
 ## Reading specs and operator messages
 
+The operator's spec for this run is always written to
+`.belayer/runs/<session-id>/SPEC.md` and registered as an artifact with
+`kind: spec`, `producer: operator`. Your first instruction message contains the
+same text inline for convenience, but SPEC.md is the canonical source of truth —
+the PM will verify against it, and any specialists you spawn should be pointed
+at it rather than handed re-summarized fragments.
+
 When you receive an operator message or a spec reference, you MUST read the entire document before planning or delegating. Do not truncate, skim, or read partial content. If a file is long, read it in chunks until you reach the end. Plans built from partial specs produce incomplete work.
 
 ## Your default team

--- a/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
+++ b/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
@@ -86,7 +86,7 @@ For multi-repo setups, `.belayer/config.yaml` can't live in any single repo beca
 For local dev without crag, pass a workspace config explicitly:
 
 ```bash
-belayer run start --workspace ~/.belayer/workspaces/extend-fullstack.yaml --task "..."
+belayer run start --workspace ~/.belayer/workspaces/extend-fullstack.yaml --spec "..."
 ```
 
 Resolution:
@@ -533,7 +533,7 @@ worker:
    limactl shell devbox -- bash -c '
      cd ~/Documents/Programs/personal/arielcharts
      belayer daemon &
-     belayer run start --task "Add dark mode"
+     belayer run start --spec "Add dark mode"
    '
 4. crag polls: limactl shell devbox -- belayer status
 5. On completion, crag records result

--- a/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
+++ b/docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md
@@ -83,15 +83,19 @@ Six default agents — **supervisor, pm, web-dev, backend-dev, qa, reviewer**. U
 
 For multi-repo setups, `.belayer/config.yaml` can't live in any single repo because the workspace is assembled at session start. Instead, the workspace definition lives in **crag** — the outer daemon that submits requests to workers. Crag is infrastructure (a server with a database), not source code. It knows "extend-fullstack means these repos with this config."
 
-For local dev without crag, pass a workspace config explicitly:
+For local dev without crag, the eventual interface is to pass a workspace
+config explicitly. A `--workspace` flag is *planned but not yet implemented*
+— the current CLI accepts `--workdir` plus a comma-separated `--repos`
+mapping (see `belayer run start --help`). The planned shape:
 
 ```bash
+# Planned — not yet implemented. Today: use --workdir / --repos.
 belayer run start --workspace ~/.belayer/workspaces/extend-fullstack.yaml --spec "..."
 ```
 
-Resolution:
+Resolution (target state):
 - **Single-repo**: `.belayer/config.yaml` in the repo, auto-discovered
-- **Multi-repo**: workspace definition from crag or `--workspace` flag
+- **Multi-repo**: workspace definition from crag or `--workspace` flag (planned)
 - **No config**: `belayer run` auto-runs `belayer init` and scaffolds the six-agent default team
 
 ## Phase 2.5: `belayer init` workflow

--- a/hermes_bridge/tools.py
+++ b/hermes_bridge/tools.py
@@ -103,7 +103,11 @@ CREATE_ARTIFACT_SCHEMA = {
         "For revisions, write to a new path (e.g. add a version suffix or bump the kind) and "
         "register that.\n"
         "- 'kind' is a free-form tag but downstream consumers (PM, reflection) match on it — "
-        "stick to consistent kinds across a project (e.g. 'spec', 'design-doc', 'review-report')."
+        "stick to consistent kinds across a project (e.g. 'spec', 'design-doc', 'review-report').\n"
+        "- The pair (kind='spec', producer='operator') is RESERVED for the run-level SPEC.md the "
+        "daemon writes at `belayer run start`. Don't register your own artifact under that pair; "
+        "use a more specific kind (e.g. 'design-spec', 'feature-spec') or set producer to your "
+        "own agent name."
     ),
     "parameters": {
         "type": "object",
@@ -324,11 +328,12 @@ REQUEST_COMPLETION_SCHEMA = {
             "spec_artifact": {
                 "type": "string",
                 "description": (
-                    "Optional path to the spec or design-doc artifact (e.g. "
-                    "'artifacts/checkout-flow.spec.md'). If omitted, the PM searches the "
-                    "artifact registry for kinds 'spec' or 'design-doc'. Provide it "
-                    "explicitly when there are multiple specs in play and you want the PM to "
-                    "verify against a specific one."
+                    "Optional path to the spec or design-doc artifact. If omitted, the PM "
+                    "defaults to the operator-written SPEC.md (registered as kind='spec', "
+                    "producer='operator' at run start) and falls back to other 'spec' / "
+                    "'design-doc' artifacts in the registry. Provide it explicitly when "
+                    "the supervisor expanded the operator spec into a more detailed design "
+                    "doc and wants the PM to verify against that instead."
                 ),
             },
         },

--- a/hermes_bridge/tools.py
+++ b/hermes_bridge/tools.py
@@ -104,10 +104,11 @@ CREATE_ARTIFACT_SCHEMA = {
         "register that.\n"
         "- 'kind' is a free-form tag but downstream consumers (PM, reflection) match on it — "
         "stick to consistent kinds across a project (e.g. 'spec', 'design-doc', 'review-report').\n"
-        "- The pair (kind='spec', producer='operator') is RESERVED for the run-level SPEC.md the "
-        "daemon writes at `belayer run start`. Don't register your own artifact under that pair; "
-        "use a more specific kind (e.g. 'design-spec', 'feature-spec') or set producer to your "
-        "own agent name."
+        "- By convention, the pair (kind='spec', producer='operator') is used for the run-level "
+        "SPEC.md registered by `belayer run start` from the operator's --spec text. The "
+        "artifacts API does not currently enforce that reservation, so don't register your own "
+        "artifact under that pair; use a more specific kind (e.g. 'design-spec', 'feature-spec') "
+        "or set producer to your own agent name."
     ),
     "parameters": {
         "type": "object",

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -84,7 +84,7 @@ func newRunStartCmd() *cobra.Command {
 			// Persist the operator's spec to disk + register it as an artifact so
 			// every agent (and the PM gate) reads the same source of truth instead
 			// of mining `belayer message list` for the supervisor's instruction.
-			specRel, err := writeSpecArtifact(c, baseDir, sess.ID, spec)
+			specRel, err := writeSpecArtifact(c, baseDir, sess.ID, supervisorWorkdir, spec)
 			if err != nil {
 				return fmt.Errorf("persist spec: %w", err)
 			}
@@ -197,23 +197,48 @@ func provisionWorkspace(baseDir, sessionID string, repos map[string]string) (str
 // .belayer/runs/<sessionID>/SPEC.md and registers it as an artifact with
 // kind=spec, producer=operator. This is the canonical operator-input artifact:
 // every agent (and the PM gate) reads SPEC.md instead of mining the message log
-// for the supervisor's first instruction. Returns the absolute path written.
-func writeSpecArtifact(c *Client, baseDir, sessionID, spec string) (string, error) {
+// for the supervisor's first instruction.
+//
+// The registered artifact Path follows the workspace-relative convention
+// documented in CREATE_ARTIFACT_SCHEMA: paths are resolvable from the agent's
+// workspace root (supervisorWorkdir). In multi-repo mode the agent cwd is
+// .belayer/runs/<id>/workspace/, which cannot reach ../SPEC.md when the
+// workspace is sandboxed, so SPEC.md is also linked into the workspace root.
+// Returns the registered workspace-relative path.
+func writeSpecArtifact(c *Client, baseDir, sessionID, supervisorWorkdir, spec string) (string, error) {
 	runDir := filepath.Join(baseDir, ".belayer", "runs", sessionID)
 	if err := os.MkdirAll(runDir, 0o700); err != nil {
 		return "", fmt.Errorf("create run dir: %w", err)
 	}
-	specPath := filepath.Join(runDir, "SPEC.md")
-	if err := os.WriteFile(specPath, []byte(spec), 0o600); err != nil {
+	specAbs := filepath.Join(runDir, "SPEC.md")
+	if err := os.WriteFile(specAbs, []byte(spec), 0o600); err != nil {
 		return "", fmt.Errorf("write SPEC.md: %w", err)
 	}
+
+	// Path to register with the artifact API, relative to the agent's
+	// workspace root. Single-repo runs have supervisorWorkdir == baseDir so
+	// the path is the canonical on-disk location. Multi-repo runs set
+	// supervisorWorkdir to the provisioned workspace dir, so we mirror
+	// SPEC.md into the workspace root and register it there.
+	registeredPath := filepath.Join(".belayer", "runs", sessionID, "SPEC.md")
+	if supervisorWorkdir != "" && supervisorWorkdir != baseDir {
+		linkPath := filepath.Join(supervisorWorkdir, "SPEC.md")
+		if err := os.Symlink(specAbs, linkPath); err != nil {
+			// Fall back to a plain copy if symlinks are unavailable (e.g. cross-device, Windows).
+			if writeErr := os.WriteFile(linkPath, []byte(spec), 0o600); writeErr != nil {
+				return "", fmt.Errorf("place SPEC.md in workspace: %w (symlink: %v)", writeErr, err)
+			}
+		}
+		registeredPath = "SPEC.md"
+	}
+
 	if _, err := c.CreateArtifact(sessionID, artifactCreateCLIRequest{
 		Kind:     "spec",
-		Path:     specPath,
+		Path:     registeredPath,
 		Producer: "operator",
 		Summary:  "Initial run spec from operator (--spec text passed to belayer run start).",
 	}); err != nil {
 		return "", fmt.Errorf("register spec artifact: %w", err)
 	}
-	return specPath, nil
+	return registeredPath, nil
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -20,13 +20,13 @@ func newRunCmd() *cobra.Command {
 }
 
 func newRunStartCmd() *cobra.Command {
-	var socket, name, task, supervisorProfile, workdir, reposFlag string
+	var socket, name, spec, supervisorProfile, workdir, reposFlag string
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: "Create a run, spawn supervisor, and deliver the initial task",
+		Short: "Create a run, spawn supervisor, and deliver the initial spec",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if strings.TrimSpace(task) == "" {
-				return fmt.Errorf("--task is required")
+			if strings.TrimSpace(spec) == "" {
+				return fmt.Errorf("--spec is required")
 			}
 			if strings.TrimSpace(supervisorProfile) == "" {
 				return fmt.Errorf("--supervisor-profile is required")
@@ -80,21 +80,32 @@ func newRunStartCmd() *cobra.Command {
 			if _, err := c.UpdateSession(sess.ID, "running"); err != nil {
 				return fmt.Errorf("mark session running: %w", err)
 			}
+
+			// Persist the operator's spec to disk + register it as an artifact so
+			// every agent (and the PM gate) reads the same source of truth instead
+			// of mining `belayer message list` for the supervisor's instruction.
+			specRel, err := writeSpecArtifact(c, baseDir, sess.ID, spec)
+			if err != nil {
+				return fmt.Errorf("persist spec: %w", err)
+			}
+
 			if _, err := c.SpawnAgent(sess.ID, spawnAgentRequest{Name: "supervisor", Role: "supervisor", Profile: supervisorProfile, Workdir: supervisorWorkdir}); err != nil {
 				return fmt.Errorf("spawn supervisor: %w", err)
 			}
-			if _, err := c.SendMessage(sess.ID, "supervisor", task, "instruction", true); err != nil {
-				return fmt.Errorf("deliver initial task: %w", err)
+			if _, err := c.SendMessage(sess.ID, "supervisor", spec, "instruction", true); err != nil {
+				return fmt.Errorf("deliver initial spec: %w", err)
 			}
 			// Log the initial prompt as telemetry so post-mortems can see what started the run.
 			initData, _ := json.Marshal(map[string]string{
-				"task":               task,
+				"spec":               spec,
+				"spec_path":          specRel,
 				"supervisor_profile": supervisorProfile,
 			})
 			_ = c.LogEvent(sess.ID, "run_initiated", string(initData))
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Run started: %s (%s)\n", sess.ID, sess.Name)
 			fmt.Fprintln(cmd.OutOrStdout(), "Supervisor: supervisor")
+			fmt.Fprintf(cmd.OutOrStdout(), "Spec: %s\n", specRel)
 			if len(repos) > 0 {
 				fmt.Fprintln(cmd.OutOrStdout(), "Repos:")
 				for repoName, repoPath := range repos {
@@ -111,7 +122,7 @@ func newRunStartCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
 	cmd.Flags().StringVar(&name, "name", "", "Run/session name")
-	cmd.Flags().StringVar(&task, "task", "", "Initial task text for the supervisor")
+	cmd.Flags().StringVar(&spec, "spec", "", "Initial spec text — written to .belayer/runs/<id>/SPEC.md and registered as the operator artifact")
 	cmd.Flags().StringVar(&supervisorProfile, "supervisor-profile", "", "Hermes profile for the supervisor")
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Working directory (defaults to cwd)")
 	cmd.Flags().StringVar(&reposFlag, "repos", "", "Repos to include: name=path,name=path (e.g. frontend=../fe,backend=../be)")
@@ -180,4 +191,29 @@ func provisionWorkspace(baseDir, sessionID string, repos map[string]string) (str
 	}
 
 	return workspaceDir, nil
+}
+
+// writeSpecArtifact persists the operator's --spec text to
+// .belayer/runs/<sessionID>/SPEC.md and registers it as an artifact with
+// kind=spec, producer=operator. This is the canonical operator-input artifact:
+// every agent (and the PM gate) reads SPEC.md instead of mining the message log
+// for the supervisor's first instruction. Returns the absolute path written.
+func writeSpecArtifact(c *Client, baseDir, sessionID, spec string) (string, error) {
+	runDir := filepath.Join(baseDir, ".belayer", "runs", sessionID)
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		return "", fmt.Errorf("create run dir: %w", err)
+	}
+	specPath := filepath.Join(runDir, "SPEC.md")
+	if err := os.WriteFile(specPath, []byte(spec), 0o600); err != nil {
+		return "", fmt.Errorf("write SPEC.md: %w", err)
+	}
+	if _, err := c.CreateArtifact(sessionID, artifactCreateCLIRequest{
+		Kind:     "spec",
+		Path:     specPath,
+		Producer: "operator",
+		Summary:  "Initial run spec from operator (--spec text passed to belayer run start).",
+	}); err != nil {
+		return "", fmt.Errorf("register spec artifact: %w", err)
+	}
+	return specPath, nil
 }


### PR DESCRIPTION
## Summary

- Renames `belayer run start --task` → `--spec` to align with the artifact vocabulary the daemon already uses.
- Writes the operator's spec text to `.belayer/runs/<session-id>/SPEC.md` and registers it as an artifact with `kind: spec`, `producer: operator`.
- Reserves `(kind=spec, producer=operator)` as the canonical operator-input artifact: schema docs and PM/supervisor prompts now point at SPEC.md as the source of truth.

## Why

Today only the supervisor sees the `--task` text directly. The PM has to mine `belayer message list` to find what the run was actually about, and implementers receive whatever fragment the supervisor decided to put in their spawn message — pure telephone game. With SPEC.md in the artifact registry, the PM gate, supervisor, and any specialist can all read the same document.

## Stacked PR

Stacked on #76 (`feat/default-team-and-init`). Merge that first; this PR will rebase onto `master` automatically.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/...` passes (no test referenced `--task` directly)
- [ ] End-to-end: `belayer run start --spec "test"` writes `.belayer/runs/<id>/SPEC.md` and `belayer artifact list` shows `kind=spec, producer=operator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)