### PR TITLE
feat(init): embed hermes_bridge + document deployment gaps

### DIFF
--- a/docs/SANDBOXING.md
+++ b/docs/SANDBOXING.md
@@ -6,32 +6,28 @@ Clamshell is Belayer's Docker-based sandbox mode. Each session runs its bridge s
 
 ```mermaid
 graph TD
-    subgraph host["macOS Host"]
-        CLI["belayer CLI\n(run start / logs / roster)"]
-        ENV["~/.belayer.env\n(OPENCODE_GO_API_KEY, GITHUB_TOKEN, …)"]
-    end
-
-    subgraph vm["Colima VM"]
+    subgraph host["Host (Linux VM in prod, Colima VM in dev)"]
         subgraph daemon["belayer daemon (Go)"]
             API["HTTP API\n(daemon.sock +\n/workspace/.belayer/daemon.sock)"]
             DB[("SQLite\nsessions · agents · events")]
             ENVLOAD["godotenv.Load()\n~/.belayer.env → os.Setenv()"]
+            INIT["belayer init\n(auto-runs on each belayer run)\nextracts hermes_bridge/\n→ /workspace/.belayer/hermes_bridge/"]
         end
 
         subgraph sandbox["Docker: clamshell-{session}"]
-            subgraph bridge["bridge subprocess\npython3 -m hermes_bridge\n(env-file injected at docker exec)"]
+            subgraph bridge["bridge subprocess\npython3 -m hermes_bridge"]
                 MAIN["__main__.py\nresolve_runtime_provider()\n→ provider=opencode-go"]
                 PATCH["monkey-patch\n_create_openai_client()\n→ always fresh httpx.Client\n   proxy=proxy.internal:3128\n   + TCP keepalive"]
                 AGENT["Hermes AIAgent\nOpenAI SDK\nhttp_client=↑"]
                 TOOLS["belayer tools\nterminal · spawn_agent\nrequest_completion …"]
             end
-            WS["/workspace bind-mount\n(project dir)\nincludes hermes_bridge/\n+ PYTHONPATH entry"]
+            WS["/workspace bind-mount\n(project dir)\n.belayer/hermes_bridge/ on PYTHONPATH"]
         end
 
         subgraph proxy["Docker: clamshell-proxy-{session}"]
             EGRESS["egress broker\nCONNECT proxy\nproxy.internal:3128"]
             ATTEST["process attestation\nbinary=python3 ✓"]
-            ALLOW["allowlist\nopencode.ai:443 ✓\nDocker host gateway:7523 ✓\nDocker host gateway:3000-4000 ✓"]
+            ALLOW["allowlist\nopencode.ai:443 ✓\ndaemon host:7523 ✓\ndaemon host:3000-4000 ✓"]
         end
     end
 
@@ -39,10 +35,9 @@ graph TD
         LLM["opencode.ai\n/zen/go/v1\nkimi-k2.5"]
     end
 
-    ENV -->|"loaded at daemon startup"| ENVLOAD
     ENVLOAD --> API
-    CLI -->|"daemon.sock"| API
-    API -->|"docker exec --env-file\nOPENCODE_GO_API_KEY\nHTTPS_PROXY\nBELAYER_SESSION_ID\nBELAYER_SOCKET\nBELAYER_TOOLS\nPYTHONPATH"| MAIN
+    INIT -.->|extracts to| WS
+    API -->|"⚠ docker exec --env-file\n(raw creds — see Known Gaps §1,§2)\nOPENCODE_GO_API_KEY\nHTTPS_PROXY\nBELAYER_SESSION_ID\nBELAYER_SOCKET\nBELAYER_TOOLS\nPYTHONPATH"| MAIN
     MAIN --> PATCH
     PATCH --> AGENT
     AGENT -->|"CONNECT tunnel\nvia proxy.internal:3128"| EGRESS
@@ -53,18 +48,20 @@ graph TD
     AGENT <-->|"/workspace/.belayer/daemon.sock\n(Unix socket in bind-mount)"| API
     API <--> DB
     TOOLS -.->|"execute inside container"| AGENT
-    WS -.->|"imports hermes_bridge"| MAIN
+    WS -.->|"imports hermes_bridge from\n/workspace/.belayer/hermes_bridge"| MAIN
 ```
 
 ## Credential chain
 
 Provider credentials (e.g. `OPENCODE_GO_API_KEY`) live in `~/.belayer.env` on the host. At daemon startup, `godotenv.Load()` reads the workspace `.belayer/.belayer.env` first (workspace wins), then `~/.belayer.env`. Both are loaded into the daemon's `os.Environ()` without overwriting already-set variables.
 
-When the daemon spawns a bridge subprocess via `docker exec`, `bridge.BuildEnv()` serialises the daemon's env into a temp env-file. The container process inherits `OPENCODE_GO_API_KEY` (and any other provider-specific vars) from there. `resolve_runtime_provider()` in `__main__.py` detects the key and selects the `opencode-go` Hermes provider.
+When the daemon spawns a bridge subprocess, `bridge.BuildEnv()` serialises the daemon's env into a temp env-file. The container process inherits `OPENCODE_GO_API_KEY` (and any other provider-specific vars) from there. `resolve_runtime_provider()` in `__main__.py` detects the key and selects the `opencode-go` Hermes provider.
 
 `BELAYER_PROVIDER` / `BELAYER_BASE_URL` act as fallbacks only — they are ignored when the Hermes config already resolves a provider. `BELAYER_API_KEY` is the exception: it always overrides the key returned by `resolve_runtime_provider()`, because the in-container user may carry an invalid or stale token (e.g. from a copied-in OAuth cache) that would otherwise win.
 
-## Proxy client lifecycle fix
+**Security note:** this chain today hands the real API key to the bridge process inside the container. See Known Gaps §2.
+
+## Proxy client lifecycle
 
 Hermes rebuilds its OpenAI client on every tool-call cycle (`_close_openai_client` → `_create_openai_client`). The close tears down the underlying `httpx.Client`, breaking the proxy connection for subsequent LLM calls.
 
@@ -74,11 +71,92 @@ The fix monkey-patches `agent._create_openai_client` at spawn time so every invo
 
 The patched method strips any `http_client` key from the kwargs snapshot before forwarding to the original method, so Hermes's internal recovery path (`_try_recover_primary_transport`) also gets a fresh client automatically.
 
-## hermes_bridge distribution gap
+## hermes_bridge distribution
 
