### PR TITLE
feat(clamshell): e2e proof — proxy keepalive, godotenv credentials, SANDBOXING docs

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -1,0 +1,11 @@
+# Belayer Execution Plans
+
+## Active Plans
+
+| Plan | Goal | Created |
+|------|------|---------|
+| [2026-04-17-clamshell-e2e-proof](exec-plans/active/2026-04-17-clamshell-e2e-proof.md) | Prove belayer runs end-to-end in Colima+Clamshell with arielcharts pnpm dev runtime | 2026-04-17 |
+
+## Completed Plans
+
+_None yet._

--- a/docs/SANDBOXING.md
+++ b/docs/SANDBOXING.md
@@ -31,7 +31,7 @@ graph TD
         subgraph proxy["Docker: clamshell-proxy-{session}"]
             EGRESS["egress broker\nCONNECT proxy\nproxy.internal:3128"]
             ATTEST["process attestation\nbinary=python3 ✓"]
-            ALLOW["allowlist\nopencode.ai:443 ✓\n192.168.5.2:7523 ✓\n192.168.5.2:3000-4000 ✓"]
+            ALLOW["allowlist\nopencode.ai:443 ✓\nDocker host gateway:7523 ✓\nDocker host gateway:3000-4000 ✓"]
         end
     end
 
@@ -62,7 +62,7 @@ Provider credentials (e.g. `OPENCODE_GO_API_KEY`) live in `~/.belayer.env` on th
 
 When the daemon spawns a bridge subprocess via `docker exec`, `bridge.BuildEnv()` serialises the daemon's env into a temp env-file. The container process inherits `OPENCODE_GO_API_KEY` (and any other provider-specific vars) from there. `resolve_runtime_provider()` in `__main__.py` detects the key and selects the `opencode-go` Hermes provider.
 
-`BELAYER_PROVIDER` / `BELAYER_BASE_URL` act as fallbacks only — they are ignored when the Hermes config already resolves a provider.
+`BELAYER_PROVIDER` / `BELAYER_BASE_URL` act as fallbacks only — they are ignored when the Hermes config already resolves a provider. `BELAYER_API_KEY` is the exception: it always overrides the key returned by `resolve_runtime_provider()`, because the in-container user may carry an invalid or stale token (e.g. from a copied-in OAuth cache) that would otherwise win.
 
 ## Proxy client lifecycle fix
 