-`hermes_bridge/` is plain Python source — it is **not** embedded in the Go binary. The container imports it from `/workspace/hermes_bridge/` (the project's bind-mounted directory). This means:
+`hermes_bridge/` ships embedded in the belayer binary (`//go:embed all:hermes_bridge` in `embed.go`). On every `belayer init` — and on every `belayer run` via `autoInitIfMissing` — the embedded tree is extracted to `.belayer/hermes_bridge/`, **always overwriting**. The tree is gitignored: it is machine-generated output pinned to the binary version, not project source.
 
-1. Every project that uses Clamshell must have a copy of `hermes_bridge/` checked in or synced.
-2. Changes to `hermes_bridge/` in the belayer repo must be manually propagated to each project.
+Inside the clamshell container, PYTHONPATH is set to `/workspace/.belayer` (the container's view of the project's `.belayer/` directory). `python3 -m hermes_bridge` then resolves to `/workspace/.belayer/hermes_bridge/__main__.py`. There is no manual sync step; binary upgrades automatically refresh the extracted bridge on the next run.
 
-Long-term options: embed a wheel in the binary and extract via `belayer init`, or publish `hermes_bridge` as a PyPI package.
+---
+
+## Deployment topologies
+
+### Ideal: Nightshift Linux VM (production)
+
+This is the intended deployment. The daemon runs directly on a Linux VM that hosts the Nightshift worker.
+
+```
+Linux VM
+├── /usr/local/bin/belayer           (Linux binary, no cross-compile)
+├── ~/.belayer.env                   (OPENCODE_GO_API_KEY + other creds)
+└── project workspace (git clone)
+    └── .belayer/                     (scaffolded by `belayer init`)
+        ├── agents/                   (user-editable identity templates)
+        ├── hermes_bridge/            (extracted from binary, gitignored)
+        ├── config.yaml
+        └── policies/standard.yaml
+```
+
+**Moving pieces:** three — the daemon process, the clamshell bridge container, and the clamshell proxy container. No VM abstraction layer above the host. `belayer init` handles bridge extraction automatically on every run.
+
+**Deploy steps on a fresh VM:**
+
+1. Install Docker + iptables (the proxy container uses REDIRECT rules).
+2. Copy the Linux `belayer` binary to `/usr/local/bin/belayer`.
+3. Drop `~/.belayer.env` (or mount it from a secret store).
+4. In the project workspace, run `belayer daemon` once to start the supervisor and `belayer run start --task "<task>"` to launch a session.
+
+No other moving parts. The architecture diagram above describes this topology exactly.
+
+### Local dev: macOS via Colima
+
+Developing on macOS adds one layer: Colima provides a Linux VM because macOS can't run iptables REDIRECT natively. This is a **local dev tax** for proving Linux patterns on macOS — not the intended production setup.
+
+Extra steps compared to the ideal topology:
+
+1. **Cross-compile** on the macOS host:
+   ```bash
+   GOOS=linux GOARCH=arm64 go build -tags clamshell -o belayer-linux-arm64 ./cmd/belayer
+   ```
+   The `-tags clamshell` flag is required; without it the sandbox driver is not compiled in.
+
+2. **Install the binary inside the Colima VM:**
+   ```bash
+   # On Colima VM (kill any running daemon first — the binary can't be
+   # overwritten while in use)
+   sudo cp belayer-linux-arm64 /usr/local/bin/belayer
+   ```
+
+3. **Credentials live on the VM**, not the macOS host:
+   ```
+   # ~/.belayer.env on the Colima VM
+   OPENCODE_GO_API_KEY=<key>
+   ```
+
+4. **Workspace path** on the VM is typically `/home/<user>/<project>` (virtiofs mirror of the macOS path, or a separate checkout — either works).
+
+Everything downstream of the VM boundary — daemon, containers, proxy, bridge — is identical to the production topology.
+
+**OrbStack** is a faster drop-in replacement for Colima if Colima's virtiofs performance becomes painful. Pure open-source alternatives (Lima, Rancher Desktop) also use QEMU + virtiofs and land at the same performance level as Colima.
+
+---
+
+## Known security gaps
+
+These are active gaps in the current implementation, not design principles. They are documented here so they are not forgotten and so operators understand what the sandbox does and does not enforce today.
+
+### §1. Bridge exec bypasses the clamshell CLI
+
+`internal/sandbox/clamshell.go` `Clamshell.Exec` invokes `docker exec --env-file <tmpfile> <container> sh -lc '...'` directly. The clamshell CLI is used for `sandbox create`, `sandbox connect`, `sandbox stop`, and `gateway start` — but not for the hot-path exec that launches bridge subprocesses.
+
+**What this means:** any policy or credential-handling a future `clamshell exec` wrapper would enforce is absent today. Every bridge spawn is a raw `docker exec`.
+
+**Fix:** introduce a `clamshell exec` command that wraps `docker exec` with sandbox-aware credential handling. Bridge spawn plumbs through it instead of calling Docker directly. Designed in a follow-up doc.
+
+### §2. Agent process sees raw provider credentials
+
+The env-file written by `docker exec --env-file` contains `OPENCODE_GO_API_KEY=<real key>` (plus `HTTPS_PROXY`, `BELAYER_*`, `PYTHONPATH`). That file — and the container process environment that inherits from it — is readable inside the sandbox. A compromised agent can `cat /proc/self/environ`, exfiltrate the key, and the attacker walks away with a real opencode credential.
+
+**What this means:** the sandbox today prevents the agent from *using* unauthorized egress (proxy allowlist does that work), but it does not prevent the agent from *seeing* the credential that makes that egress valuable. If exfiltrated through an allowed channel, the key is real and usable from anywhere.
+
+**Fix:** the agent should receive an opaque session token rather than the real credential. The credential swap happens at egress — either proxy-side (strip the session token, inject the real `Authorization` based on the attested session) or via a clamshell-owned credential broker. Designed in a follow-up doc alongside §1 since both fixes share the `clamshell exec` plumbing.

--- a/docs/design-docs/2026-04-17-embed-hermes-bridge-design.md
+++ b/docs/design-docs/2026-04-17-embed-hermes-bridge-design.md
@@ -51,7 +51,7 @@ Parallel to the existing `DefaultAgents` pattern in `embed.go`:
 var DefaultBridge embed.FS
 ```
 
-`internal/cli/init.go` grows a `copyDefaultBridge(dst string) ([]string, error)` function that walks the embedded tree and writes files to `dst`, always overwriting (no `force` parameter). It skips `__pycache__/` directories and `*.pyc` files so stale bytecode from the host build never leaks into projects.
+`internal/cli/init.go` grows a `copyDefaultBridge(dst string) ([]string, error)` function that wipes `dst` and then walks the embedded tree, writing each file. The wipe is required because files renamed or deleted in later binary versions would otherwise linger on disk and get picked up by Python's import machinery; the tree is fully machine-owned and gitignored, so destroying it before re-extracting is safe. The walk skips `__pycache__/` directories and `*.pyc` files so stale bytecode from the host build never leaks into projects.
 
 `scaffold()` calls `copyDefaultBridge()` after `copyDefaultAgents()` and includes the written paths in the result summary. The `--force` flag's scope is unchanged — it only affects `copyDefaultAgents()`, since bridge extraction already overwrites unconditionally.
 
@@ -59,13 +59,13 @@ var DefaultBridge embed.FS
 
 ### Gitignore update
 
-The `gitignoreBlock` constant gets one new line:
+The gitignore list gets one new entry:
 
 ```
 /.belayer/hermes_bridge/
 ```
 
-Added alongside the existing `/.belayer/runs/` and `/.belayer/worktrees/` entries. The marker comment and append logic are unchanged — projects that have already been initialized will get the new entry appended on the next `belayer init` run (or can add it manually).
+Added alongside the existing `/.belayer/runs/` and `/.belayer/worktrees/` entries. `ensureGitignoreEntries()` is upgraded from a marker-gated "write block once" check to a per-entry check that diffs the expected entries against the file contents and appends any missing ones — so projects initialized under an older binary pick up new entries on the next `belayer init` or auto-init run. Fresh projects still get a single labelled block; upgrades get the missing entries appended under a compact `# belayer — added on upgrade` header so their provenance is visible.
 
 ### PYTHONPATH routing in clamshell mode
 

--- a/docs/design-docs/2026-04-17-embed-hermes-bridge-design.md
+++ b/docs/design-docs/2026-04-17-embed-hermes-bridge-design.md
@@ -1,0 +1,122 @@
+---
+status: current
+created: 2026-04-17
+branch: feat/clamshell-e2e
+supersedes:
+implemented-by:
+consulted-learnings: []
+---
+
+# Embed hermes_bridge in binary + document deployment topologies
+
+## Goal
+
+Ship `hermes_bridge/` as embedded assets inside the belayer binary and extract them into `.belayer/hermes_bridge/` during `belayer init`, eliminating the manual sync step required for clamshell sessions. Rewrite `docs/SANDBOXING.md` to document two deployment topologies (ideal Nightshift Linux VM vs current macOS/Colima dev) and explicitly call out the known security gaps in the current clamshell exec path.
+
+## Motivation
+
+### Bridge distribution
+
+Today `hermes_bridge/` is plain Python source that must exist at `/workspace/hermes_bridge/` inside the clamshell container. The container imports it from the bind-mounted project workspace, which means every project that uses clamshell needs a copy of the bridge files, and every change to bridge code must be manually propagated to every project. This silently breaks whenever bridge source drifts from the binary version.
+
+Embedding the bridge and extracting via `belayer init` makes the bridge binary-versioned: upgrading the binary automatically upgrades the bridge on next `belayer init` or auto-init. Projects gitignore the extracted copy, so there's no confusion about whether it's source or generated.
+
+### Deployment documentation
+
+`docs/SANDBOXING.md` currently documents the Colima setup but conflates "what you need on a developer macOS machine" with "how the system is meant to run in production." Nightshift workers are always Linux VMs, so the macOS/Colima layer is purely a local dev tax. The docs should make that distinction explicit so future operators aren't confused about which steps are essential vs. which are macOS-only workarounds.
+
+### Known security gaps
+
+While mapping the current architecture for the docs rewrite, two gaps surfaced that need to be captured — not fixed in this PR, but documented so they're not forgotten:
+
+1. **Exec path bypasses clamshell CLI.** `internal/sandbox/clamshell.go:213-273` calls `docker exec --env-file <tmpfile> <container>` directly for every bridge spawn. The clamshell CLI is only used for `sandbox create`, `sandbox connect`, `sandbox stop`, and `gateway start`. Any policy or credential-handling a future `clamshell exec` would enforce is absent on today's hot path.
+
+2. **Agent sees raw credentials.** The env-file today contains `OPENCODE_GO_API_KEY=<real key>` (plus `HTTPS_PROXY`, `BELAYER_*`, `PYTHONPATH`). That file — and the process environment that inherits from it — is readable inside the container. A compromised agent can `cat /proc/self/environ`, exfiltrate the key, and the attacker has the real opencode credential. The correct shape is agent gets an opaque session token and the proxy does the credential swap at egress, but that's a separate design.
+
+This design doc ships the bridge-embedding change today and documents both gaps in SANDBOXING.md. Gap #2 specifically is the next brainstorm.
+
+## Architecture
+
+### Bridge embedding
+
+Parallel to the existing `DefaultAgents` pattern in `embed.go`:
+
+```go
+// DefaultBridge is the hermes_bridge Python package copied into a project's
+// .belayer/hermes_bridge/ directory by `belayer init`. Unlike DefaultAgents,
+// this copy is machine-generated and gitignored — it is always overwritten
+// on init so the extracted bridge matches the binary version.
+//
+//go:embed all:hermes_bridge
+var DefaultBridge embed.FS
+```
+
+`internal/cli/init.go` grows a `copyDefaultBridge(dst string) ([]string, error)` function that walks the embedded tree and writes files to `dst`, always overwriting (no `force` parameter). It skips `__pycache__/` directories and `*.pyc` files so stale bytecode from the host build never leaks into projects.
+
+`scaffold()` calls `copyDefaultBridge()` after `copyDefaultAgents()` and includes the written paths in the result summary. The `--force` flag's scope is unchanged — it only affects `copyDefaultAgents()`, since bridge extraction already overwrites unconditionally.
+
+`autoInitIfMissing()` is already wired into `belayer run`; the new bridge extraction runs through the same path, so binary upgrades propagate without requiring users to manually re-run `belayer init`.
+
+### Gitignore update
+
+The `gitignoreBlock` constant gets one new line:
+
+```
+/.belayer/hermes_bridge/
+```
+
+Added alongside the existing `/.belayer/runs/` and `/.belayer/worktrees/` entries. The marker comment and append logic are unchanged — projects that have already been initialized will get the new entry appended on the next `belayer init` run (or can add it manually).
+
+### PYTHONPATH routing in clamshell mode
+
+Current state: `cfg.BelayerRoot` holds the host path to the belayer repo root (where `hermes_bridge/` lives on the developer's machine). In clamshell mode this path is unreachable inside the container, but bridge imports work anyway because the bind-mounted workspace at `/workspace/` happens to contain a copy of `hermes_bridge/` and `/workspace` is added to PYTHONPATH.
+
+New state: when spawning a clamshell bridge, `internal/daemon/agents.go` overrides `cfg.BelayerRoot = "/workspace/.belayer"` (the container's view of the extracted bridge's parent directory). `internal/bridge/bridge.go`'s existing PYTHONPATH construction appends `BelayerRoot` to PYTHONPATH, so `python3 -m hermes_bridge` resolves to `/workspace/.belayer/hermes_bridge/`.
+
+Host (non-clamshell) mode is unchanged — `BelayerRoot` continues to point at the belayer repo root.
+
+### SANDBOXING.md rewrite
+
+Replace the current single-topology documentation with four sections:
+
+1. **Architecture diagram** — updated Mermaid diagram reflecting the new `/workspace/.belayer/hermes_bridge/` import path. The existing "distribution gap" subgraph is removed. A dashed-line annotation on the `docker exec --env-file` edge calls out that this path is raw-credential today; details live in section 4.
+
+2. **Ideal deployment: Nightshift Linux VM** — the target production topology. Daemon runs directly on a Linux VM, `belayer init` extracts the bridge, `~/.belayer.env` holds credentials (or they come from a secret store mount), `belayer run start` — three moving pieces: daemon, clamshell container, proxy container. No cross-compile, no VM abstraction layer, no manual bridge sync.
+
+3. **Local dev: macOS via Colima** — the current developer workflow. Adds Colima VM hosting the daemon + Docker. Requires cross-compile (`GOOS=linux GOARCH=arm64 go build -tags clamshell`), `scp` binary to VM, install to `/usr/local/bin/belayer`, `~/.belayer.env` placed on the VM filesystem. Everything else identical to the prod topology. Documented as "a local dev tax for proving Linux patterns on macOS" so readers know it's not the intended deployment.
+
+4. **Known security gaps** — explicit, prominent section covering:
+    - **Exec bypasses clamshell CLI.** Bridge spawns go via `docker exec --env-file` directly rather than a `clamshell exec` wrapper. Fix requires a new clamshell CLI command and plumbing through `internal/sandbox/clamshell.go` `Exec`. Tracked as next design.
+    - **Agent sees raw credentials.** Env-file contains the real `OPENCODE_GO_API_KEY`. A compromised agent can exfiltrate it trivially. Target design: opaque session token in env, real-key injection at the egress proxy (or a clamshell-owned credential broker). Explicitly out of scope here; documented so it isn't forgotten.
+
+    Each gap gets a one-paragraph explanation of what's wrong and a pointer to the upcoming design. No half-fixes in this PR.
+
+Both topology sections (2 and 3) share the same credential chain, proxy client lifecycle, and egress allowlist subsections — those details are common to any deployment.
+
+## Components / files touched
+
+- `embed.go` — add `DefaultBridge embed.FS`
+- `internal/cli/init.go` — add `copyDefaultBridge()`; call from `scaffold()`; update `gitignoreBlock`
+- `internal/daemon/agents.go` — override `cfg.BelayerRoot` to `/workspace/.belayer` when spawning clamshell bridges
+- `docs/SANDBOXING.md` — rewrite with the two-topology + known-gaps structure
+- `.gitignore` (the belayer repo's own) — add `/.belayer/hermes_bridge/` so the extracted copy in the belayer repo itself doesn't get committed if someone runs `belayer init` at the repo root
+
+## Error handling
+
+- `copyDefaultBridge()` returns an error if the embed walk fails or a file write fails. `scaffold()` propagates the error — init aborts rather than leaving a partial extraction on disk.
+- `__pycache__/` and `*.pyc` filtering uses string prefix + suffix checks on the relative path. Defensive only — the embed is built from source in CI; pyc files shouldn't appear. If one does, it's skipped.
+- If `.belayer/hermes_bridge/` already exists as a regular file (not a directory), the writer returns an error and init aborts with a clear message. Recovery is manual: the user deletes the stale file and re-runs init.
+
+## Testing
+
+- Unit: `copyDefaultBridge()` given a known embedded tree produces the expected files on disk, overwrites existing files, and skips `__pycache__` entries.
+- Unit: `scaffold()` with a fresh directory writes the bridge alongside agents; running again overwrites the bridge but leaves agents untouched (without `--force`).
+- Integration: `belayer init` in a fresh project produces `.belayer/hermes_bridge/__main__.py` matching the source file byte-for-byte.
+- E2E: clamshell session on the Colima VM reaches `bridge:idle` with `api_calls >= 2`, importing the bridge from `/workspace/.belayer/hermes_bridge/` (verified via session logs showing the new PYTHONPATH entry). This validates the BelayerRoot override lands correctly.
+
+## Out of scope
+
+- **Credential swap / opaque session tokens.** The current raw-env-file exec path stays unchanged in this PR. Its replacement (clamshell-CLI-owned credential broker or proxy-side injection) gets its own brainstorm and design doc.
+- **Clamshell exec wrapper.** Bridge spawns continue to call `docker exec` directly. The policy-aware `clamshell exec` wrapper is part of the credential-swap design, not this one.
+- **PyPI publishing of `hermes_bridge`.** Embedding is the lightweight fix; PyPI is a separate future option if we ever need to support bridge use outside a belayer binary install.
+- **Changes to agent template distribution.** `DefaultAgents` keeps its current "write once, `--force` to overwrite" semantics — user-editable, unlike the bridge.

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -9,3 +9,4 @@
 - [Tool catalog and identity](2026-04-16-tool-catalog-and-identity.md) — Co-locate belayer tools with agent templates, role-based tool gating
 - ~~[VM sandbox and template bootstrap](2026-04-16-vm-sandbox-and-template-bootstrap.md)~~ — Superseded by sandbox-runtime-and-crag-proof
 - [Sandbox, runtime, and crag proof](2026-04-16-sandbox-runtime-and-crag-proof.md) — SandboxDriver + RuntimeProvider interfaces, lightweight crag, arielcharts E2E proof
+- [Embed hermes_bridge + deployment docs](2026-04-17-embed-hermes-bridge-design.md) — Ship bridge embedded in binary, extract via belayer init; rewrite SANDBOXING.md with prod/dev topologies and known security gaps

--- a/embed.go
+++ b/embed.go
@@ -11,3 +11,13 @@ import "embed"
 //
 //go:embed all:agents
 var DefaultAgents embed.FS
+
+// DefaultBridge is the hermes_bridge Python package copied into a project's
+// .belayer/hermes_bridge/ directory by `belayer init`. Unlike DefaultAgents,
+// this copy is machine-generated and gitignored — it is always overwritten
+// on init so the extracted bridge matches the binary version. The extractor
+// filters __pycache__/ and *.pyc entries at walk time to avoid leaking host
+// bytecode into projects.
+//
+//go:embed all:hermes_bridge
+var DefaultBridge embed.FS

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -100,6 +100,12 @@ upgrading belayer); existing config.yaml and policies/ are never overwritten.`,
 			if result.alreadyInitialized && !force {
 				fmt.Fprintf(out, "belayer already initialized at %s (refreshed %d bridge file(s))\n",
 					belayerDir, result.bridgeRefreshed)
+				// Surface any upgrade changes (e.g. new .gitignore entries
+				// appended on a binary bump) so the user sees them even though
+				// the rest of the re-init path is silent.
+				for _, line := range result.created {
+					fmt.Fprintln(out, line)
+				}
 				return nil
 			}
 
@@ -174,6 +180,17 @@ func scaffold(belayerDir string, force bool) (scaffoldResult, error) {
 		}
 	}
 
+	// Gitignore maintenance runs before the re-init early return so that
+	// binary upgrades which add new entries (e.g. /.belayer/hermes_bridge/)
+	// land in already-initialized projects, not just fresh ones.
+	gitignoreNote, err := ensureGitignoreEntries(filepath.Dir(belayerDir))
+	if err != nil {
+		return result, err
+	}
+	if gitignoreNote != "" {
+		result.created = append(result.created, gitignoreNote)
+	}
+
 	// If already initialized and not --force, stop here — user-owned files
 	// (config.yaml, policies/, agents/) remain untouched.
 	if result.alreadyInitialized && !force {
@@ -206,72 +223,97 @@ func scaffold(belayerDir string, force bool) (scaffoldResult, error) {
 
 	sort.Strings(result.created)
 
-	// Update the project's .gitignore so per-run scratch directories under
-	// .belayer/ (runs/, worktrees/) don't get committed, while leaving the
-	// committed config (agents/, config.yaml, policies/) tracked.
-	gitignoreNote, err := ensureGitignoreEntries(filepath.Dir(belayerDir))
-	if err != nil {
-		return result, err
-	}
-	if gitignoreNote != "" {
-		result.created = append(result.created, gitignoreNote)
-	}
-
 	return result, nil
 }
 
-// gitignoreBlock is appended to the project .gitignore on first init. Entries
-// are anchored with a leading slash so they only match at the repo root —
-// nested .belayer/ inside subprojects (e.g. inside .belayer/worktrees/...)
-// are not affected by these rules. The leading newline is a separator from
-// preceding content; it is stripped when the file is created from scratch
-// so the file doesn't start with a blank line.
+// gitignoreHeader labels the belayer-managed block. Kept as a named constant
+// so the marker check below can match on it exactly, and so later versions can
+// append a second labelled block for entries added on upgrade.
+//
+// Entries in gitignoreEntries are anchored with a leading slash so they only
+// match at the repo root — nested .belayer/ inside subprojects (e.g. inside
+// .belayer/worktrees/...) are not affected by these rules.
 //
 // hermes_bridge/ is gitignored because the tree is extracted from the binary
 // on every `belayer init` and always overwrites — committing it would drift
 // against the binary version.
-const gitignoreBlock = `
-# belayer — per-run state (committed: agents/, config.yaml, policies/)
-/.belayer/runs/
-/.belayer/worktrees/
-/.belayer/hermes_bridge/
-`
+const (
+	gitignoreHeader        = "# belayer — per-run state (committed: agents/, config.yaml, policies/)"
+	gitignoreUpgradeHeader = "# belayer — added on upgrade"
+	gitignoreMarker        = "# belayer — per-run state"
+)
 
-const gitignoreMarker = "# belayer — per-run state"
+var gitignoreEntries = []string{
+	"/.belayer/runs/",
+	"/.belayer/worktrees/",
+	"/.belayer/hermes_bridge/",
+}
 
-// ensureGitignoreEntries appends gitignoreBlock to <project>/.gitignore when
-// the marker is absent. Returns a one-line summary describing what changed,
-// suitable for printing in the init summary; returns "" when no change was
-// needed. Never modifies an existing line — only appends.
+// ensureGitignoreEntries makes sure every entry in gitignoreEntries is present
+// in <project>/.gitignore. On a fresh file (or one without the belayer marker)
+// it writes the full labelled block. On upgrades — marker present but a newer
+// belayer release introduced an entry — it appends the missing entries under
+// an "added on upgrade" label so their provenance is visible. Returns a
+// one-line summary describing what changed, or "" when no change was needed.
+// Never modifies an existing line — only appends.
 func ensureGitignoreEntries(projectDir string) (string, error) {
 	path := filepath.Join(projectDir, ".gitignore")
 	existing, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return "", fmt.Errorf("read %s: %w", path, err)
 	}
-	if strings.Contains(string(existing), gitignoreMarker) {
+
+	present := map[string]bool{}
+	for _, line := range strings.Split(string(existing), "\n") {
+		present[strings.TrimSpace(line)] = true
+	}
+
+	var missing []string
+	for _, entry := range gitignoreEntries {
+		if !present[entry] {
+			missing = append(missing, entry)
+		}
+	}
+	if len(missing) == 0 {
 		return "", nil
 	}
 
-	block := gitignoreBlock
+	fresh := len(existing) == 0
+	markerPresent := strings.Contains(string(existing), gitignoreMarker)
+
 	out := append([]byte{}, existing...)
-	if len(out) == 0 {
-		// Fresh file — drop the separator newline so the file starts with the marker.
-		block = strings.TrimLeft(block, "\n")
-	} else if out[len(out)-1] != '\n' {
-		// Existing file without a trailing newline — add one so we don't merge
-		// onto a previous incomplete line.
+	if !fresh {
+		if out[len(out)-1] != '\n' {
+			out = append(out, '\n')
+		}
+		// Separator blank line before the belayer block so it doesn't merge
+		// visually into whatever the user had above.
 		out = append(out, '\n')
 	}
-	out = append(out, []byte(block)...)
+
+	switch {
+	case !markerPresent:
+		out = append(out, []byte(gitignoreHeader+"\n")...)
+	default:
+		// Marker already present but new entries surfaced in a later release.
+		// Label the upgrade block so users can see where these came from.
+		out = append(out, []byte(gitignoreUpgradeHeader+"\n")...)
+	}
+	for _, entry := range missing {
+		out = append(out, []byte(entry+"\n")...)
+	}
 
 	if err := os.WriteFile(path, out, 0o644); err != nil {
 		return "", fmt.Errorf("write %s: %w", path, err)
 	}
-	if len(existing) == 0 {
+	switch {
+	case fresh:
 		return "  + .gitignore (created with belayer entries)", nil
+	case !markerPresent:
+		return "  ~ .gitignore (appended belayer entries)", nil
+	default:
+		return "  ~ .gitignore (appended missing belayer entries on upgrade)", nil
 	}
-	return "  ~ .gitignore (appended belayer entries)", nil
 }
 
 // copyDefaultAgents walks the embedded agents/ tree and writes each file into
@@ -328,9 +370,21 @@ func copyDefaultAgents(dst string, force bool) ([]string, error) {
 // is machine-generated Go+Python glue pinned to this binary's version, so a
 // stale file on disk would produce a hard-to-debug version-skew bug.
 //
+// The destination is wiped before extraction so files renamed or deleted in
+// later binary versions don't linger on disk and get picked up by Python's
+// import machinery. The tree is gitignored and fully machine-owned, so this
+// is safe — nothing user-authored should live here.
+//
 // __pycache__ directories and *.pyc files are skipped so host bytecode from
 // developer builds never leaks into projects.
 func copyDefaultBridge(dst string) ([]string, error) {
+	if err := os.RemoveAll(dst); err != nil {
+		return nil, fmt.Errorf("reset bridge tree %s: %w", dst, err)
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir %s: %w", dst, err)
+	}
+
 	var written []string
 	err := fs.WalkDir(belayer.DefaultBridge, "hermes_bridge", func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -98,7 +98,8 @@ upgrading belayer); existing config.yaml and policies/ are never overwritten.`,
 			}
 
 			if result.alreadyInitialized && !force {
-				fmt.Fprintf(out, "belayer already initialized at %s\n", belayerDir)
+				fmt.Fprintf(out, "belayer already initialized at %s (refreshed %d bridge file(s))\n",
+					belayerDir, result.bridgeRefreshed)
 				return nil
 			}
 
@@ -118,14 +119,24 @@ upgrading belayer); existing config.yaml and policies/ are never overwritten.`,
 
 // scaffoldResult records what scaffold produced so callers can render output
 // (or, in the auto-init path from `belayer run`, skip output entirely).
+//
+// bridgeRefreshed is separate from created because bridge files are always
+// overwritten on every init — on re-init we want a one-line refresh summary
+// rather than N lines of "+ .belayer/hermes_bridge/<file>" noise.
 type scaffoldResult struct {
 	alreadyInitialized bool
 	created            []string
+	bridgeRefreshed    int
 }
 
 // scaffold creates belayerDir and its standard children. It is the core init
 // routine, separated from the cobra command so `belayer run` can call it
-// directly. When force is false and belayerDir exists, it is a no-op.
+// directly.
+//
+// On re-init without --force, user-owned files (config.yaml, policies/,
+// agents/) are not touched — the CLI reports "already initialized". The
+// hermes_bridge/ tree is refreshed unconditionally on every call so the
+// extracted copy always matches the binary version.
 func scaffold(belayerDir string, force bool) (scaffoldResult, error) {
 	var result scaffoldResult
 
@@ -134,18 +145,40 @@ func scaffold(belayerDir string, force bool) (scaffoldResult, error) {
 			return result, fmt.Errorf("%s exists but is not a directory", belayerDir)
 		}
 		result.alreadyInitialized = true
-		if !force {
-			return result, nil
-		}
 	} else if !os.IsNotExist(err) {
 		return result, fmt.Errorf("stat %s: %w", belayerDir, err)
 	}
 
-	for _, sub := range []string{"", "policies", "agents"} {
+	for _, sub := range []string{"", "policies", "agents", "hermes_bridge"} {
 		p := filepath.Join(belayerDir, sub)
 		if err := os.MkdirAll(p, 0o755); err != nil {
 			return result, fmt.Errorf("mkdir %s: %w", p, err)
 		}
+	}
+
+	// Bridge extraction runs on every scaffold, not gated by --force. It is
+	// machine-owned: the extracted tree is overwritten so it always matches
+	// the running binary's embedded copy.
+	bridgeRoot := filepath.Join(belayerDir, "hermes_bridge")
+	bridgeCopied, err := copyDefaultBridge(bridgeRoot)
+	if err != nil {
+		return result, err
+	}
+	result.bridgeRefreshed = len(bridgeCopied)
+	// On fresh init, surface bridge files in the created list so the user
+	// sees what was written. On re-init we rely on bridgeRefreshed for the
+	// one-line summary.
+	if !result.alreadyInitialized {
+		for _, p := range bridgeCopied {
+			result.created = append(result.created, "  + "+relativize(belayerDir, p))
+		}
+	}
+
+	// If already initialized and not --force, stop here — user-owned files
+	// (config.yaml, policies/, agents/) remain untouched.
+	if result.alreadyInitialized && !force {
+		sort.Strings(result.created)
+		return result, nil
 	}
 
 	configPath := filepath.Join(belayerDir, "config.yaml")
@@ -193,10 +226,15 @@ func scaffold(belayerDir string, force bool) (scaffoldResult, error) {
 // are not affected by these rules. The leading newline is a separator from
 // preceding content; it is stripped when the file is created from scratch
 // so the file doesn't start with a blank line.
+//
+// hermes_bridge/ is gitignored because the tree is extracted from the binary
+// on every `belayer init` and always overwrites — committing it would drift
+// against the binary version.
 const gitignoreBlock = `
 # belayer — per-run state (committed: agents/, config.yaml, policies/)
 /.belayer/runs/
 /.belayer/worktrees/