--- a/docs/SANDBOXING.md
+++ b/docs/SANDBOXING.md
@@ -1,0 +1,84 @@
+# Clamshell Sandboxing
+
+Clamshell is Belayer's Docker-based sandbox mode. Each session runs its bridge subprocess inside an isolated container with a MITM CONNECT proxy enforcing an egress allowlist and process attestation.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph host["macOS Host"]
+        CLI["belayer CLI\n(run start / logs / roster)"]
+        ENV["~/.belayer.env\n(OPENCODE_GO_API_KEY, GITHUB_TOKEN, …)"]
+    end
+
+    subgraph vm["Colima VM"]
+        subgraph daemon["belayer daemon (Go)"]
+            API["HTTP API\n(daemon.sock +\n/workspace/.belayer/daemon.sock)"]
+            DB[("SQLite\nsessions · agents · events")]
+            ENVLOAD["godotenv.Load()\n~/.belayer.env → os.Setenv()"]
+        end
+
+        subgraph sandbox["Docker: clamshell-{session}"]
+            subgraph bridge["bridge subprocess\npython3 -m hermes_bridge\n(env-file injected at docker exec)"]
+                MAIN["__main__.py\nresolve_runtime_provider()\n→ provider=opencode-go"]
+                PATCH["monkey-patch\n_create_openai_client()\n→ always fresh httpx.Client\n   proxy=proxy.internal:3128\n   + TCP keepalive"]
+                AGENT["Hermes AIAgent\nOpenAI SDK\nhttp_client=↑"]
+                TOOLS["belayer tools\nterminal · spawn_agent\nrequest_completion …"]
+            end
+            WS["/workspace bind-mount\n(project dir)\nincludes hermes_bridge/\n+ PYTHONPATH entry"]
+        end
+
+        subgraph proxy["Docker: clamshell-proxy-{session}"]
+            EGRESS["egress broker\nCONNECT proxy\nproxy.internal:3128"]
+            ATTEST["process attestation\nbinary=python3 ✓"]
+            ALLOW["allowlist\nopencode.ai:443 ✓\n192.168.5.2:7523 ✓\n192.168.5.2:3000-4000 ✓"]
+        end
+    end
+
+    subgraph ext["External"]
+        LLM["opencode.ai\n/zen/go/v1\nkimi-k2.5"]
+    end
+
+    ENV -->|"loaded at daemon startup"| ENVLOAD
+    ENVLOAD --> API
+    CLI -->|"daemon.sock"| API
+    API -->|"docker exec --env-file\nOPENCODE_GO_API_KEY\nHTTPS_PROXY\nBELAYER_SESSION_ID\nBELAYER_SOCKET\nBELAYER_TOOLS\nPYTHONPATH"| MAIN
+    MAIN --> PATCH
+    PATCH --> AGENT
+    AGENT -->|"CONNECT tunnel\nvia proxy.internal:3128"| EGRESS
+    EGRESS --> ATTEST
+    ATTEST --> ALLOW
+    ALLOW -->|"TLS to opencode.ai:443"| LLM
+    LLM -->|streaming response| ALLOW
+    AGENT <-->|"/workspace/.belayer/daemon.sock\n(Unix socket in bind-mount)"| API
+    API <--> DB
+    TOOLS -.->|"execute inside container"| AGENT
+    WS -.->|"imports hermes_bridge"| MAIN
+```
+
+## Credential chain
+
+Provider credentials (e.g. `OPENCODE_GO_API_KEY`) live in `~/.belayer.env` on the host. At daemon startup, `godotenv.Load()` reads the workspace `.belayer/.belayer.env` first (workspace wins), then `~/.belayer.env`. Both are loaded into the daemon's `os.Environ()` without overwriting already-set variables.
+
+When the daemon spawns a bridge subprocess via `docker exec`, `bridge.BuildEnv()` serialises the daemon's env into a temp env-file. The container process inherits `OPENCODE_GO_API_KEY` (and any other provider-specific vars) from there. `resolve_runtime_provider()` in `__main__.py` detects the key and selects the `opencode-go` Hermes provider.
+
+`BELAYER_PROVIDER` / `BELAYER_BASE_URL` act as fallbacks only — they are ignored when the Hermes config already resolves a provider.
+
+## Proxy client lifecycle fix
+
+Hermes rebuilds its OpenAI client on every tool-call cycle (`_close_openai_client` → `_create_openai_client`). The close tears down the underlying `httpx.Client`, breaking the proxy connection for subsequent LLM calls.
+
+The fix monkey-patches `agent._create_openai_client` at spawn time so every invocation creates a **fresh** `httpx.Client` with:
+- `proxy=httpx.Proxy("http://proxy.internal:3128")`
+- TCP keepalive socket options (SO_KEEPALIVE, TCP_KEEPIDLE=30, TCP_KEEPINTVL=10, TCP_KEEPCNT=3)
+
+The patched method strips any `http_client` key from the kwargs snapshot before forwarding to the original method, so Hermes's internal recovery path (`_try_recover_primary_transport`) also gets a fresh client automatically.
+
+## hermes_bridge distribution gap
+
+`hermes_bridge/` is plain Python source — it is **not** embedded in the Go binary. The container imports it from `/workspace/hermes_bridge/` (the project's bind-mounted directory). This means:
+
+1. Every project that uses Clamshell must have a copy of `hermes_bridge/` checked in or synced.
+2. Changes to `hermes_bridge/` in the belayer repo must be manually propagated to each project.
+
+Long-term options: embed a wheel in the binary and extract via `belayer init`, or publish `hermes_bridge` as a PyPI package.

--- a/docs/exec-plans/active/2026-04-17-clamshell-e2e-proof.md
+++ b/docs/exec-plans/active/2026-04-17-clamshell-e2e-proof.md
@@ -1,0 +1,1276 @@
+# Clamshell End-to-End Proof of Concept
+
+> **Status**: Active | **Created**: 2026-04-17 | **Last Updated**: 2026-04-17
+> **Design Doc**: `docs/design-docs/2026-04-16-sandbox-runtime-and-crag-proof.md`
+> **Consulted Learnings**: None
+> **For Claude:** Use /harness:orchestrate to execute this plan.
+
+## Goal
+
+Prove that Belayer can run a full nightshift in a secure sandboxed environment: agents run inside Clamshell containers on a Colima VM, arielcharts pnpm dev server is the live runtime, and a real bugfix spec ("persist user's pan/zoom/view of chart on re-render") is completed end-to-end with full telemetry and network egress control.
+
+## Architecture
+
+Colima VM hosts: belayer daemon, pnpm dev (runtime), and the clamshell gateway. Bridge subprocesses (`python3 -m hermes_bridge`) run INSIDE clamshell Docker containers. The daemon communicates with sandboxed bridges over a TCP listener (not Unix socket — containers can't reach host Unix sockets). The pnpm dev server runs on the VM host; containers reach it at `172.17.0.1:3000`. QA agent uses Playwright (baked into the Docker image) to drive the running web app.
+
+## Tech Stack
+
+Go (belayer daemon, clamshell driver, daemon TCP listener), Python (hermes_bridge), Docker/clamshell (sandboxing), pnpm/Next.js (arielcharts runtime), Playwright (QA agent).
+
+---
+
+## Decision Log
+
+| Date | Phase | Decision | Rationale |
+|------|-------|----------|-----------|
+| 2026-04-17 | Design | Use Colima over Lima | Lima had seccomp issues with Docker; Colima has better Docker compatibility |
+| 2026-04-17 | Design | Bake hermes-agent + hermes_bridge into Docker image | `read_only_paths` in clamshell policy are Landlock rules, NOT Docker bind mounts — host paths aren't visible in container |
+| 2026-04-17 | Design | Daemon TCP listener for bridge→daemon comms in clamshell mode | Unix socket is on host, containers can't reach it; TCP on 0.0.0.0 is reachable via Docker host gateway IP (172.17.0.1) |
+| 2026-04-17 | Design | Use opencode-go provider (kimi-k2.5) for all agents | OPENCODE_GO_API_KEY is available; avoids Anthropic dependency for initial run |
+| 2026-04-17 | Design | Per-session sandbox, shared /workspace | All agents in session share one clamshell sandbox; simplest model for PoC |
+
+## Progress
+
+- [ ] Task 1: Verify Colima VM environment (.belayer.env, dependencies)
+- [ ] Task 2: Install clamshell CLI in Colima VM
+- [ ] Task 3: Install hermes in Colima VM
+- [ ] Task 4: Build and install belayer binary (linux/arm64, -tags clamshell) in Colima VM
+- [ ] Task 5: Clone arielcharts and configure .belayer/ for clamshell + opencode-go
+- [ ] Task 6: Fix seccomp profile (add statx syscall)
+- [ ] Task 7: Build clamshell sandbox Docker image (with hermes-agent + playwright)
+- [ ] Task 8: Add TCP listener to belayer daemon for clamshell bridge comms
+- [ ] Task 9: Update http_client.py to support HTTP URLs (for TCP daemon socket)
+- [ ] Task 10: Update daemon bridge env — pass TCP socket path in clamshell mode
+- [ ] Task 11: Configure clamshell policy for arielcharts (opencode.ai, pnpm dev, daemon socket)
+- [ ] Task 12: Verify noop-mode run (sanity check before clamshell)
+- [ ] Task 13: First clamshell run — iterate on network policy until agents complete
+- [ ] Task 14: Verify telemetry and add network deny event logging
+- [ ] Task 15: Write summary document
+
+## Surprises & Discoveries
+
+_Updated as we work._
+
+## Plan Drift
+
+_None yet._
+
+---
+
+## Task 1: Verify Colima VM Environment
+
+**Files:**
+- Colima VM: `~/.belayer.env`, `~/.bash_profile`
+
+**What we expect to be in place (from prior session):**
+- Docker 29.2.1 running ✓
+- `~/extend-clamshell/` with modified Dockerfile ✓
+- `~/.belayer.env` with OPENCODE_GO_API_KEY, HERMES_MAX_ITERATIONS=100, GITHUB_TOKEN, OPENCODE_GO_BASE_URL ✓
+- `python3-pip`, `python3-venv`, `git` installed ✓
+
+- [ ] **Step 1: SSH into Colima and verify .belayer.env**
+
+```bash
+colima ssh -- bash -c "cat ~/.belayer.env | sed 's/=.*/=***/' && echo '---' && ls ~/extend-clamshell/ && docker --version"
+```
+
+Expected: four env var names (values masked), extend-clamshell directory listing, Docker 29.2.x
+
+- [ ] **Step 2: Ensure .bash_profile sources .belayer.env**
+
+```bash
+colima ssh -- bash -c "grep -n belayer.env ~/.bash_profile 2>/dev/null || echo 'NOT FOUND — need to add'"
+```
+
+If not present:
+```bash
+colima ssh -- bash -c "cat >> ~/.bash_profile << 'PROFILE_EOF'
+set -a; [ -f ~/.belayer.env ] && source ~/.belayer.env; set +a
+PROFILE_EOF"
+```
+
+- [ ] **Step 3: Verify env vars load in a fresh shell**
+
+```bash
+colima ssh -- bash -lc "echo OPENCODE_GO_BASE_URL=\$OPENCODE_GO_BASE_URL && echo GITHUB_TOKEN_SET=\$([ -n \"\$GITHUB_TOKEN\" ] && echo yes || echo no)"
+```
+
+Expected: `OPENCODE_GO_BASE_URL=https://opencode.ai/zen/go/v1`, `GITHUB_TOKEN_SET=yes`
+
+- [ ] **Step 4: Commit (no code change, just verify)**
+
+---
+
+## Task 2: Install clamshell CLI in Colima VM
+
+**Files:**
+- Colima VM: `~/extend-clamshell/` (already exists)
+
+- [ ] **Step 1: Install clamshell as editable package**
+
+```bash
+colima ssh -- bash -lc "cd ~/extend-clamshell && pip3 install -e . 2>&1 | tail -10"
+```
+
+Expected: `Successfully installed clamshell-...`
+
+- [ ] **Step 2: Verify clamshell CLI is working**
+
+```bash
+colima ssh -- bash -lc "clamshell --version || python3 -m clamshell --version"
+```
+
+Expected: version string
+
+- [ ] **Step 3: Start clamshell gateway**
+
+```bash
+colima ssh -- bash -lc "clamshell gateway start 2>&1"
+```
+
+Expected: gateway starts or is already running
+
+- [ ] **Step 4: Verify gateway is running**
+
+```bash
+colima ssh -- bash -lc "clamshell gateway status 2>&1"
+```
+
+Expected: running/listening status
+
+---
+
+## Task 3: Install hermes in Colima VM
+
+**Files:**
+- Colima VM: `~/.hermes/hermes-agent/`
+
+The bridge's `defaultPythonCmd()` in `internal/bridge/bridge.go:22` looks for `~/.hermes/hermes-agent/venv/bin/python3` first. We need hermes installed there.
+
+- [ ] **Step 1: Create hermes directories and venv**
+
+```bash
+colima ssh -- bash -lc "mkdir -p ~/.hermes/hermes-agent ~/.hermes/profiles && python3 -m venv ~/.hermes/hermes-agent/venv"
+```
+
+Expected: no errors
+
+- [ ] **Step 2: Install hermes-agent from GitHub**
+
+hermes-agent is not on PyPI, must install from GitHub:
+```bash
+colima ssh -- bash -lc "~/.hermes/hermes-agent/venv/bin/pip install --upgrade pip && ~/.hermes/hermes-agent/venv/bin/pip install git+https://github.com/NousResearch/hermes-agent.git 2>&1 | tail -5"
+```
+
+Expected: `Successfully installed hermes-agent-...`
+
+- [ ] **Step 3: Verify hermes modules are importable**
+
+```bash
+colima ssh -- bash -lc "~/.hermes/hermes-agent/venv/bin/python3 -c \"from run_agent import AIAgent; print('hermes OK')\""
+```
+
+Expected: `hermes OK`
+
+- [ ] **Step 4: Verify hermes_bridge is also importable (via site-packages in Docker image — skip for now, verify in Task 7)**
+
+This is for the container; on the VM host, hermes_bridge is accessible via PYTHONPATH (set by belayer to BelayerRoot). That's handled when belayer runs noop mode. For clamshell mode, it's baked into the image.
+
+---
+
+## Task 4: Build and Install belayer Binary in Colima VM
+
+**Files:**
+- Local Mac: `cmd/belayer/`, `internal/sandbox/clamshell.go`
+- Colima VM: `~/bin/belayer` or `~/.local/bin/belayer`
+
+The clamshell driver only compiles with `-tags clamshell`. We cross-compile from Mac for linux/arm64 (Colima uses ARM64 on Apple Silicon).
+
+- [ ] **Step 1: Cross-compile belayer for linux/arm64 with clamshell tag**
+
+Run on Mac (local terminal):
+```bash
+cd /Users/donovanyohan/Documents/Programs/personal/belayer
+GOOS=linux GOARCH=arm64 go build -tags clamshell -o /tmp/belayer-linux-arm64 ./cmd/belayer && echo "Build OK: $(file /tmp/belayer-linux-arm64)"
+```
+
+Expected: `ELF 64-bit LSB executable, ARM aarch64`
+
+- [ ] **Step 2: Copy binary into Colima VM**
+
+```bash
+colima ssh -- bash -c "mkdir -p ~/.local/bin"
+colima cp /tmp/belayer-linux-arm64 colima:~/.local/bin/belayer
+colima ssh -- chmod +x ~/.local/bin/belayer
+```
+
+- [ ] **Step 3: Add ~/.local/bin to PATH in .bash_profile**
+
+```bash
+colima ssh -- bash -c "grep -q '.local/bin' ~/.bash_profile || echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bash_profile"
+```
+
+- [ ] **Step 4: Verify belayer is installed and built with clamshell**
+
+```bash
+colima ssh -- bash -lc "belayer --version && belayer daemon --help | grep -i sandbox"
+```
+
+Expected: version string; help text mentioning sandbox/socket options
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -p  # if any belayer source changes were needed
+git commit -m "build: cross-compile belayer with clamshell tag for linux/arm64"
+```
+
+---
+
+## Task 5: Clone arielcharts and Configure .belayer/
+
+**Files:**
+- Colima VM: `~/arielcharts/.belayer/config.yaml`, `~/arielcharts/.belayer/agents/*/agent.yaml`, `~/arielcharts/.belayer/policies/standard.yaml`
+
+- [ ] **Step 1: Clone arielcharts in Colima VM**
+
+```bash
+colima ssh -- bash -lc "[ -d ~/arielcharts ] && echo 'already exists' || git clone https://github.com/donovan-yohan/arielcharts.git ~/arielcharts"
+```
+
+- [ ] **Step 2: Run belayer init to scaffold .belayer/**
+
+```bash
+colima ssh -- bash -lc "cd ~/arielcharts && belayer init && ls .belayer/"
+```
+
+Expected: `.belayer/agents/` with 6 agent directories, `config.yaml`, `policies/`
+
+- [ ] **Step 3: Update .belayer/config.yaml for clamshell mode and runtime**
+
+```bash
+colima ssh -- python3 -c "
+import os
+cfg = '''sandbox:
+  mode: clamshell
+  policy: .belayer/policies/standard.yaml
+
+runtime:
+  up: \"pnpm install --frozen-lockfile && pnpm dev &\"
+  health: \"curl -sf http://localhost:3000 || curl -sf http://localhost:4000/health\"
+  down: \"pkill -f next || pkill -f tsx || true\"
+  endpoints:
+    - name: web
+      host: localhost
+      port: 3000
+    - name: server
+      host: localhost
+      port: 4000
+'''
+os.makedirs(os.path.expanduser('~/arielcharts/.belayer'), exist_ok=True)
+open(os.path.expanduser('~/arielcharts/.belayer/config.yaml'), 'w').write(cfg)
+print('config.yaml written')
+"
+```
+
+- [ ] **Step 4: Update all agent.yaml files to use opencode-go + kimi-k2.5**
+
+```bash
+colima ssh -- bash -lc "for f in ~/arielcharts/.belayer/agents/*/agent.yaml; do
+  python3 -c \"
+import sys, re
+path = sys.argv[1]
+content = open(path).read()
+content = re.sub(r'vendor:.*', 'vendor: opencode-go', content)
+content = re.sub(r'model:.*', 'model: kimi-k2.5', content)
+open(path, 'w').write(content)
+print('Updated:', path)
+\" \"\$f\"
+done"
+```
+
+- [ ] **Step 5: Create .belayer/policies/standard.yaml with correct endpoints**
+
+```bash
+colima ssh -- python3 -c "
+policy = '''version: 5
+
+sandbox:
+  user: sandbox
+  group: sandbox
+  work_dir: /workspace
+  runtime_dir: /run/agent
+  artifact_outbox: /run/agent/outbox
+  read_only_paths:
+    - /usr
+    - /lib
+    - /lib64
+    - /bin
+    - /sbin
+    - /etc
+    - /var/log
+    - /app
+  read_write_paths:
+    - /tmp
+    - /workspace
+    - /run/agent
+    - /run/agent/outbox
+  masked_paths:
+    - /proc/kcore
+    - /proc/latency_stats
+    - /proc/timer_list
+    - /sys/firmware
+  tmpfs_paths:
+    - /tmp
+
+process:
+  no_new_privileges: true
+  drop_capabilities: [\"ALL\"]
+  memory_limit: 4096m
+  pids_limit: 512
+  cpu_quota: 200000
+  read_only_rootfs: false
+
+network:
+  mode: proxy
+  proxy_listen: 3128
+  allow_http: false
+  providers:
+    github: true
+    npm: true
+    pypi: true
+  custom_endpoints:
+    - host: opencode.ai
+      ports: [443]
+      protocol: rest
+      note: OpenCode Go inference (kimi-k2.5)
+    - host: api.moonshot.cn
+      ports: [443]
+      protocol: rest
+      note: Moonshot/Kimi inference
+    - host: portal.nousresearch.com
+      ports: [443]
+      protocol: rest
+      note: Hermes Nous OAuth
+    - host: inference-api.nousresearch.com
+      ports: [443]
+      protocol: rest
+      note: Hermes Nous inference
+  localhost:
+    - host: 172.17.0.1
+      ports: [3000, 4000, 7523]
+      note: arielcharts pnpm dev server + belayer daemon TCP socket
+  tcp_endpoints: []
+'''
+import os
+os.makedirs(os.path.expanduser('~/arielcharts/.belayer/policies'), exist_ok=True)
+open(os.path.expanduser('~/arielcharts/.belayer/policies/standard.yaml'), 'w').write(policy)
+print('policy written')
+"
+```
+
+Note: Port 7523 is the belayer daemon TCP listener (added in Task 8). `172.17.0.1` is the Docker host gateway IP reachable from inside Colima Docker containers.
+
+- [ ] **Step 6: Install Node.js + pnpm in Colima VM (for runtime)**
+
+```bash
+colima ssh -- bash -lc "which node || (curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && sudo apt-get install -y nodejs && npm install -g pnpm)"
+colima ssh -- bash -lc "node --version && pnpm --version"
+```
+
+Expected: node 20.x, pnpm version
+
+---
+
+## Task 6: Fix Seccomp Profile (statx Syscall)
+
+**Files:**
+- Colima VM: `~/extend-clamshell/etc/seccomp-default.json`
+
+The default clamshell seccomp profile uses `SCMP_ACT_ERRNO` (deny all) as the default action but is missing `statx` which Docker/runc uses during container setup. This causes exit 127/125 on container startup.
+
+- [ ] **Step 1: Verify statx is missing from the profile**
+
+```bash
+colima ssh -- bash -lc "grep -c 'statx' ~/extend-clamshell/etc/seccomp-default.json && echo 'statx present' || echo 'statx MISSING'"
+```
+
+- [ ] **Step 2: Check current syscall list structure**
+
+```bash
+colima ssh -- bash -lc "python3 -c \"import json; d=json.load(open('/root/extend-clamshell/etc/seccomp-default.json')); print('defaultAction:', d.get('defaultAction')); print('syscall count:', len(d.get('syscalls', [])))\""
+```
+
+Expected: `defaultAction: SCMP_ACT_ERRNO`, syscall count >100
+
+- [ ] **Step 3: Add statx and other commonly missing syscalls**
+
+```bash
+colima ssh -- python3 << 'PYEOF'
+import json, copy
+
+path = '/root/extend-clamshell/etc/seccomp-default.json'
+with open(path) as f:
+    profile = json.load(f)
+
+# Check if statx exists
+existing_names = set()
+for entry in profile.get('syscalls', []):
+    for name in entry.get('names', []):
+        existing_names.add(name)
+
+missing = [s for s in ['statx', 'clone3', 'faccessat2', 'epoll_pwait2', 'landlock_create_ruleset', 'landlock_add_rule', 'landlock_restrict_self', 'io_uring_setup', 'io_uring_enter', 'io_uring_register', 'memfd_secret'] if s not in existing_names]
+print('Missing syscalls to add:', missing)
+
+if missing:
+    profile['syscalls'].append({
+        'names': missing,
+        'action': 'SCMP_ACT_ALLOW'
+    })
+    with open(path, 'w') as f:
+        json.dump(profile, f, indent=2)
+    print('Updated seccomp profile with', len(missing), 'missing syscalls')
+else:
+    print('All target syscalls already present')
+PYEOF
+```
+
+- [ ] **Step 4: Verify statx is now in the profile**
+
+```bash
+colima ssh -- bash -lc "python3 -c \"import json; d=json.load(open('/root/extend-clamshell/etc/seccomp-default.json')); names=[n for e in d['syscalls'] for n in e.get('names',[])]; print('statx:', 'statx' in names)\""
+```
+
+Expected: `statx: True`
+
+---
+
+## Task 7: Build Clamshell Sandbox Docker Image
+
+**Files:**
+- Colima VM: `~/extend-clamshell/images/sandbox-rootfs/Dockerfile`
+
+The Dockerfile already has hermes-agent and hermes_bridge modifications from the prior session. We need to verify, add Playwright, and build.
+
+- [ ] **Step 1: Review the current Dockerfile**
+
+```bash
+colima ssh -- bash -lc "cat ~/extend-clamshell/images/sandbox-rootfs/Dockerfile"
+```
+
+Expected: should include `pip install git+https://github.com/NousResearch/hermes-agent.git` and `hermes_bridge` copy
+
+- [ ] **Step 2: Ensure Dockerfile has Playwright**
+
+Add playwright AFTER hermes installation. Append to Dockerfile if missing:
+```bash
+colima ssh -- bash -lc "grep -q playwright ~/extend-clamshell/images/sandbox-rootfs/Dockerfile && echo 'playwright present' || echo 'playwright MISSING'"
+```
+
+If missing, add it:
+```bash
+colima ssh -- python3 -c "
+path = '/root/extend-clamshell/images/sandbox-rootfs/Dockerfile'
+content = open(path).read()
+
+if 'playwright' not in content:
+    # Find a good insertion point — after the pip installs
+    playwright_lines = '''
+# Install Playwright for QA agent
+RUN pip install --no-cache-dir playwright \\\\ 
+    && playwright install chromium \\\\ 
+    && playwright install-deps chromium
+'''
+    # Insert before the last CMD or ENTRYPOINT
+    if 'CMD' in content:
+        content = content.replace('CMD', playwright_lines + '\nCMD', 1)
+    else:
+        content += playwright_lines
+    open(path, 'w').write(content)
+    print('Added playwright to Dockerfile')
+else:
+    print('playwright already in Dockerfile')
+"
+```
+
+- [ ] **Step 3: Build the Docker image**
+
+```bash
+colima ssh -- bash -lc "cd ~/extend-clamshell/images/sandbox-rootfs && docker build -t belayer-sandbox:latest . 2>&1 | tail -20"
+```
+
+Expected: `Successfully built ...`, `Successfully tagged belayer-sandbox:latest`
+
+This may take a few minutes (first build, downloads hermes-agent from GitHub).
+
+- [ ] **Step 4: Verify hermes imports work inside the image**
+
+```bash
+colima ssh -- docker run --rm belayer-sandbox:latest python3 -c "from run_agent import AIAgent; from hermes_state import SessionDB; import hermes_bridge; print('ALL OK')"
+```
+
+Expected: `ALL OK`
+
+- [ ] **Step 5: Verify playwright is importable**
+
+```bash
+colima ssh -- docker run --rm belayer-sandbox:latest python3 -c "from playwright.sync_api import sync_playwright; print('playwright OK')"
+```
+
+Expected: `playwright OK`
+
+- [ ] **Step 6: Check that clamshell knows about the new image**
+
+```bash
+colima ssh -- bash -lc "clamshell image list 2>&1 || clamshell images list 2>&1 || echo 'check clamshell docs for image command'"
+```
+
+Update extend-clamshell config to point to `belayer-sandbox:latest` if needed (consult clamshell docs for the config key).
+
+---
+
+## Task 8: Add TCP Listener to Belayer Daemon
+
+**Files:**
+- `internal/daemon/daemon.go`
+- `internal/cli/daemon.go`
+
+When `sandbox.mode: clamshell`, agents run inside Docker containers that cannot reach the host Unix socket `~/.belayer/daemon.sock`. The daemon needs to also bind a TCP listener so containers can reach it via Docker's host gateway (`172.17.0.1`).
+
+- [ ] **Step 1: Add TCPAddr field to daemon.Config**
+
+In `internal/daemon/daemon.go`, find the `Config` struct (line 28) and add:
+
+```go
+type Config struct {
+	SocketPath  string
+	DBPath      string
+	BelayerRoot string
+	// TCPAddr, if non-empty, causes the daemon to listen on this TCP address
+	// in addition to the Unix socket. Used when sandbox.mode=clamshell so
+	// bridge subprocesses inside Docker containers can reach the daemon via
+	// the Docker host gateway (172.17.0.1).
+	TCPAddr string
+	// ...existing fields...
+	SandboxDrivers *sandbox.Registry
+	Runtime        runtime.Provider
+}
+```
+
+- [ ] **Step 2: Write a failing test for TCP listener**
+
+In `internal/daemon/daemon_test.go` (or create it), add:
+
+```go
+func TestDaemonTCPListener(t *testing.T) {
+    cfg := daemon.Config{
+        SocketPath: filepath.Join(t.TempDir(), "daemon.sock"),
+        DBPath:     filepath.Join(t.TempDir(), "test.db"),
+        TCPAddr:    "127.0.0.1:0", // port 0 = OS picks a free port
+    }
+    d, err := daemon.New(cfg)
+    if err != nil {
+        t.Fatalf("New: %v", err)
+    }
+    ctx, cancel := context.WithCancel(context.Background())
+    errCh := make(chan error, 1)
+    go func() { errCh <- d.Start(ctx) }()
+    time.Sleep(50 * time.Millisecond) // wait for listeners
+
+    // Daemon should expose a TCPPort() method returning the actual bound port.
+    port := d.TCPPort()
+    if port == 0 {
+        t.Fatal("TCPPort() returned 0 after Start")
+    }
+
+    // Hit /health over TCP.
+    resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+    if err != nil {
+        t.Fatalf("GET /health over TCP: %v", err)
+    }
+    resp.Body.Close()
+    if resp.StatusCode != 200 {
+        t.Fatalf("expected 200, got %d", resp.StatusCode)
+    }
+
+    cancel()
+    <-errCh
+}
+```
+
+Run: `go test ./internal/daemon/... -run TestDaemonTCPListener -v`
+Expected: FAIL (TCPAddr not wired yet)
+
+- [ ] **Step 3: Implement TCP listener in daemon.Start()**
+
+In `internal/daemon/daemon.go`, modify the `Start` function after the Unix socket listener setup. Find where `net.Listen("unix", ...)` is called (around line 163) and add TCP listener:
+
+```go
+func (d *Daemon) Start(ctx context.Context) error {
+    // ... existing Unix socket setup ...
+    ln, err := net.Listen("unix", d.config.SocketPath)
+    if err != nil {
+        return fmt.Errorf("daemon: listen unix: %w", err)
+    }
+    os.Chmod(d.config.SocketPath, 0o600)
+    d.listener = ln
+
+    // TCP listener for clamshell containers (optional).
+    var tcpListener net.Listener
+    if d.config.TCPAddr != "" {
+        tcpLn, err := net.Listen("tcp", d.config.TCPAddr)
+        if err != nil {
+            ln.Close()
+            return fmt.Errorf("daemon: listen tcp %s: %w", d.config.TCPAddr, err)
+        }
+        d.tcpListener = tcpLn
+        d.tcpPort = tcpLn.Addr().(*net.TCPAddr).Port
+        log.Printf("daemon: TCP listener on %s (port %d)", d.config.TCPAddr, d.tcpPort)
+    }
+    // ... rest of Start ...
+}
+```
+
+Add fields to the `Daemon` struct:
+```go
+type Daemon struct {
+    // ...existing fields...
+    tcpListener net.Listener
+    tcpPort     int
+}
+```
+
+Add a `TCPPort()` method:
+```go
+func (d *Daemon) TCPPort() int { return d.tcpPort }
+```
+
+Ensure the TCP listener also serves the same HTTP mux. After `d.server = &http.Server{Handler: mux}`, also serve on tcpListener:
+```go
+if d.tcpListener != nil {
+    tcpServer := &http.Server{Handler: mux}
+    go tcpServer.Serve(d.tcpListener)
+    // Add tcpServer to Shutdown call in the shutdown path.
+}
+```
+
+Also close tcpListener in `Shutdown()`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+go test ./internal/daemon/... -run TestDaemonTCPListener -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Add --tcp-addr flag to daemon CLI**
+
+In `internal/cli/daemon.go`, add flag and wiring:
+
+```go
+var tcpAddr string
+// in RunE:
+if tcpAddr != "" {
+    cfg.TCPAddr = tcpAddr
+}
+// in cmd.Flags():
+cmd.Flags().StringVar(&tcpAddr, "tcp-addr", "", "Also bind a TCP listener (e.g. 0.0.0.0:7523) for clamshell container access")
+```
+
+- [ ] **Step 6: Run all daemon tests**
+
+```bash
+go test ./internal/daemon/... -v 2>&1 | tail -30
+```
+
+Expected: all PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/daemon/daemon.go internal/cli/daemon.go
+git commit -m "feat(daemon): add optional TCP listener for clamshell container bridge access"
+```
+
+---
+
+## Task 9: Update hermes_bridge http_client to Support HTTP URLs
+
+**Files:**
+- `hermes_bridge/http_client.py`
+
+When `BELAYER_SOCKET` is an HTTP URL (e.g., `http://172.17.0.1:7523`), use regular HTTP instead of Unix socket.
+
+- [ ] **Step 1: Update unix_post and unix_get to handle both Unix and HTTP**
+
+Replace the contents of `hermes_bridge/http_client.py`:
+
+```python
+"""HTTP client for daemon communication.
+
+Supports both Unix socket paths (e.g. /path/to/daemon.sock) and
+HTTP URL addresses (e.g. http://172.17.0.1:7523) for the BELAYER_SOCKET
+env var. Unix sockets are used when belayer runs with noop sandbox mode;
+HTTP URLs are used when agents run inside clamshell Docker containers and
+need to reach the daemon on the host via Docker's bridge gateway.
+"""
+
+import json
+import logging
+import http.client
+import socket as sock
+from urllib.parse import urlparse
+
+log = logging.getLogger("http_client")
+
+
+def _is_http_url(socket_path: str) -> bool:
+    return socket_path.startswith("http://") or socket_path.startswith("https://")
+
+
+def unix_post(socket_path: str, path: str, body: dict) -> tuple[int, str]:
+    """POST JSON body to the daemon over its Unix socket or TCP address."""
+    try:
+        payload = json.dumps(body).encode()
+        headers = {"Content-Type": "application/json"}
+
+        if _is_http_url(socket_path):
+            parsed = urlparse(socket_path)
+            conn = http.client.HTTPConnection(parsed.hostname, parsed.port or 80)
+        else:
+            conn = http.client.HTTPConnection("localhost")
+            s = sock.socket(sock.AF_UNIX, sock.SOCK_STREAM)
+            s.connect(socket_path)
+            conn.sock = s
+
+        conn.request("POST", path, body=payload, headers=headers)
+        resp = conn.getresponse()
+        resp_body = resp.read().decode()
+        conn.close()
+        return resp.status, resp_body
+    except Exception as e:
+        log.debug("unix_post %s failed: %s", path, e)
+        return 0, str(e)
+
+
+def unix_get(socket_path: str, path: str) -> tuple[int, str]:
+    """GET from the daemon over its Unix socket or TCP address."""
+    try:
+        if _is_http_url(socket_path):
+            parsed = urlparse(socket_path)
+            conn = http.client.HTTPConnection(parsed.hostname, parsed.port or 80)
+        else:
+            conn = http.client.HTTPConnection("localhost")
+            s = sock.socket(sock.AF_UNIX, sock.SOCK_STREAM)
+            s.connect(socket_path)
+            conn.sock = s
+
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        resp_body = resp.read().decode()
+        conn.close()
+        return resp.status, resp_body
+    except Exception as e:
+        log.debug("unix_get %s failed: %s", path, e)
+        return 0, str(e)
+```
+
+- [ ] **Step 2: Run existing tests (if any)**
+
+```bash
+cd /Users/donovanyohan/Documents/Programs/personal/belayer
+python3 -m pytest hermes_bridge/ -v 2>&1 | tail -20 || echo "no tests found (ok)"
+```
+
+- [ ] **Step 3: Quick manual smoke test**
+
+```bash
+python3 -c "
+from hermes_bridge.http_client import _is_http_url
+assert _is_http_url('http://172.17.0.1:7523') == True
+assert _is_http_url('/tmp/daemon.sock') == False
+assert _is_http_url('http://localhost:7523') == True
+print('smoke test passed')
+"
+```
+
+Expected: `smoke test passed`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hermes_bridge/http_client.py
+git commit -m "feat(bridge): support HTTP URL in BELAYER_SOCKET for clamshell container daemon access"
+```
+
+---
+
+## Task 10: Update Daemon to Pass TCP Socket Path in Clamshell Mode
+
+**Files:**
+- `internal/daemon/agents.go` (line ~264, `bridgeLaunchAgent`)
+- `internal/daemon/daemon.go`
+
+When the sandbox driver for a session is clamshell, bridge agents run inside Docker containers. They need `BELAYER_SOCKET` to point to the TCP address rather than the Unix socket path.
+
+The Docker host gateway from inside a Docker container is typically `172.17.0.1` on Linux. This is configurable via a new daemon config field.
+
+- [ ] **Step 1: Add DockerHostGateway field to daemon.Config**
+
+In `internal/daemon/daemon.go`, add to Config:
+
+```go
+// DockerHostGateway is the IP address of the Docker host as seen from inside
+// Docker containers. Used to construct BELAYER_SOCKET for clamshell-mode bridge
+// subprocesses. Defaults to "172.17.0.1" (standard Docker bridge network).
+DockerHostGateway string
+```
+
+And in `DefaultConfig()`:
+```go
+DockerHostGateway: "172.17.0.1",
+```
+
+- [ ] **Step 2: Write a test for clamshell socket path selection**
+
+In `internal/daemon/agents_test.go` (or create), add a test that when the session driver is clamshell, the bridge config SocketPath is the TCP URL:
+
+```go
+func TestBridgeCfgSocketPathForClamshell(t *testing.T) {
+    // This is a unit test for the socket path selection logic.
+    // bridgeLaunchAgent is unexported; test via the exported helper that
+    // constructs the bridge Config. If no such helper exists, add one.
+    //
+    // For now, this verifies the logic by inspecting logs or using a thin
+    // exported function bridgeSocketPath(mode, unixPath, gateway, port).
+    
+    got := bridgeSocketPath("clamshell", "/tmp/daemon.sock", "172.17.0.1", 7523)
+    want := "http://172.17.0.1:7523"
+    if got != want {
+        t.Fatalf("want %q, got %q", want, got)
+    }
+
+    got = bridgeSocketPath("noop", "/tmp/daemon.sock", "172.17.0.1", 7523)
+    if got != "/tmp/daemon.sock" {
+        t.Fatalf("noop mode should use unix socket, got %q", got)
+    }
+}
+```
+
+Run: `go test ./internal/daemon/... -run TestBridgeCfgSocketPathForClamshell -v`
+Expected: FAIL (function doesn't exist yet)
+
+- [ ] **Step 3: Add bridgeSocketPath helper and wire it into bridgeLaunchAgent**
+
+In `internal/daemon/agents.go`, add helper (unexported is fine, make exported for testability):
+
+```go
+// bridgeSocketPath returns the socket path/URL to inject into BELAYER_SOCKET
+// for a bridge subprocess. For clamshell sandboxes the bridge runs inside a
+// Docker container and must reach the daemon via the Docker host gateway over
+// TCP. For all other drivers the Unix socket path is used directly.
+func bridgeSocketPath(driverName, unixPath, dockerGateway string, tcpPort int) string {
+    if driverName == "clamshell" && tcpPort > 0 {
+        return fmt.Sprintf("http://%s:%d", dockerGateway, tcpPort)
+    }
+    return unixPath
+}
+```
+
+Then in `bridgeLaunchAgent()`, find where `cfg.SocketPath` is set (it's currently `d.config.SocketPath`). Replace with:
+
+```go
+socketPath := bridgeSocketPath(
+    driverName,              // from resolved sandbox driver
+    d.config.SocketPath,
+    d.config.DockerHostGateway,
+    d.tcpPort,
+)
+cfg := bridge.Config{
+    // ...
+    SocketPath: socketPath,
+    // ...
+}
+```
+
+You'll need to pass `driverName` into `bridgeLaunchAgent`. Check the existing function signature in `agents.go:264` and adjust.
+
+- [ ] **Step 4: Add --docker-gateway flag to daemon CLI**
+
+In `internal/cli/daemon.go`:
+```go
+var dockerGateway string
+// in RunE:
+if dockerGateway != "" {
+    cfg.DockerHostGateway = dockerGateway
+}
+// in cmd.Flags():
+cmd.Flags().StringVar(&dockerGateway, "docker-gateway", "", "Docker host gateway IP for clamshell bridge access (default 172.17.0.1)")
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+go test ./internal/daemon/... -v 2>&1 | tail -30
+```
+
+Expected: all PASS including new test
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/daemon/daemon.go internal/daemon/agents.go internal/cli/daemon.go
+git commit -m "feat(daemon): route bridge BELAYER_SOCKET to TCP in clamshell mode"
+```
+
+---
+
+## Task 11: Rebuild and Redeploy belayer to Colima
+
+After Tasks 8-10, we have Go code changes. Rebuild and redeploy.
+
+- [ ] **Step 1: Build tests pass locally**
+
+```bash
+go test ./... 2>&1 | tail -20
+```
+
+Expected: all PASS
+
+- [ ] **Step 2: Cross-compile new binary**
+
+```bash
+GOOS=linux GOARCH=arm64 go build -tags clamshell -o /tmp/belayer-linux-arm64 ./cmd/belayer && echo "Build OK"
+```
+
+- [ ] **Step 3: Copy to Colima and verify**
+
+```bash
+colima cp /tmp/belayer-linux-arm64 colima:~/.local/bin/belayer
+colima ssh -- chmod +x ~/.local/bin/belayer
+colima ssh -- bash -lc "belayer daemon --help | grep -E 'tcp-addr|docker-gateway'"
+```
+
+Expected: both flags present in help output
+
+---
+
+## Task 12: Verify Noop Mode Run (Sanity Check)
+
+Before attempting clamshell, verify belayer works in the Colima VM in noop mode. This catches environment issues before clamshell complexity.
+
+- [ ] **Step 1: Temporarily set sandbox mode to noop**
+
+```bash
+colima ssh -- bash -lc "sed -i 's/mode: clamshell/mode: noop/' ~/arielcharts/.belayer/config.yaml && grep mode ~/arielcharts/.belayer/config.yaml"
+```
+
+- [ ] **Step 2: Start belayer daemon in Colima (background)**
+
+```bash
+colima ssh -- bash -lc "cd ~/arielcharts && belayer daemon --workdir ~/arielcharts > /tmp/daemon.log 2>&1 &
+sleep 2 && tail -5 /tmp/daemon.log"
+```
+
+Expected: `belayer daemon listening on ~/.belayer/daemon.sock`, `belayer runtime: command (loaded from ...)`
+
+- [ ] **Step 3: Start a belayer run with a simple task**
+
+```bash
+colima ssh -- bash -lc "cd ~/arielcharts && belayer run start --task 'Write a one-line comment at the top of README.md' 2>&1"
+```
+
+Watch the output. The supervisor should spawn and the agents should communicate.
+
+- [ ] **Step 4: Watch logs**
+
+```bash
+colima ssh -- bash -lc "belayer logs 2>&1 | head -50"
+```
+
+Expected: session created, supervisor spawned, agents communicating
+
+- [ ] **Step 5: Stop daemon**
+
+```bash
+colima ssh -- bash -lc "pkill -f 'belayer daemon' || true"
+```
+
+- [ ] **Step 6: Restore clamshell mode**
+
+```bash
+colima ssh -- bash -lc "sed -i 's/mode: noop/mode: clamshell/' ~/arielcharts/.belayer/config.yaml"
+```
+
+---
+
+## Task 13: First Clamshell Run — Iterate Until Complete
+
+This is the core iteration loop. Run with clamshell, watch errors, fix policy/config, repeat.
+
+**Files:**
+- Colima VM: `~/arielcharts/.belayer/policies/standard.yaml`
+- Colima VM: logs at `~/.extend-clamshell/runtime/*/host/events/`
+
+- [ ] **Step 1: Start clamshell gateway**
+
+```bash
+colima ssh -- bash -lc "clamshell gateway start 2>&1 && sleep 1 && clamshell gateway status"
+```
+
+- [ ] **Step 2: Start belayer daemon with TCP listener**
+
+```bash
+colima ssh -- bash -lc "cd ~/arielcharts && belayer daemon --workdir ~/arielcharts --tcp-addr 0.0.0.0:7523 > /tmp/daemon.log 2>&1 &
+sleep 2 && tail -10 /tmp/daemon.log"
+```
+
+Expected: `daemon listening on ~/.belayer/daemon.sock`, `TCP listener on 0.0.0.0:7523`
+
+- [ ] **Step 3: Start the arielcharts run with the bugfix spec**
+
+```bash
+colima ssh -- bash -lc "cd ~/arielcharts && belayer run start --task 'Bugfix: persist user pan/zoom/view of the chart when the chart is re-rendered. The chart should remember the viewport state (pan position, zoom level) across re-renders so the user does not lose their view.' 2>&1 &"
+```
+
+- [ ] **Step 4: Tail deny events (in a separate terminal)**
+
+```bash
+colima ssh -- bash -lc "find ~/.extend-clamshell/runtime -name 'deny-events.json' -exec tail -f {} + 2>/dev/null || echo 'no deny events yet'"
+```
+
+Watch for blocked network requests. Each blocked host needs to be added to the policy.
+
+- [ ] **Step 5: Iteration — fix policy for each deny event**
+
+For each blocked host in deny events, add to `custom_endpoints` in `~/arielcharts/.belayer/policies/standard.yaml`:
+```yaml
+- host: <blocked-host>
+  ports: [443]
+  protocol: rest
+  note: <why it's needed>
+```
+
+After updating policy: stop daemon, stop existing session, restart gateway, restart daemon, retry run.
+
+Common expected blocks:
+- `opencode.ai` — already in policy
+- `api.moonshot.cn` — already in policy  
+- `registry.npmjs.org` — enabled via `npm: true` provider
+- `pypi.org` — enabled via `pypi: true` provider
+- `github.com` / `api.github.com` — enabled via `github: true` provider
+
+If new hosts appear (e.g., a CDN, a dependency), add them and document in the Surprises section.
+
+- [ ] **Step 6: Verify bridge→daemon communication works**
+
+Check daemon logs for bridge events:
+```bash
+colima ssh -- bash -lc "tail -f /tmp/daemon.log"
+```
+
+Expected: `bridge:started`, `bridge:turn_usage` events flowing in
+
+If bridge can't reach daemon, check:
+1. Is TCP listener bound? `ss -tlnp | grep 7523`
+2. Is 172.17.0.1:7523 reachable from container? `docker run --rm belayer-sandbox:latest curl -s http://172.17.0.1:7523/health`
+3. Is clamshell policy allowing port 7523 on 172.17.0.1?
+
+- [ ] **Step 7: Verify pnpm dev is running and accessible from container**
+
+```bash
+colima ssh -- bash -lc "curl -s http://localhost:3000 | head -5"
+```
+
+If pnpm dev isn't started yet (the runtime provider should start it), check daemon logs for `runtime up` errors.
+
+Test QA agent can reach it from inside a container:
+```bash
+colima ssh -- docker run --rm belayer-sandbox:latest curl -s http://172.17.0.1:3000 | head -5
+```
+
+Expected: HTML response from Next.js
+
+- [ ] **Step 8: Continue until a full session completes**
+
+Watch `belayer status` for the session to reach `completed` or `failed` state.
+
+```bash
+colima ssh -- bash -lc "watch -n 5 'belayer status 2>&1 | tail -20'"
+```
+
+Expected eventually: session status `completed`
+
+---
+
+## Task 14: Verify Telemetry and Add Network Deny Event Logging
+
+**Goal:** Ensure rich agent telemetry is captured even through clamshell, and that deny events are persisted as session artifacts.
+
+- [ ] **Step 1: Verify agent events flow through**
+
+```bash
+colima ssh -- bash -lc "belayer logs 2>&1 | grep -E 'bridge:|agent_status:' | head -30"
+```
+
+Expected: `bridge:started`, `bridge:turn_usage`, `bridge:idle`/`bridge:finished` events
+
+- [ ] **Step 2: Check if deny events are readable from belayer**
+
+Deny events are at `~/.extend-clamshell/runtime/{sandbox-name}/host/events/deny-events.json`:
+```bash
+colima ssh -- bash -lc "find ~/.extend-clamshell -name 'deny-events.json' -exec wc -l {} +"
+```
+
+- [ ] **Step 3: Add deny event logging to belayer daemon**
+
+In `internal/daemon/daemon.go` (or a new `internal/daemon/sandbox_monitor.go`), add a goroutine that watches for clamshell sandbox deny events and logs them as session events.
+
+The deny events file path pattern is: `~/.extend-clamshell/runtime/{sandbox-name}/host/events/deny-events.json`
+
+Where `sandbox-name` is the session ID (same as `cfg.Name` in `sandbox.Config`).
+
+Add this function:
+
+```go
+// watchDenyEvents tails the clamshell deny events file for a session and
+// logs each block as a "sandbox:deny" event in the session event stream.
+// Returns when ctx is done.
+func (d *Daemon) watchDenyEvents(ctx context.Context, sessionID, sandboxName string) {
+    home, _ := os.UserHomeDir()
+    denyPath := filepath.Join(home, ".extend-clamshell", "runtime", sandboxName, "host", "events", "deny-events.json")
+    
+    // Poll every 2s — deny events are low-volume
+    ticker := time.NewTicker(2 * time.Second)
+    defer ticker.Stop()
+    
+    var offset int64
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case <-ticker.C:
+            f, err := os.Open(denyPath)
+            if err != nil {
+                continue // file doesn't exist yet
+            }
+            f.Seek(offset, io.SeekStart)
+            scanner := bufio.NewScanner(f)
+            for scanner.Scan() {
+                line := scanner.Text()
+                if line == "" { continue }
+                var event map[string]any
+                if err := json.Unmarshal([]byte(line), &event); err == nil {
+                    d.store.AppendEvent(sessionID, "sandbox:deny", event)
+                    log.Printf("session %s: sandbox deny: %v", sessionID, event)
+                }
+            }
+            offset, _ = f.Seek(0, io.SeekCurrent)
+            f.Close()
+        }
+    }
+}
+```
+
+Call `go d.watchDenyEvents(ctx, sessionID, sandboxName)` after sandbox Create() in the session start flow.
+
+- [ ] **Step 4: Verify deny events appear in belayer logs**
+
+```bash
+colima ssh -- bash -lc "belayer logs 2>&1 | grep 'sandbox:deny' | head -10"
+```
+
+Expected: if there are any deny events, they should appear here
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/daemon/
+git commit -m "feat(daemon): log clamshell network deny events as session events"
+```
+
+---
+
+## Task 15: Write Summary Document
+
+**Files:**
+- `docs/CLAMSHELL-POC-SUMMARY.md`
+
+- [ ] **Step 1: Write the summary document**
+
+Create `docs/CLAMSHELL-POC-SUMMARY.md` covering:
+
+1. **Steps to get it working** — exact setup commands for a fresh Colima VM
+2. **Code changes made** — list every file changed in belayer, arielcharts, extend-clamshell
+3. **Network policy** — final list of required endpoints (from deny event log)
+4. **Risks and pitfalls** — what was hard, what can break
+5. **Next steps / improvements** — things to do before production use
+6. **Architecture insights** — anything surprising about the runtime↔sandbox connection
+
+Template:
+```markdown
+# Clamshell PoC: Steps to Production
+
+## Summary
+
+What was proven: [one paragraph]
+
+## Setup Steps (Fresh Colima VM)
+
+[Step by step commands from scratch]
+
+## Code Changes Required
+
+### belayer repo
+- [file]: [what changed and why]
+
+### extend-clamshell (Docker image)
+- [file]: [what changed and why]
+
+### arielcharts repo
+- [file]: [what changed and why]
+
+## Required Network Endpoints
+
+| Host | Port | Purpose |
+|------|------|---------|
+| ... | 443 | ... |
+
+## Risks and Pitfalls
+
+- **Seccomp syscall gaps**: The default seccomp profile may be missing syscalls...
+- **Docker bridge IP hardcoded**: 172.17.0.1 is Docker default but may differ...
+- **hermes-agent from GitHub**: No pinned version...
+
+## Next Steps for Production
+
+1. ...
+2. ...
+
+## Architecture Notes
+
+[anything surprising]
+```
+
+- [ ] **Step 2: Commit summary**
+
+```bash
+git add docs/CLAMSHELL-POC-SUMMARY.md
+git commit -m "docs: clamshell PoC summary and production roadmap"
+```
+
+---
+
+## Outcomes & Retrospective
+
+_Filled when work is done._
+
+**What worked:**
+-
+
+**What didn't:**
+-
+
+**Learnings to codify:**
+-

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.10.2
 	go.yaml.in/yaml/v3 v3.0.4
 	modernc.org/sqlite v1.45.0
@@ -12,7 +13,6 @@ require (
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -114,6 +114,7 @@ def main() -> None:
     session_id = _require_env("BELAYER_SESSION_ID")
     agent_id = _require_env("BELAYER_AGENT_ID")
     socket_path = _require_env("BELAYER_SOCKET")
+    log.info("BELAYER_SOCKET=%s (is_http=%s)", socket_path, socket_path.startswith("http"))
 
     run_dir = os.environ.get("BELAYER_RUN_DIR", "")
     role = os.environ.get("BELAYER_ROLE", "specialist")
@@ -162,6 +163,23 @@ def main() -> None:
     except Exception as exc:
         log.warning("Could not resolve runtime provider: %s (falling back to AIAgent defaults)", exc)
 
+    # --- Override/supplement with BELAYER_* provider vars --------------------
+    # These are injected by the daemon when the sandbox user has no Hermes config
+    # (e.g. clamshell). API key always overrides (container user may have an
+    # invalid key). Base URL and provider only apply when not already resolved.
+    belayer_api_key = os.environ.get("BELAYER_API_KEY", "")
+    belayer_base_url = os.environ.get("BELAYER_BASE_URL", "")
+    belayer_provider = os.environ.get("BELAYER_PROVIDER", "")
+    if belayer_api_key:
+        runtime_api_key = belayer_api_key
+        log.info("Using BELAYER_API_KEY for LLM provider")
+    if belayer_base_url and not runtime_base_url:
+        runtime_base_url = belayer_base_url
+        log.info("Using BELAYER_BASE_URL=%s for LLM provider (fallback)", belayer_base_url)
+    if belayer_provider and not runtime_provider:
+        runtime_provider = belayer_provider
+        log.info("Using BELAYER_PROVIDER=%s for LLM provider (fallback)", belayer_provider)
+
     # --- Resolve model from Hermes config if not explicitly set --------------
     if not model:
         try:
@@ -207,6 +225,45 @@ def main() -> None:
         log.error("Failed to construct AIAgent: %s", exc)
         post_event(socket_path, session_id, agent_id, "bridge:failed", {"error": str(exc)})
         sys.exit(1)
+
+    # Fix: Hermes injects a keepalive-only httpx.Client (via _create_openai_client)
+    # which wipes proxy mounts even when HTTPS_PROXY is set. Additionally, Hermes
+    # closes the OpenAI client on rebuilds, which closes any shared http_client.
+    # Solution: monkey-patch _create_openai_client to always build a fresh proxy
+    # client per OpenAI client instance, so each Hermes rebuild gets its own client.
+    _proxy_url = os.environ.get("HTTPS_PROXY", "") or os.environ.get("https_proxy", "")
+    if _proxy_url and hasattr(agent, "_create_openai_client"):
+        try:
+            import httpx as _httpx
+            import socket as _socket
+            _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
+            if hasattr(_socket, "TCP_KEEPIDLE"):
+                _sock_opts.extend([
+                    (_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 30),
+                    (_socket.IPPROTO_TCP, _socket.TCP_KEEPINTVL, 10),
+                    (_socket.IPPROTO_TCP, _socket.TCP_KEEPCNT, 3),
+                ])
+            _proxy_url_cap = _proxy_url
+            _sock_opts_cap = _sock_opts
+            _orig_create = agent._create_openai_client  # bound method
+
+            def _proxy_create(client_kwargs, *, reason, shared):
+                fresh = dict(client_kwargs)
+                fresh.pop("http_client", None)
+                fresh["http_client"] = _httpx.Client(
+                    proxy=_httpx.Proxy(_proxy_url_cap),
+                    transport=_httpx.HTTPTransport(socket_options=_sock_opts_cap),
+                )
+                return _orig_create(fresh, reason=reason, shared=shared)
+
+            agent._create_openai_client = _proxy_create
+            # Rebuild now so the initial client also gets the proxy.
+            agent.client = agent._create_openai_client(
+                agent._client_kwargs, reason="proxy_inject", shared=True
+            )
+            log.info("Patched _create_openai_client for proxy+keepalive (proxy=%s)", _proxy_url)
+        except Exception as _e:
+            log.warning("Could not patch proxy client into AIAgent: %s", _e)
 
     # --- Register Belayer tools --------------------------------------------
     allowed_tools_env = os.environ.get("BELAYER_TOOLS", "")

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -116,12 +116,18 @@ def main() -> None:
     socket_path = _require_env("BELAYER_SOCKET")
     log.info("BELAYER_SOCKET=%s (is_http=%s)", socket_path, socket_path.startswith("http"))
 
+    # Multiline env values are escaped by the Go-side writeEnvFile() as the
+    # two-character sequence `\n` so docker --env-file stays parseable. Decode
+    # any BELAYER_* value that can legitimately contain newlines here.
+    def _decode_nl(val: str) -> str:
+        return val.replace(r"\n", "\n")
+
     run_dir = os.environ.get("BELAYER_RUN_DIR", "")
     role = os.environ.get("BELAYER_ROLE", "specialist")
     profile = os.environ.get("BELAYER_PROFILE", "")
     model = os.environ.get("BELAYER_MODEL", "")
-    initial_message = os.environ.get("BELAYER_MESSAGE", "")
-    system_prompt = os.environ.get("BELAYER_SYSTEM_PROMPT", "").replace(r"\n", "\n")
+    initial_message = _decode_nl(os.environ.get("BELAYER_MESSAGE", ""))
+    system_prompt = _decode_nl(os.environ.get("BELAYER_SYSTEM_PROMPT", ""))
     hermes_session_id = os.environ.get("BELAYER_HERMES_SESSION_ID", "")
     ephemeral = os.environ.get("BELAYER_EPHEMERAL", "true").lower() != "false"
 
@@ -257,10 +263,18 @@ def main() -> None:
                 return _orig_create(fresh, reason=reason, shared=shared)
 
             agent._create_openai_client = _proxy_create
-            # Rebuild now so the initial client also gets the proxy.
+            # Rebuild now so the initial client also gets the proxy. Close the
+            # pre-patch client first so its httpx transport pool is released —
+            # otherwise the original client's sockets hang around until GC.
+            old_client = getattr(agent, "client", None)
             agent.client = agent._create_openai_client(
                 agent._client_kwargs, reason="proxy_inject", shared=True
             )
+            if old_client is not None:
+                try:
+                    old_client.close()
+                except Exception:  # noqa: BLE001 - best-effort cleanup
+                    pass
             log.info("Patched _create_openai_client for proxy+keepalive (proxy=%s)", _proxy_url)
         except Exception as _e:
             log.warning("Could not patch proxy client into AIAgent: %s", _e)

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -120,7 +120,7 @@ def main() -> None:
     profile = os.environ.get("BELAYER_PROFILE", "")
     model = os.environ.get("BELAYER_MODEL", "")
     initial_message = os.environ.get("BELAYER_MESSAGE", "")
-    system_prompt = os.environ.get("BELAYER_SYSTEM_PROMPT", "")
+    system_prompt = os.environ.get("BELAYER_SYSTEM_PROMPT", "").replace(r"\n", "\n")
     hermes_session_id = os.environ.get("BELAYER_HERMES_SESSION_ID", "")
     ephemeral = os.environ.get("BELAYER_EPHEMERAL", "true").lower() != "false"
 

--- a/hermes_bridge/http_client.py
+++ b/hermes_bridge/http_client.py
@@ -22,7 +22,10 @@ log = logging.getLogger("http_client")
 
 
 def _is_http_url(socket_path: str) -> bool:
-    return socket_path.startswith("http://") or socket_path.startswith("https://")
+    """Return True for plain HTTP URLs. HTTPS is intentionally not supported;
+    the daemon is only reached over loopback, a bind-mounted Unix socket, or
+    an HTTP-CONNECT proxy, so TLS termination is never needed."""
+    return socket_path.startswith("http://")
 
 
 def _make_conn(socket_path: str) -> http.client.HTTPConnection:

--- a/hermes_bridge/http_client.py
+++ b/hermes_bridge/http_client.py
@@ -1,38 +1,41 @@
-"""Shared Unix socket HTTP client for daemon communication.
+"""HTTP client for daemon communication.
 
-All daemon calls go through a Unix socket. Python's http.client supports
-this by swapping in a pre-connected AF_UNIX socket. Each call creates a
-fresh connection — volume is low enough that pooling isn't worth the
-complexity.
+Supports both Unix socket paths (e.g. /path/to/daemon.sock) and HTTP URL
+addresses (e.g. http://172.17.0.1:7523). Unix sockets are used when belayer
+runs with noop sandbox mode; HTTP URLs are used when bridges run inside
+clamshell Docker containers and reach the daemon via Docker's host gateway.
 """
 
 import json
 import logging
 import http.client
 import socket as sock
+from urllib.parse import urlparse
 
 log = logging.getLogger("http_client")
 
 
+def _is_http_url(socket_path: str) -> bool:
+    return socket_path.startswith("http://") or socket_path.startswith("https://")
+
+
+def _make_conn(socket_path: str) -> http.client.HTTPConnection:
+    if _is_http_url(socket_path):
+        parsed = urlparse(socket_path)
+        return http.client.HTTPConnection(parsed.hostname, parsed.port or 80)
+    conn = http.client.HTTPConnection("localhost")
+    s = sock.socket(sock.AF_UNIX, sock.SOCK_STREAM)
+    s.connect(socket_path)
+    conn.sock = s
+    return conn
+
+
 def unix_post(socket_path: str, path: str, body: dict) -> tuple[int, str]:
-    """POST JSON body to the daemon over its Unix socket.
-
-    Returns (status_code, response_body_text).
-    Returns (0, error_message) on connection/IO failure.
-    """
+    """POST JSON body to the daemon over its Unix socket or TCP address."""
     try:
-        conn = http.client.HTTPConnection("localhost")
-        s = sock.socket(sock.AF_UNIX, sock.SOCK_STREAM)
-        s.connect(socket_path)
-        conn.sock = s
-
+        conn = _make_conn(socket_path)
         payload = json.dumps(body).encode()
-        conn.request(
-            "POST",
-            path,
-            body=payload,
-            headers={"Content-Type": "application/json"},
-        )
+        conn.request("POST", path, body=payload, headers={"Content-Type": "application/json"})
         resp = conn.getresponse()
         resp_body = resp.read().decode()
         conn.close()
@@ -43,17 +46,9 @@ def unix_post(socket_path: str, path: str, body: dict) -> tuple[int, str]:
 
 
 def unix_get(socket_path: str, path: str) -> tuple[int, str]:
-    """GET from the daemon over its Unix socket.
-
-    Returns (status_code, response_body_text).
-    Returns (0, error_message) on failure.
-    """
+    """GET from the daemon over its Unix socket or TCP address."""
     try:
-        conn = http.client.HTTPConnection("localhost")
-        s = sock.socket(sock.AF_UNIX, sock.SOCK_STREAM)
-        s.connect(socket_path)
-        conn.sock = s
-
+        conn = _make_conn(socket_path)
         conn.request("GET", path)
         resp = conn.getresponse()
         resp_body = resp.read().decode()

--- a/hermes_bridge/http_client.py
+++ b/hermes_bridge/http_client.py
@@ -1,13 +1,19 @@
 """HTTP client for daemon communication.
 
-Supports both Unix socket paths (e.g. /path/to/daemon.sock) and HTTP URL
-addresses (e.g. http://172.17.0.1:7523). Unix sockets are used when belayer
-runs with noop sandbox mode; HTTP URLs are used when bridges run inside
-clamshell Docker containers and reach the daemon via Docker's host gateway.
+Supports Unix socket paths, direct HTTP URLs, and HTTP-CONNECT-proxied URLs.
+
+- Unix socket (e.g. /path/to/daemon.sock): used in noop sandbox mode.
+- Direct HTTP URL (e.g. http://172.17.0.1:7523): used when the host gateway
+  is directly reachable from the container.
+- CONNECT-proxied HTTP URL: used inside clamshell sandboxes where the host
+  gateway is not directly routable. Set BELAYER_HTTP_PROXY=http://host:port
+  to route daemon calls through an HTTP CONNECT proxy (clamshell transparent
+  proxy at 172.31.0.2:3128).
 """
 
 import json
 import logging
+import os
 import http.client
 import socket as sock
 from urllib.parse import urlparse
@@ -22,6 +28,12 @@ def _is_http_url(socket_path: str) -> bool:
 def _make_conn(socket_path: str) -> http.client.HTTPConnection:
     if _is_http_url(socket_path):
         parsed = urlparse(socket_path)
+        proxy_url = os.environ.get("BELAYER_HTTP_PROXY", "")
+        if proxy_url:
+            proxy = urlparse(proxy_url)
+            conn = http.client.HTTPConnection(proxy.hostname, proxy.port or 3128)
+            conn.set_tunnel(parsed.hostname, parsed.port or 80)
+            return conn
         return http.client.HTTPConnection(parsed.hostname, parsed.port or 80)
     conn = http.client.HTTPConnection("localhost")
     s = sock.socket(sock.AF_UNIX, sock.SOCK_STREAM)

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -35,9 +35,13 @@ type Config struct {
 	Role            string
 	Profile         string
 	Workdir         string
-	SocketPath      string // daemon Unix socket path
+	SocketPath      string // daemon Unix socket path or http://host:port for TCP
+	HTTPProxy       string // HTTP CONNECT proxy for clamshell (e.g. http://172.31.0.2:3128)
 	RunDir          string // e.g. /workspace/.belayer/runs/{session}/{agent}
 	Model           string // optional model override
+	APIKey          string // LLM provider API key (injected when Hermes config is unavailable, e.g. clamshell)
+	BaseURL         string // LLM provider base URL (e.g. https://opencode.ai/zen/go/v1)
+	Provider        string // LLM provider name (e.g. "openai")
 	Message         string // initial message/instructions for the agent
 	SystemPrompt    string // optional system prompt injected via ephemeral_system_prompt
 	HermesSessionID string // for crash recovery resume
@@ -105,11 +109,31 @@ func BuildEnv(cfg Config) []string {
 	env = appendEnv(env, "BELAYER_SESSION_ID", cfg.SessionID)
 	env = appendEnv(env, "BELAYER_AGENT_ID", cfg.AgentID)
 	env = appendEnv(env, "BELAYER_SOCKET", cfg.SocketPath)
+	if cfg.HTTPProxy != "" {
+		env = appendEnv(env, "BELAYER_HTTP_PROXY", cfg.HTTPProxy)
+		// Inject standard proxy env vars so Python's httpx/requests/urllib route
+		// LLM API calls through the sandbox egress broker. The docker exec env-file
+		// only contains what we pass — the container's startup env is not inherited.
+		for _, k := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"} {
+			env = appendEnv(env, k, cfg.HTTPProxy)
+		}
+		env = appendEnv(env, "NO_PROXY", "127.0.0.1,localhost,::1")
+		env = appendEnv(env, "no_proxy", "127.0.0.1,localhost,::1")
+	}
 	env = appendEnv(env, "BELAYER_RUN_DIR", cfg.RunDir)
 	env = appendEnv(env, "BELAYER_ROLE", cfg.Role)
 	env = appendEnv(env, "BELAYER_PROFILE", cfg.Profile)
 	if cfg.Model != "" {
 		env = appendEnv(env, "BELAYER_MODEL", cfg.Model)
+	}
+	if cfg.APIKey != "" {
+		env = appendEnv(env, "BELAYER_API_KEY", cfg.APIKey)
+	}
+	if cfg.BaseURL != "" {
+		env = appendEnv(env, "BELAYER_BASE_URL", cfg.BaseURL)
+	}
+	if cfg.Provider != "" {
+		env = appendEnv(env, "BELAYER_PROVIDER", cfg.Provider)
 	}
 	if cfg.Message != "" {
 		env = appendEnv(env, "BELAYER_MESSAGE", cfg.Message)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -65,9 +65,15 @@ func newDaemonCmd() *cobra.Command {
 			if dockerGateway != "" {
 				cfg.DockerHostGateway = dockerGateway
 			}
-			cfg.BridgeAPIKey = bridgeAPIKey
-			cfg.BridgeBaseURL = bridgeBaseURL
-			cfg.BridgeProvider = bridgeProvider
+			if bridgeAPIKey != "" {
+				cfg.BridgeAPIKey = bridgeAPIKey
+			}
+			if bridgeBaseURL != "" {
+				cfg.BridgeBaseURL = bridgeBaseURL
+			}
+			if bridgeProvider != "" {
+				cfg.BridgeProvider = bridgeProvider
+			}
 
 			wd := workdir
 			if wd == "" {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -5,22 +5,50 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/donovan-yohan/belayer/internal/daemon"
 	"github.com/donovan-yohan/belayer/internal/runtime"
 	"github.com/donovan-yohan/belayer/internal/sandbox"
+	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 )
 
+// loadEnvFile reads KEY=VALUE lines from path into the current process
+// environment without overwriting already-set vars (workspace file wins over
+// home file because workspace is loaded first).
+func loadEnvFile(path string) {
+	if _, err := os.Stat(path); err != nil {
+		return
+	}
+	_ = godotenv.Load(path) // godotenv.Load skips keys already in os.Environ
+}
+
 func newDaemonCmd() *cobra.Command {
 	var socketPath, dbPath, belayerRoot, workdir, tcpAddr, dockerGateway string
+	var bridgeAPIKey, bridgeBaseURL, bridgeProvider string
 
 	cmd := &cobra.Command{
 		Use:   "daemon",
 		Short: "Start the belayer daemon",
 		Long:  "Starts the long-running belayer supervisor on a Unix socket.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Load .belayer.env files into the daemon process environment so
+			// bridge subprocesses inherit provider credentials (e.g. OPENCODE_GO_API_KEY).
+			// Workspace-scoped file is loaded first so it takes precedence over home.
+			wd0 := workdir
+			if wd0 == "" {
+				if cwd, err := os.Getwd(); err == nil {
+					wd0 = cwd
+				}
+			}
+			if wd0 != "" {
+				loadEnvFile(filepath.Join(wd0, ".belayer", ".belayer.env"))
+			}
+			home, _ := os.UserHomeDir()
+			loadEnvFile(filepath.Join(home, ".belayer.env"))
+
 			cfg := daemon.DefaultConfig()
 			if socketPath != "" {
 				cfg.SocketPath = socketPath
@@ -37,6 +65,9 @@ func newDaemonCmd() *cobra.Command {
 			if dockerGateway != "" {
 				cfg.DockerHostGateway = dockerGateway
 			}
+			cfg.BridgeAPIKey = bridgeAPIKey
+			cfg.BridgeBaseURL = bridgeBaseURL
+			cfg.BridgeProvider = bridgeProvider
 
 			wd := workdir
 			if wd == "" {
@@ -59,6 +90,13 @@ func newDaemonCmd() *cobra.Command {
 			} else {
 				fmt.Fprintf(cmd.OutOrStdout(), "belayer runtime: command (loaded from %s/.belayer/config.yaml)\n", wd)
 			}
+			// If the workdir has a .belayer/ directory, also bind a Unix socket
+			// there so clamshell bridge subprocesses can reach the daemon via the
+			// bind-mounted workspace path (/workspace/.belayer/daemon.sock).
+			wsSock := filepath.Join(wd, ".belayer", "daemon.sock")
+			if _, err := os.Stat(filepath.Dir(wsSock)); err == nil {
+				cfg.WorkspaceSockPath = wsSock
+			}
 
 			d, err := daemon.New(cfg)
 			if err != nil {
@@ -79,5 +117,8 @@ func newDaemonCmd() *cobra.Command {
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Workspace directory (for .belayer/config.yaml lookup; default cwd)")
 	cmd.Flags().StringVar(&tcpAddr, "tcp-addr", "", "Also bind a TCP listener (e.g. 0.0.0.0:7523) for clamshell container access")
 	cmd.Flags().StringVar(&dockerGateway, "docker-gateway", "", "Docker host gateway IP for clamshell bridge access (default 172.17.0.1)")
+	cmd.Flags().StringVar(&bridgeAPIKey, "bridge-api-key", "", "LLM provider API key injected into bridge subprocesses (for clamshell where sandbox has no Hermes config)")
+	cmd.Flags().StringVar(&bridgeBaseURL, "bridge-base-url", "", "LLM provider base URL injected into bridge subprocesses (e.g. https://opencode.ai/zen/go/v1)")
+	cmd.Flags().StringVar(&bridgeProvider, "bridge-provider", "", "LLM provider name injected into bridge subprocesses (e.g. openai)")
 	return cmd
 }

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -14,7 +14,7 @@ import (
 )
 
 func newDaemonCmd() *cobra.Command {
-	var socketPath, dbPath, belayerRoot, workdir string
+	var socketPath, dbPath, belayerRoot, workdir, tcpAddr, dockerGateway string
 
 	cmd := &cobra.Command{
 		Use:   "daemon",
@@ -30,6 +30,12 @@ func newDaemonCmd() *cobra.Command {
 			}
 			if belayerRoot != "" {
 				cfg.BelayerRoot = belayerRoot
+			}
+			if tcpAddr != "" {
+				cfg.TCPAddr = tcpAddr
+			}
+			if dockerGateway != "" {
+				cfg.DockerHostGateway = dockerGateway
 			}
 
 			wd := workdir
@@ -71,5 +77,7 @@ func newDaemonCmd() *cobra.Command {
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database path (default ~/.belayer/belayer.db)")
 	cmd.Flags().StringVar(&belayerRoot, "belayer-root", "", "Path to belayer repo root (for hermes_bridge PYTHONPATH)")
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Workspace directory (for .belayer/config.yaml lookup; default cwd)")
+	cmd.Flags().StringVar(&tcpAddr, "tcp-addr", "", "Also bind a TCP listener (e.g. 0.0.0.0:7523) for clamshell container access")
+	cmd.Flags().StringVar(&dockerGateway, "docker-gateway", "", "Docker host gateway IP for clamshell bridge access (default 172.17.0.1)")
 	return cmd
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -57,8 +57,9 @@ func newRunStartCmd() *cobra.Command {
 				return fmt.Errorf("auto-init .belayer/: %w", err)
 			}
 
-			// Create session — we need its ID first to provision the workspace.
-			sess, err := c.CreateSession(sessionName, "nightshift", repos, "")
+			// Create session with baseDir as workspace so the daemon can resolve
+			// sandbox settings (.belayer/config.yaml) even when no repos are given.
+			sess, err := c.CreateSession(sessionName, "nightshift", repos, baseDir)
 			if err != nil {
 				return fmt.Errorf("create session: %w", err)
 			}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -29,7 +29,7 @@ func newRunStartCmd() *cobra.Command {
 				return fmt.Errorf("--task is required")
 			}
 			if strings.TrimSpace(supervisorProfile) == "" {
-				return fmt.Errorf("--supervisor-profile is required")
+				supervisorProfile = "default"
 			}
 
 			// Parse repos.
@@ -113,7 +113,7 @@ func newRunStartCmd() *cobra.Command {
 	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
 	cmd.Flags().StringVar(&name, "name", "", "Run/session name")
 	cmd.Flags().StringVar(&task, "task", "", "Initial task text for the supervisor")
-	cmd.Flags().StringVar(&supervisorProfile, "supervisor-profile", "", "Hermes profile for the supervisor")
+	cmd.Flags().StringVar(&supervisorProfile, "supervisor-profile", "default", "Hermes profile for the supervisor")
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Working directory (defaults to cwd)")
 	cmd.Flags().StringVar(&reposFlag, "repos", "", "Repos to include: name=path,name=path (e.g. frontend=../fe,backend=../be)")
 	return cmd

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -145,6 +145,7 @@ func (d *Daemon) handleSpawnAgent(w http.ResponseWriter, r *http.Request) {
 
 	proc, err := d.spawnBridgeAgent(req)
 	if err != nil {
+		log.Printf("spawn agent %s failed: %v", req.Name, err)
 		_ = d.store.UpdateAgentRunStatus(sessionID, req.Name, "failed")
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -417,6 +418,11 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		RunDir:          runDir,
 		BelayerRoot:     d.config.BelayerRoot,
 		BelayerTools:    belayerTools,
+	}
+	// In clamshell mode the bridge runs inside the Docker container where the
+	// host hermes venv path doesn't exist; use the container's system python3.
+	if ss.mode == "clamshell" {
+		cfg.Cmd = []string{"python3", "-m", "hermes_bridge"}
 	}
 	_ = worktreePath // stored in DB; cleanup handled separately
 

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -362,28 +362,6 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		break
 	}
 
-	cfg := bridge.Config{
-		SessionID:       req.SessionID,
-		AgentID:         req.Name,
-		Role:            req.Role,
-		Profile:         req.Profile,
-		Model:           req.Model,
-		Message:         req.Message,
-		SystemPrompt:    systemPrompt,
-		HermesSessionID: req.HermesSessionID,
-		Ephemeral:       ephemeral,
-		Workdir:         workdir,
-		SocketPath:      d.config.SocketPath,
-		RunDir:          runDir,
-		BelayerRoot:     d.config.BelayerRoot,
-		BelayerTools:    belayerTools,
-	}
-	_ = worktreePath // stored in DB; cleanup handled separately
-
-	// Build command and environment using bridge pure functions.
-	argv := bridge.BuildCmd(cfg)
-	env := bridge.BuildEnv(cfg)
-
 	// Set up stdin pipe for daemon→agent communication.
 	stdinR, stdinW, err := os.Pipe()
 	if err != nil {
@@ -405,7 +383,8 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		return nil, fmt.Errorf("open stderr log: %w", err)
 	}
 
-	// Get or create sandbox handle for the session.
+	// Get or create sandbox handle for the session. Must happen before building
+	// bridge.Config so we can select the correct socket path (Unix vs TCP).
 	sess, err := d.store.GetSession(req.SessionID)
 	if err != nil {
 		stdinR.Close()
@@ -422,6 +401,28 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		stderrLog.Close()
 		return nil, fmt.Errorf("ensure sandbox handle: %w", err)
 	}
+
+	cfg := bridge.Config{
+		SessionID:       req.SessionID,
+		AgentID:         req.Name,
+		Role:            req.Role,
+		Profile:         req.Profile,
+		Model:           req.Model,
+		Message:         req.Message,
+		SystemPrompt:    systemPrompt,
+		HermesSessionID: req.HermesSessionID,
+		Ephemeral:       ephemeral,
+		Workdir:         workdir,
+		SocketPath:      bridgeSocketPath(ss.mode, d.config.SocketPath, d.config.DockerHostGateway, d.tcpPort),
+		RunDir:          runDir,
+		BelayerRoot:     d.config.BelayerRoot,
+		BelayerTools:    belayerTools,
+	}
+	_ = worktreePath // stored in DB; cleanup handled separately
+
+	// Build command and environment using bridge pure functions.
+	argv := bridge.BuildCmd(cfg)
+	env := bridge.BuildEnv(cfg)
 
 	osProc, err := ss.driver.Exec(d.startCtx, ss.handle, argv, sandbox.ExecOpts{
 		Env:    env,
@@ -722,6 +723,17 @@ func agentIdentityPaths(workdir, belayerRoot, identity, file string) []string {
 		addPath(filepath.Join(belayerRoot, "agents", identity, file))
 	}
 	return paths
+}
+
+// bridgeSocketPath returns the socket path/URL to use as BELAYER_SOCKET for a
+// bridge subprocess. For clamshell sandboxes the bridge runs inside a Docker
+// container and must reach the daemon via the Docker host gateway over TCP.
+// For all other drivers the Unix socket path is returned unchanged.
+func bridgeSocketPath(mode, unixPath, dockerGateway string, tcpPort int) string {
+	if mode == "clamshell" && tcpPort > 0 {
+		return fmt.Sprintf("http://%s:%d", dockerGateway, tcpPort)
+	}
+	return unixPath
 }
 
 func splitLines(s string) []string {

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -750,6 +750,10 @@ func agentIdentityPaths(workdir, belayerRoot, identity, file string) []string {
 // container and accesses the daemon via a Unix socket in the bind-mounted
 // workspace directory (/workspace/.belayer/daemon.sock). Falls back to the
 // TCP gateway URL if the workspace socket path was not configured.
+//
+// The container-side /workspace path is a clamshell convention enforced by the
+// sandbox driver (see sandbox/clamshell.go:sandboxWorkspace). If that constant
+// ever changes, this function must be updated in lockstep.
 func bridgeSocketPath(mode, unixPath, dockerGateway string, tcpPort int, workspaceSockPath string) string {
 	if mode != "clamshell" {
 		return unixPath

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -410,26 +410,33 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		return nil, fmt.Errorf("ensure sandbox handle: %w", err)
 	}
 
+	socketPath := bridgeSocketPath(ss.mode, d.config.SocketPath, d.config.DockerHostGateway, d.tcpPort, d.config.WorkspaceSockPath)
+	log.Printf("spawn %s: mode=%q socketPath=%q tcpPort=%d gateway=%q", req.Name, ss.mode, socketPath, d.tcpPort, d.config.DockerHostGateway)
 	cfg := bridge.Config{
 		SessionID:       req.SessionID,
 		AgentID:         req.Name,
 		Role:            req.Role,
 		Profile:         req.Profile,
 		Model:           agentModel,
+		APIKey:          d.config.BridgeAPIKey,
+		BaseURL:         d.config.BridgeBaseURL,
+		Provider:        d.config.BridgeProvider,
 		Message:         req.Message,
 		SystemPrompt:    systemPrompt,
 		HermesSessionID: req.HermesSessionID,
 		Ephemeral:       ephemeral,
 		Workdir:         workdir,
-		SocketPath:      bridgeSocketPath(ss.mode, d.config.SocketPath, d.config.DockerHostGateway, d.tcpPort),
+		SocketPath:      socketPath,
 		RunDir:          runDir,
 		BelayerRoot:     d.config.BelayerRoot,
 		BelayerTools:    belayerTools,
 	}
 	// In clamshell mode the bridge runs inside the Docker container where the
 	// host hermes venv path doesn't exist; use the container's system python3.
+	// Also inject proxy vars so LLM API calls route through the egress broker.
 	if ss.mode == "clamshell" {
 		cfg.Cmd = []string{"python3", "-m", "hermes_bridge"}
+		cfg.HTTPProxy = "http://proxy.internal:3128"
 	}
 	_ = worktreePath // stored in DB; cleanup handled separately
 
@@ -740,10 +747,20 @@ func agentIdentityPaths(workdir, belayerRoot, identity, file string) []string {
 
 // bridgeSocketPath returns the socket path/URL to use as BELAYER_SOCKET for a
 // bridge subprocess. For clamshell sandboxes the bridge runs inside a Docker
-// container and must reach the daemon via the Docker host gateway over TCP.
-// For all other drivers the Unix socket path is returned unchanged.
-func bridgeSocketPath(mode, unixPath, dockerGateway string, tcpPort int) string {
-	if mode == "clamshell" && tcpPort > 0 {
+// container and accesses the daemon via a Unix socket in the bind-mounted
+// workspace directory (/workspace/.belayer/daemon.sock). Falls back to the
+// TCP gateway URL if the workspace socket path was not configured.
+func bridgeSocketPath(mode, unixPath, dockerGateway string, tcpPort int, workspaceSockPath string) string {
+	if mode != "clamshell" {
+		return unixPath
+	}
+	// Prefer workspace Unix socket: the workspace is bind-mounted into the
+	// container at /workspace, so the container-side path is always this.
+	if workspaceSockPath != "" {
+		return "/workspace/.belayer/daemon.sock"
+	}
+	// Fallback: TCP listener via Docker host gateway.
+	if tcpPort > 0 {
 		return fmt.Sprintf("http://%s:%d", dockerGateway, tcpPort)
 	}
 	return unixPath

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -330,9 +330,10 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		}
 	}
 
-	// Load belayer_tools from <agent-dir>/agent.yaml if it exists. Same
+	// Load belayer_tools and model from <agent-dir>/agent.yaml if it exists. Same
 	// project-local-over-shipped resolution as the system prompt.
 	var belayerTools []string
+	agentModel := req.Model // explicit spawn request takes precedence
 	for _, yamlPath := range agentIdentityPaths(workdir, d.config.BelayerRoot, identity, "agent.yaml") {
 		data, err := os.ReadFile(yamlPath)
 		if err != nil {
@@ -340,9 +341,15 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		}
 		// Simple line-based parse — avoid YAML library dependency.
 		// Looks for "belayer_tools:" then collects "  - tool_name" lines.
+		// Also reads "model: <value>" for the default model.
 		inTools := false
 		for _, line := range splitLines(string(data)) {
 			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "model:") && agentModel == "" {
+				agentModel = strings.TrimSpace(strings.TrimPrefix(trimmed, "model:"))
+				inTools = false
+				continue
+			}
 			if trimmed == "belayer_tools:" || trimmed == "belayer_tools: []" {
 				inTools = true
 				if trimmed == "belayer_tools: []" {
@@ -359,7 +366,7 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 				}
 			}
 		}
-		log.Printf("Loaded belayer_tools from %s for agent %s (identity=%s): %v", yamlPath, req.Name, identity, belayerTools)
+		log.Printf("Loaded agent.yaml from %s for agent %s (identity=%s): model=%q tools=%v", yamlPath, req.Name, identity, agentModel, belayerTools)
 		break
 	}
 
@@ -408,7 +415,7 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		AgentID:         req.Name,
 		Role:            req.Role,
 		Profile:         req.Profile,
-		Model:           req.Model,
+		Model:           agentModel,
 		Message:         req.Message,
 		SystemPrompt:    systemPrompt,
 		HermesSessionID: req.HermesSessionID,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -40,6 +40,12 @@ type Config struct {
 	// subprocesses. Defaults to "172.17.0.1" (standard Docker bridge network).
 	DockerHostGateway string
 
+	// WorkspaceSockPath, if non-empty, causes the daemon to also bind a Unix
+	// socket at this path. Used when sandbox.mode=clamshell so bridge
+	// subprocesses inside Docker containers can reach the daemon via a
+	// bind-mounted workspace path (e.g. /workspace/.belayer/daemon.sock).
+	WorkspaceSockPath string
+
 	// SandboxDrivers is the registry the daemon resolves per-session drivers
 	// against. Each session's driver is chosen by name from .belayer/config.yaml's
 	// sandbox.mode. Nil falls back to a registry containing only the noop driver,
@@ -48,6 +54,13 @@ type Config struct {
 	// Runtime overrides the dev-stack provider.
 	// Nil falls back to &runtime.Noop{}.
 	Runtime runtime.Provider
+
+	// BridgeAPIKey, BridgeBaseURL, BridgeProvider are injected as BELAYER_API_KEY /
+	// BELAYER_BASE_URL / BELAYER_PROVIDER into every bridge subprocess. Used in
+	// clamshell mode where the sandbox user has no Hermes provider configured.
+	BridgeAPIKey  string
+	BridgeBaseURL string
+	BridgeProvider string
 }
 
 // DefaultConfig returns config using ~/.belayer/ paths.
@@ -87,6 +100,11 @@ type Daemon struct {
 	// Nil when config.TCPAddr is empty.
 	tcpListener *http.Server
 	tcpPort     int
+
+	// workspaceSockListener is an optional Unix socket inside the workspace
+	// directory so clamshell bridge subprocesses can reach the daemon via a
+	// bind-mounted path without network proxying.
+	workspaceSockListener *http.Server
 
 	// Per-session sandbox state. Each entry caches the driver resolved from
 	// .belayer/config.yaml's sandbox.mode plus the Handle returned by Create.
@@ -201,6 +219,32 @@ func (d *Daemon) Start(ctx context.Context) error {
 		log.Printf("daemon: TCP listener on %s (port %d)", d.config.TCPAddr, d.tcpPort)
 	}
 
+	// Optional workspace Unix socket for clamshell container bridge access.
+	// The workspace directory is bind-mounted into clamshell containers so the
+	// bridge can reach the daemon via /workspace/.belayer/daemon.sock without
+	// any network proxying.
+	if d.config.WorkspaceSockPath != "" {
+		if err := os.MkdirAll(filepath.Dir(d.config.WorkspaceSockPath), 0o755); err != nil {
+			ln.Close()
+			return fmt.Errorf("daemon: create workspace sock dir: %w", err)
+		}
+		os.Remove(d.config.WorkspaceSockPath)
+		wsLn, err := net.Listen("unix", d.config.WorkspaceSockPath)
+		if err != nil {
+			ln.Close()
+			return fmt.Errorf("daemon: listen workspace sock %s: %w", d.config.WorkspaceSockPath, err)
+		}
+		// World-readable so the sandbox user (non-root) inside clamshell can connect.
+		os.Chmod(d.config.WorkspaceSockPath, 0o777)
+		d.workspaceSockListener = &http.Server{Handler: d.server.Handler}
+		go func() {
+			if serveErr := d.workspaceSockListener.Serve(wsLn); serveErr != nil && serveErr != http.ErrServerClosed {
+				log.Printf("daemon: workspace sock serve: %v", serveErr)
+			}
+		}()
+		log.Printf("daemon: workspace socket on %s", d.config.WorkspaceSockPath)
+	}
+
 	// Provision the runtime before serving. For the noop provider this is a
 	// no-op; the hook exists so future providers (command, clamshell, ...)
 	// can fail fast if the dev stack can't come up. Captured endpoints flow
@@ -235,6 +279,9 @@ func (d *Daemon) Shutdown(ctx context.Context) error {
 	err := d.server.Shutdown(shutCtx)
 	if d.tcpListener != nil {
 		_ = d.tcpListener.Shutdown(shutCtx)
+	}
+	if d.workspaceSockListener != nil {
+		_ = d.workspaceSockListener.Shutdown(shutCtx)
 	}
 
 	// Tear down any outstanding sandbox handles.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -202,6 +202,21 @@ func (d *Daemon) Start(ctx context.Context) error {
 	d.listener = ln
 	d.startCtx = ctx
 
+	// cleanupExtraListeners shuts down any TCP/workspace servers started below
+	// and removes the workspace socket file. Called on any early-return error
+	// path so we don't leak background goroutines or bound sockets.
+	cleanupExtraListeners := func() {
+		if d.tcpListener != nil {
+			_ = d.tcpListener.Close()
+		}
+		if d.workspaceSockListener != nil {
+			_ = d.workspaceSockListener.Close()
+		}
+		if d.config.WorkspaceSockPath != "" {
+			os.Remove(d.config.WorkspaceSockPath)
+		}
+	}
+
 	// Optional TCP listener for clamshell container bridge access.
 	if d.config.TCPAddr != "" {
 		tcpLn, err := net.Listen("tcp", d.config.TCPAddr)
@@ -225,17 +240,28 @@ func (d *Daemon) Start(ctx context.Context) error {
 	// any network proxying.
 	if d.config.WorkspaceSockPath != "" {
 		if err := os.MkdirAll(filepath.Dir(d.config.WorkspaceSockPath), 0o755); err != nil {
+			cleanupExtraListeners()
 			ln.Close()
 			return fmt.Errorf("daemon: create workspace sock dir: %w", err)
 		}
 		os.Remove(d.config.WorkspaceSockPath)
 		wsLn, err := net.Listen("unix", d.config.WorkspaceSockPath)
 		if err != nil {
+			cleanupExtraListeners()
 			ln.Close()
 			return fmt.Errorf("daemon: listen workspace sock %s: %w", d.config.WorkspaceSockPath, err)
 		}
-		// World-readable so the sandbox user (non-root) inside clamshell can connect.
-		os.Chmod(d.config.WorkspaceSockPath, 0o777)
+		// Readable/writable by any user so the non-root sandbox user inside the
+		// clamshell container can reach the socket through the bind mount.
+		// Execute bit is meaningless on a socket, so 0o666 is strictly tighter
+		// than 0o777. TODO: narrow to 0o660 via dedicated group + chown once
+		// the container UID/GID mapping is stabilized.
+		if err := os.Chmod(d.config.WorkspaceSockPath, 0o666); err != nil {
+			wsLn.Close()
+			cleanupExtraListeners()
+			ln.Close()
+			return fmt.Errorf("daemon: chmod workspace sock %s: %w", d.config.WorkspaceSockPath, err)
+		}
 		d.workspaceSockListener = &http.Server{Handler: d.server.Handler}
 		go func() {
 			if serveErr := d.workspaceSockListener.Serve(wsLn); serveErr != nil && serveErr != http.ErrServerClosed {
@@ -251,6 +277,8 @@ func (d *Daemon) Start(ctx context.Context) error {
 	// into each session's sandbox via ensureSandboxHandle.
 	endpoints, err := d.runtime.Up(ctx)
 	if err != nil {
+		cleanupExtraListeners()
+		ln.Close()
 		return fmt.Errorf("daemon: runtime up: %w", err)
 	}
 	d.runtimeEndpoints = endpoints
@@ -301,6 +329,9 @@ func (d *Daemon) Shutdown(ctx context.Context) error {
 
 	d.store.Close()
 	os.Remove(d.config.SocketPath)
+	if d.config.WorkspaceSockPath != "" {
+		os.Remove(d.config.WorkspaceSockPath)
+	}
 	return err
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -30,6 +30,16 @@ type Config struct {
 	DBPath      string
 	BelayerRoot string // directory containing hermes_bridge/ (for PYTHONPATH)
 
+	// TCPAddr, if non-empty, causes the daemon to also bind a TCP listener at
+	// this address (e.g. "0.0.0.0:7523"). Used when sandbox.mode=clamshell so
+	// bridge subprocesses inside Docker containers can reach the daemon via the
+	// Docker host gateway (172.17.0.1). Use "host:0" to let the OS pick a port.
+	TCPAddr string
+	// DockerHostGateway is the IP address of the Docker host as seen from inside
+	// Docker containers. Used to build BELAYER_SOCKET for clamshell bridge
+	// subprocesses. Defaults to "172.17.0.1" (standard Docker bridge network).
+	DockerHostGateway string
+
 	// SandboxDrivers is the registry the daemon resolves per-session drivers
 	// against. Each session's driver is chosen by name from .belayer/config.yaml's
 	// sandbox.mode. Nil falls back to a registry containing only the noop driver,
@@ -45,8 +55,9 @@ func DefaultConfig() Config {
 	home, _ := os.UserHomeDir()
 	base := filepath.Join(home, ".belayer")
 	return Config{
-		SocketPath: filepath.Join(base, "daemon.sock"),
-		DBPath:     filepath.Join(base, "belayer.db"),
+		SocketPath:        filepath.Join(base, "daemon.sock"),
+		DBPath:            filepath.Join(base, "belayer.db"),
+		DockerHostGateway: "172.17.0.1",
 	}
 }
 
@@ -71,6 +82,11 @@ type Daemon struct {
 	// calls so they observe daemon shutdown. Initialized to context.Background
 	// in New so tests that skip Start still work.
 	startCtx context.Context
+
+	// tcpListener is the optional TCP listener for clamshell container access.
+	// Nil when config.TCPAddr is empty.
+	tcpListener *http.Server
+	tcpPort     int
 
 	// Per-session sandbox state. Each entry caches the driver resolved from
 	// .belayer/config.yaml's sandbox.mode plus the Handle returned by Create.
@@ -168,6 +184,23 @@ func (d *Daemon) Start(ctx context.Context) error {
 	d.listener = ln
 	d.startCtx = ctx
 
+	// Optional TCP listener for clamshell container bridge access.
+	if d.config.TCPAddr != "" {
+		tcpLn, err := net.Listen("tcp", d.config.TCPAddr)
+		if err != nil {
+			ln.Close()
+			return fmt.Errorf("daemon: listen tcp %s: %w", d.config.TCPAddr, err)
+		}
+		d.tcpPort = tcpLn.Addr().(*net.TCPAddr).Port
+		d.tcpListener = &http.Server{Handler: d.server.Handler}
+		go func() {
+			if serveErr := d.tcpListener.Serve(tcpLn); serveErr != nil && serveErr != http.ErrServerClosed {
+				log.Printf("daemon: tcp serve: %v", serveErr)
+			}
+		}()
+		log.Printf("daemon: TCP listener on %s (port %d)", d.config.TCPAddr, d.tcpPort)
+	}
+
 	// Provision the runtime before serving. For the noop provider this is a
 	// no-op; the hook exists so future providers (command, clamshell, ...)
 	// can fail fast if the dev stack can't come up. Captured endpoints flow
@@ -190,12 +223,19 @@ func (d *Daemon) Start(ctx context.Context) error {
 	return nil
 }
 
+// TCPPort returns the port the TCP listener is bound to, or 0 if no TCP
+// listener was configured. Valid after Start() returns without error.
+func (d *Daemon) TCPPort() int { return d.tcpPort }
+
 // Shutdown gracefully drains in-flight requests and closes everything.
 func (d *Daemon) Shutdown(ctx context.Context) error {
 	shutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	err := d.server.Shutdown(shutCtx)
+	if d.tcpListener != nil {
+		_ = d.tcpListener.Shutdown(shutCtx)
+	}
 
 	// Tear down any outstanding sandbox handles.
 	d.sandboxMu.Lock()
@@ -223,6 +263,7 @@ func (d *Daemon) Shutdown(ctx context.Context) error {
 type sessionSandbox struct {
 	driver sandbox.Driver
 	handle sandbox.Handle
+	mode   string // sandbox.mode value from .belayer/config.yaml (e.g. "noop", "clamshell")
 }
 
 // ensureSandboxHandle returns the session's sandbox state, creating one on
@@ -268,7 +309,7 @@ func (d *Daemon) ensureSandboxHandle(ctx context.Context, sess store.Session) (s
 		}()
 		return existing, nil
 	}
-	ss := sessionSandbox{driver: driver, handle: h}
+	ss := sessionSandbox{driver: driver, handle: h, mode: mode}
 	d.sessionSandboxes[sess.ID] = ss
 	return ss, nil
 }

--- a/internal/sandbox/clamshell.go
+++ b/internal/sandbox/clamshell.go
@@ -147,10 +147,16 @@ func (c *Clamshell) Create(ctx context.Context, cfg Config) (Handle, error) {
 		return Handle{}, cleanupAfterCreate(fmt.Errorf("sandbox/clamshell: connect: %w (stderr: %s)", err, stderr))
 	}
 	var connect struct {
-		Container string `json:"container"`
+		Container string   `json:"container"`
+		Argv      []string `json:"argv"`
 	}
 	if err := json.Unmarshal(connectOut, &connect); err != nil {
 		return Handle{}, cleanupAfterCreate(fmt.Errorf("sandbox/clamshell: parse connect output: %w (stdout: %s)", err, connectOut))
+	}
+	// Newer clamshell versions may return argv=[docker exec -it <container> /bin/bash]
+	// instead of a direct container field; extract the container name from argv[3].
+	if connect.Container == "" && len(connect.Argv) >= 4 {
+		connect.Container = connect.Argv[3]
 	}
 	if connect.Container == "" {
 		return Handle{}, cleanupAfterCreate(fmt.Errorf("sandbox/clamshell: connect output missing container field: %s", connectOut))
@@ -250,6 +256,10 @@ func (c *Clamshell) Exec(ctx context.Context, h Handle, cmd []string, opts ExecO
 // writeEnvFile materializes env ("KEY=VALUE" entries) into a 0600 tempfile
 // suitable for `docker exec --env-file`. Callers must remove the returned
 // path once the referring process has exited.
+//
+// Docker's --env-file does not support multiline values. Any newlines in a
+// value are encoded as the two-character sequence \n so the file stays valid.
+// Readers (e.g. hermes_bridge) must decode \n back to real newlines.
 func writeEnvFile(env []string) (string, error) {
 	tmp, err := os.CreateTemp("", "belayer-env-*.env")
 	if err != nil {
@@ -262,8 +272,19 @@ func writeEnvFile(env []string) (string, error) {
 		os.Remove(tmp.Name())
 		return "", fmt.Errorf("sandbox/clamshell: chmod env: %w", err)
 	}
-	body := strings.Join(env, "\n")
-	if len(env) > 0 {
+	var lines []string
+	for _, entry := range env {
+		idx := strings.IndexByte(entry, '=')
+		if idx < 0 {
+			lines = append(lines, entry)
+			continue
+		}
+		key := entry[:idx]
+		val := strings.ReplaceAll(entry[idx+1:], "\n", `\n`)
+		lines = append(lines, key+"="+val)
+	}
+	body := strings.Join(lines, "\n")
+	if len(lines) > 0 {
 		body += "\n"
 	}
 	if _, err := tmp.WriteString(body); err != nil {

--- a/internal/sandbox/clamshell.go
+++ b/internal/sandbox/clamshell.go
@@ -154,9 +154,11 @@ func (c *Clamshell) Create(ctx context.Context, cfg Config) (Handle, error) {
 		return Handle{}, cleanupAfterCreate(fmt.Errorf("sandbox/clamshell: parse connect output: %w (stdout: %s)", err, connectOut))
 	}
 	// Newer clamshell versions may return argv=[docker exec -it <container> /bin/bash]
-	// instead of a direct container field; extract the container name from argv[3].
-	if connect.Container == "" && len(connect.Argv) >= 4 {
-		connect.Container = connect.Argv[3]
+	// instead of a direct container field. Scan for the first non-flag positional
+	// after the `exec` token so future reorderings (extra flags, podman, split
+	// -i/-t) don't silently pick up a flag string as the container name.
+	if connect.Container == "" {
+		connect.Container = extractContainerFromArgv(connect.Argv)
 	}
 	if connect.Container == "" {
 		return Handle{}, cleanupAfterCreate(fmt.Errorf("sandbox/clamshell: connect output missing container field: %s", connectOut))
@@ -221,7 +223,9 @@ func (c *Clamshell) Exec(ctx context.Context, h Handle, cmd []string, opts ExecO
 
 	args := []string{"exec", "-u", "sandbox", "-i"}
 	envFile := ""
-	env := opts.Env
+	// Copy opts.Env before mutating: callers may reuse the same opts across
+	// parallel execs and the HOME override below writes through the slice.
+	env := append([]string(nil), opts.Env...)
 	// Override HOME with the container home dir so the bridge doesn't try to
 	// write to the host user's home path (which is read-only inside the container).
 	if containerHome := h.Meta["containerHome"]; containerHome != "" {
@@ -412,6 +416,38 @@ func (c *Clamshell) preparePolicy(basePath string, endpoints []TCPEndpoint) (str
 		return "", fmt.Errorf("sandbox/clamshell: close temp policy: %w", err)
 	}
 	return tmp.Name(), nil
+}
+
+// extractContainerFromArgv parses a `docker exec ...` (or `podman exec ...`)
+// argv and returns the first positional argument after the `exec` verb, which
+// is the container name. Returns "" if the shape doesn't match.
+func extractContainerFromArgv(argv []string) string {
+	if len(argv) < 2 {
+		return ""
+	}
+	binBase := filepath.Base(argv[0])
+	if binBase != "docker" && binBase != "podman" {
+		return ""
+	}
+	// Find the `exec` token, then the first non-flag positional after it.
+	execIdx := -1
+	for i, tok := range argv {
+		if tok == "exec" {
+			execIdx = i
+			break
+		}
+	}
+	if execIdx < 0 {
+		return ""
+	}
+	for i := execIdx + 1; i < len(argv); i++ {
+		tok := argv[i]
+		if tok == "" || strings.HasPrefix(tok, "-") {
+			continue
+		}
+		return tok
+	}
+	return ""
 }
 
 // shellJoin renders argv as a single sh-safe string. We single-quote every

--- a/internal/sandbox/clamshell.go
+++ b/internal/sandbox/clamshell.go
@@ -168,6 +168,9 @@ func (c *Clamshell) Create(ctx context.Context, cfg Config) (Handle, error) {
 			"container":     connect.Container,
 			"policyFile":    policyPath,
 			"hostWorkspace": cfg.Workspace,
+			// clamshell always mounts the sandbox home at {runtime_dir}/home.
+			// runtime_dir defaults to /run/agent per clamshell policy convention.
+			"containerHome": "/run/agent/home",
 		},
 	}, nil
 }
@@ -218,8 +221,24 @@ func (c *Clamshell) Exec(ctx context.Context, h Handle, cmd []string, opts ExecO
 
 	args := []string{"exec", "-u", "sandbox", "-i"}
 	envFile := ""
-	if len(opts.Env) > 0 {
-		path, err := writeEnvFile(opts.Env)
+	env := opts.Env
+	// Override HOME with the container home dir so the bridge doesn't try to
+	// write to the host user's home path (which is read-only inside the container).
+	if containerHome := h.Meta["containerHome"]; containerHome != "" {
+		replaced := false
+		for i, e := range env {
+			if strings.HasPrefix(e, "HOME=") {
+				env[i] = "HOME=" + containerHome
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			env = append(env, "HOME="+containerHome)
+		}
+	}
+	if len(env) > 0 {
+		path, err := writeEnvFile(env)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

- **Proxy keepalive fix**: Monkey-patches `_create_openai_client` in `hermes_bridge` so every Hermes client rebuild creates a fresh `httpx.Client` with `proxy=proxy.internal:3128` + TCP keepalive. Fixes silent connection failure on second LLM call caused by Hermes closing the shared httpx.Client between tool-call cycles.
- **Credential chain via godotenv**: Daemon now loads `.belayer/.belayer.env` (workspace) and `~/.belayer.env` (home) at startup via `godotenv.Load()`. Bridge subprocesses inherit provider credentials (e.g. `OPENCODE_GO_API_KEY`) without needing `--bridge-api-key`.
- **Provider fallback fix**: `BELAYER_PROVIDER`/`BELAYER_BASE_URL` are now fallback-only — ignored when Hermes config resolves a provider. Fixes `unknown provider openai` regression from previous session.
- **Proxy env injection**: `bridge.BuildEnv()` now injects `HTTPS_PROXY`/`HTTP_PROXY` into the clamshell env-file so the bridge subprocess routes LLM traffic through the CONNECT proxy.
- **`docs/SANDBOXING.md`**: New doc with Mermaid architecture diagram covering the full clamshell flow: credential chain, proxy client lifecycle fix, egress allowlist, and hermes_bridge distribution gap.

## Out-of-repo changes required

These changes live outside this repo and must be applied manually for clamshell to work end-to-end. They are listed here for visibility — the long-term fix for most of them is embedding `hermes_bridge` in the binary (tracked as a distribution gap in `docs/SANDBOXING.md`).

### 1. Cross-compile and install the binary on the VM

```bash
# On macOS host
GOOS=linux GOARCH=arm64 go build -tags clamshell -o belayer-linux-arm64 ./cmd/belayer

# Kill any running daemon first (the binary can't be overwritten while in use)
# On Colima VM
sudo cp belayer-linux-arm64 /usr/local/bin/belayer
```

The `-tags clamshell` flag is required. Without it the clamshell sandbox driver is not compiled in and `belayer run start` fails with `sandbox driver "clamshell" is unavailable`.

### 2. Credentials file on the VM

`~/.belayer.env` must exist on the Colima VM (the host running the daemon) with at least:

```
OPENCODE_GO_API_KEY=<your key>
```

The daemon reads this file at startup via `godotenv.Load()` and the value flows into every clamshell bridge subprocess as an env-file entry.

### 3. Sync `hermes_bridge/` into each project workspace

`hermes_bridge/` is not embedded in the Go binary. The clamshell container imports it from `/workspace/hermes_bridge/` (the bind-mounted project directory). Every project that uses clamshell must have a copy, and that copy must be kept in sync with this repo after every bridge change:

```bash
# On macOS host — after any change to hermes_bridge/
cp -r hermes_bridge/ /path/to/project/hermes_bridge/

# On VM — clear stale pyc so Python picks up the new source
rm -f /path/to/project/hermes_bridge/__pycache__/*.pyc
```

### 4. Project `.belayer/config.yaml` with clamshell mode

The target project must have a `.belayer/config.yaml` that sets the sandbox mode:

```yaml
sandbox:
  mode: clamshell
```

Without this the daemon falls back to the `noop` sandbox driver and the bridge runs directly on the host without isolation or proxy.

## Test plan

- [ ] `go build -tags clamshell ./cmd/belayer` passes
- [ ] `go test ./...` passes
- [ ] Cross-compile for linux/arm64 with `-tags clamshell` and install to Colima VM
- [ ] `belayer run start` in an arielcharts workspace on the VM reaches `bridge:idle` with `api_calls >= 2` in session logs (validates multi-call proxy fix)
- [ ] Confirm `OPENCODE_GO_API_KEY` from `~/.belayer.env` flows through without `--bridge-api-key` flag
- [ ] Confirm removing `BELAYER_PROVIDER` from env does not break provider resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for Clamshell Sandboxing mode architecture and configuration
  * Added execution plans documentation tracking active and completed initiatives

* **New Features**
  * Enabled HTTP/TCP-based communication for daemon, complementing existing Unix socket support
  * Added HTTP proxy support for daemon-to-bridge communication
  * Introduced environment file (`.belayer.env`) loading from workspace and home directories
  * Added configurable TCP address binding and Docker gateway settings for sandbox networking
  * Enhanced agent model specification via `agent.yaml` configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->