+/.belayer/hermes_bridge/
 `
 
 const gitignoreMarker = "# belayer — per-run state"
@@ -285,6 +323,58 @@ func copyDefaultAgents(dst string, force bool) ([]string, error) {
 	return written, nil
 }
 
+// copyDefaultBridge walks the embedded hermes_bridge/ tree and writes each
+// file into dst. Unlike copyDefaultAgents it always overwrites — the bridge
+// is machine-generated Go+Python glue pinned to this binary's version, so a
+// stale file on disk would produce a hard-to-debug version-skew bug.
+//
+// __pycache__ directories and *.pyc files are skipped so host bytecode from
+// developer builds never leaks into projects.
+func copyDefaultBridge(dst string) ([]string, error) {
+	var written []string
+	err := fs.WalkDir(belayer.DefaultBridge, "hermes_bridge", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == "hermes_bridge" {
+			return nil
+		}
+		rel := strings.TrimPrefix(path, "hermes_bridge/")
+		// Skip bytecode: __pycache__ directories (prune the whole subtree) and
+		// any straggler *.pyc files. The walk returns SkipDir to avoid
+		// descending into __pycache__.
+		base := filepath.Base(rel)
+		if d.IsDir() && base == "__pycache__" {
+			return fs.SkipDir
+		}
+		if !d.IsDir() && strings.HasSuffix(base, ".pyc") {
+			return nil
+		}
+		out := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			if err := os.MkdirAll(out, 0o755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", out, err)
+			}
+			return nil
+		}
+
+		data, err := belayer.DefaultBridge.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read embedded %s: %w", path, err)
+		}
+		if err := os.WriteFile(out, data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", out, err)
+		}
+		written = append(written, out)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return written, nil
+}
+
 // writeIfMissing writes data to path only if path does not already exist.
 // Returns true when a file was created, false when one was already present.
 // Existing files are never touched — config.yaml and policies/ are
@@ -312,16 +402,13 @@ func relativize(parent, p string) string {
 }
 
 // autoInitIfMissing is the entry point for `belayer run` to scaffold .belayer/
-// without forcing the user to call `belayer init` first. It writes a notice
-// to w when scaffolding actually runs and stays silent on the no-op path.
+// without forcing the user to call `belayer init` first. Scaffold is invoked
+// unconditionally so the embedded hermes_bridge/ tree is refreshed on every
+// run, keeping the extracted copy in sync with the binary. On a fresh scaffold
+// (no prior .belayer/) a notice is written to w; the bridge refresh on existing
+// projects is silent to avoid log spam on the hot path.
 func autoInitIfMissing(workdir string, w io.Writer) error {
 	belayerDir := filepath.Join(workdir, ".belayer")
-	if _, err := os.Stat(belayerDir); err == nil {
-		return nil
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat %s: %w", belayerDir, err)
-	}
-
 	result, err := scaffold(belayerDir, false)
 	if err != nil {
 		return err

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -343,6 +343,114 @@ func TestInitRefreshesBridgeOnReInit(t *testing.T) {
 	}
 }
 
+func TestInitGitignoreUpgradeAppendsMissingEntry(t *testing.T) {
+	dir := t.TempDir()
+	// Seed a .gitignore that looks like a project initialized under an older
+	// belayer version: it has the marker and the two historical entries but
+	// not /.belayer/hermes_bridge/.
+	legacy := gitignoreHeader + "\n/.belayer/runs/\n/.belayer/worktrees/\n"
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(legacy), 0o644); err != nil {
+		t.Fatalf("seed legacy gitignore: %v", err)
+	}
+
+	cmd := newInitCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--target", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read gitignore: %v", err)
+	}
+	gotStr := string(got)
+	if !strings.Contains(gotStr, "/.belayer/hermes_bridge/") {
+		t.Fatalf("expected missing entry to be appended, got:\n%s", gotStr)
+	}
+	// Must not duplicate entries the user already had.
+	if strings.Count(gotStr, "/.belayer/runs/") != 1 {
+		t.Fatalf("existing /.belayer/runs/ entry should not be duplicated:\n%s", gotStr)
+	}
+	// Original marker should still appear exactly once — upgrade uses a
+	// separate labelled block.
+	if strings.Count(gotStr, gitignoreMarker) != 1 {
+		t.Fatalf("marker should appear exactly once; got:\n%s", gotStr)
+	}
+	// Upgrade header visible so users see where the new entry came from.
+	if !strings.Contains(gotStr, gitignoreUpgradeHeader) {
+		t.Fatalf("expected upgrade header in gitignore, got:\n%s", gotStr)
+	}
+
+	// Re-running should be a no-op now — all entries are present.
+	second := newInitCmd()
+	second.SetOut(&bytes.Buffer{})
+	second.SetErr(&bytes.Buffer{})
+	second.SetArgs([]string{"--target", dir})
+	if err := second.Execute(); err != nil {
+		t.Fatalf("second init: %v", err)
+	}
+	got2, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read gitignore #2: %v", err)
+	}
+	if !bytes.Equal(got, got2) {
+		t.Fatalf("second init mutated gitignore; before=%q after=%q", got, got2)
+	}
+}
+
+func TestInitPrunesStaleBridgeFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	first := newInitCmd()
+	first.SetOut(&bytes.Buffer{})
+	first.SetErr(&bytes.Buffer{})
+	first.SetArgs([]string{"--target", dir})
+	if err := first.Execute(); err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+
+	// Simulate an upstream rename/deletion by planting a stale file in the
+	// extracted tree that doesn't exist in the embedded bridge.
+	bridgeDir := filepath.Join(dir, ".belayer", "hermes_bridge")
+	stalePath := filepath.Join(bridgeDir, "stale_removed_module.py")
+	if err := os.WriteFile(stalePath, []byte("# stale\n"), 0o644); err != nil {
+		t.Fatalf("seed stale file: %v", err)
+	}
+	staleSubdir := filepath.Join(bridgeDir, "removed_subpackage")
+	if err := os.MkdirAll(staleSubdir, 0o755); err != nil {
+		t.Fatalf("seed stale subdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staleSubdir, "__init__.py"), []byte(""), 0o644); err != nil {
+		t.Fatalf("seed stale subdir file: %v", err)
+	}
+
+	second := newInitCmd()
+	second.SetOut(&bytes.Buffer{})
+	second.SetErr(&bytes.Buffer{})
+	second.SetArgs([]string{"--target", dir})
+	if err := second.Execute(); err != nil {
+		t.Fatalf("second init: %v", err)
+	}
+
+	if _, err := os.Stat(stalePath); err == nil {
+		t.Fatalf("stale file survived re-init: %s", stalePath)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat stale file: %v", err)
+	}
+	if _, err := os.Stat(staleSubdir); err == nil {
+		t.Fatalf("stale subdir survived re-init: %s", staleSubdir)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat stale subdir: %v", err)
+	}
+
+	// The real bridge files must still be present.
+	if _, err := os.Stat(filepath.Join(bridgeDir, "__main__.py")); err != nil {
+		t.Fatalf("expected __main__.py after prune: %v", err)
+	}
+}
+
 func TestAutoInitRefreshesBridgeOnExistingProject(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -154,7 +154,7 @@ func TestInitCreatesGitignoreWhenMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read .gitignore: %v", err)
 	}
-	for _, want := range []string{"/.belayer/runs/", "/.belayer/worktrees/"} {
+	for _, want := range []string{"/.belayer/runs/", "/.belayer/worktrees/", "/.belayer/hermes_bridge/"} {
 		if !strings.Contains(string(got), want) {
 			t.Fatalf("expected %q in .gitignore, got: %s", want, string(got))
 		}
@@ -246,12 +246,135 @@ func TestAutoInitIfMissingScaffoldsAndAnnounces(t *testing.T) {
 		t.Fatalf("expected scaffolded supervisor prompt: %v", err)
 	}
 
-	// Second call must be silent.
+	// Second call must be silent — the bridge refresh is a hot-path no-op from
+	// the user's perspective (files may be rewritten byte-for-byte but the
+	// announce is suppressed).
 	out2 := &bytes.Buffer{}
 	if err := autoInitIfMissing(dir, out2); err != nil {
 		t.Fatalf("autoInit second call: %v", err)
 	}
 	if out2.Len() != 0 {
 		t.Fatalf("expected silent no-op, got: %s", out2.String())
+	}
+}
+
+func TestInitExtractsHermesBridge(t *testing.T) {
+	dir := t.TempDir()
+	cmd := newInitCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--target", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	bridgeDir := filepath.Join(dir, ".belayer", "hermes_bridge")
+	// __main__.py is the package entry point; its absence is a hard failure.
+	if _, err := os.Stat(filepath.Join(bridgeDir, "__main__.py")); err != nil {
+		t.Fatalf("expected hermes_bridge/__main__.py to exist: %v", err)
+	}
+	// __init__.py makes it an importable package.
+	if _, err := os.Stat(filepath.Join(bridgeDir, "__init__.py")); err != nil {
+		t.Fatalf("expected hermes_bridge/__init__.py to exist: %v", err)
+	}
+
+	// __pycache__ from the host build must never leak into the extracted copy.
+	if _, err := os.Stat(filepath.Join(bridgeDir, "__pycache__")); err == nil {
+		t.Fatalf("__pycache__ was extracted; expected it to be filtered")
+	}
+
+	// No *.pyc files at any depth.
+	walkErr := filepath.Walk(bridgeDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(path, ".pyc") {
+			t.Errorf("unexpected .pyc file in extracted bridge: %s", path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk bridge dir: %v", walkErr)
+	}
+}
+
+func TestInitRefreshesBridgeOnReInit(t *testing.T) {
+	dir := t.TempDir()
+
+	first := newInitCmd()
+	first.SetOut(&bytes.Buffer{})
+	first.SetErr(&bytes.Buffer{})
+	first.SetArgs([]string{"--target", dir})
+	if err := first.Execute(); err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+
+	mainPath := filepath.Join(dir, ".belayer", "hermes_bridge", "__main__.py")
+	originalBytes, err := os.ReadFile(mainPath)
+	if err != nil {
+		t.Fatalf("read extracted __main__.py: %v", err)
+	}
+
+	// Simulate drift: replace the extracted bridge file with garbage.
+	if err := os.WriteFile(mainPath, []byte("# drifted\n"), 0o644); err != nil {
+		t.Fatalf("seed drift: %v", err)
+	}
+
+	second := newInitCmd()
+	out := &bytes.Buffer{}
+	second.SetOut(out)
+	second.SetErr(out)
+	second.SetArgs([]string{"--target", dir})
+	if err := second.Execute(); err != nil {
+		t.Fatalf("second init: %v", err)
+	}
+
+	// Output must announce the bridge refresh.
+	if !strings.Contains(out.String(), "refreshed") {
+		t.Fatalf("expected re-init output to mention refreshed bridge files, got: %s", out.String())
+	}
+
+	got, err := os.ReadFile(mainPath)
+	if err != nil {
+		t.Fatalf("read bridge after re-init: %v", err)
+	}
+	if !bytes.Equal(got, originalBytes) {
+		t.Fatalf("re-init did not restore bridge __main__.py; drift persisted")
+	}
+}
+
+func TestAutoInitRefreshesBridgeOnExistingProject(t *testing.T) {
+	dir := t.TempDir()
+
+	// First auto-init creates everything.
+	if err := autoInitIfMissing(dir, &bytes.Buffer{}); err != nil {
+		t.Fatalf("first autoInit: %v", err)
+	}
+
+	mainPath := filepath.Join(dir, ".belayer", "hermes_bridge", "__main__.py")
+	originalBytes, err := os.ReadFile(mainPath)
+	if err != nil {
+		t.Fatalf("read bridge: %v", err)
+	}
+	if err := os.WriteFile(mainPath, []byte("# drifted\n"), 0o644); err != nil {
+		t.Fatalf("seed drift: %v", err)
+	}
+
+	// Second auto-init (simulating another `belayer run`) must refresh bridge
+	// silently — the announce is suppressed on already-initialized projects.
+	out := &bytes.Buffer{}
+	if err := autoInitIfMissing(dir, out); err != nil {
+		t.Fatalf("second autoInit: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected silent refresh on existing project, got: %s", out.String())
+	}
+
+	got, err := os.ReadFile(mainPath)
+	if err != nil {
+		t.Fatalf("read bridge after auto re-init: %v", err)
+	}
+	if !bytes.Equal(got, originalBytes) {
+		t.Fatalf("auto-init did not refresh drifted bridge file")
 	}
 }

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -434,9 +434,13 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 	// In clamshell mode the bridge runs inside the Docker container where the
 	// host hermes venv path doesn't exist; use the container's system python3.
 	// Also inject proxy vars so LLM API calls route through the egress broker.
+	// BelayerRoot is overridden to the container's view of the extracted
+	// hermes_bridge parent (/workspace/.belayer) so `python3 -m hermes_bridge`
+	// imports the copy placed there by `belayer init`, not the host path.
 	if ss.mode == "clamshell" {
 		cfg.Cmd = []string{"python3", "-m", "hermes_bridge"}
 		cfg.HTTPProxy = "http://proxy.internal:3128"
+		cfg.BelayerRoot = "/workspace/.belayer"
 	}
 	_ = worktreePath // stored in DB; cleanup handled separately
 


### PR DESCRIPTION
## Summary

- Embeds the `hermes_bridge` Python package in the belayer binary (`//go:embed all:hermes_bridge`) and extracts it to `.belayer/hermes_bridge/` on every `belayer init` (and auto-init via `belayer run`). Always overwrite so the extracted tree tracks the binary version. `__pycache__/` and `*.pyc` are filtered at walk time to keep host bytecode out of projects.
- Wires clamshell mode to point PYTHONPATH at `/workspace/.belayer` so `python3 -m hermes_bridge` resolves against the bind-mounted project copy instead of a separately-synced path.
- Rewrites `docs/SANDBOXING.md` with a dual-topology structure (ideal Nightshift Linux VM vs macOS/Colima local dev tax) and adds a **Known Security Gaps** section documenting two follow-up items:
  - §1 bridge spawn bypasses the clamshell CLI (raw `docker exec --env-file`)
  - §2 the agent process currently sees the real `OPENCODE_GO_API_KEY`

## Stacking

Stacks on #78 — targets `feat/clamshell-e2e` so the diff is scoped to this change. Once #78 merges, this can be retargeted to `master`.

## Test plan

- [x] `go test ./...`
- [x] `go test -tags clamshell ./...`
- [x] New tests cover extraction, re-init refresh, and auto-init refresh on existing projects
- [ ] Colima VM smoke: fresh `belayer init` produces `.belayer/hermes_bridge/__main__.py`
- [ ] Colima VM smoke: `belayer run start` in clamshell mode launches bridge from `/workspace/.belayer/hermes_bridge`

## Follow-ups (not in this PR)

- Introduce a `clamshell exec` wrapper so bridge spawn goes through sandbox-aware plumbing (closes §1)
- Swap the real `OPENCODE_GO_API_KEY` for an opaque session token with credential injection at the proxy or via a clamshell-owned broker (closes §2)

Both are designed in `docs/design-docs/2026-04-17-embed-hermes-bridge-design.md` and will ship in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)