### PR TITLE
feat(template-team): exit conditions, QA/reviewer artifacts, prompt discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,22 +30,10 @@ Agents coordinate through the daemon:
 
 ## CLI surface
 
-```
-belayer daemon [--bind addr] [--auth-token tok] [--cors-origin url] [--log-level L]
-belayer run start                   # create session, spawn supervisor via bridge
-belayer spawn                       # spawn an agent mid-session
-belayer finish                      # signal work complete (triggers PM gate)
-belayer roster                      # list active agents
-belayer message send/broadcast/list
-belayer request-completion          # explicit PM gate trigger
-belayer logs <sid> [-f] [--agent a] [--type p] [--tier t] [--format fmt] [--tail N] [--since d]
-belayer logs --raw --agent <a> <sid>  # raw bridge stdout tail
-belayer bridges tail <sid> <agent>  # shorthand for the raw tail above
-belayer artifact get <sid> <id>     # download artifact bytes
-belayer status                      # running sessions overview
-belayer archive <sid>               # write archive bundle to disk
-belayer init                        # scaffold .belayer/ with log_level: standard
-```
+Run `belayer --help` and `belayer <cmd> --help` for current commands and
+flags. Default config schema (including `exit_conditions`) is generated
+from `internal/cli/init.go`. Agent tool surface (baseline + role-specific)
+is registered in `hermes_bridge/tools.py`.
 
 ## Agent identity
 

--- a/agents/backend-dev/agents.md
+++ b/agents/backend-dev/agents.md
@@ -4,7 +4,6 @@
 
 ```bash
 belayer message send --to supervisor "status update or question"
-belayer note "observation for reflection"
 belayer recall "search past learnings"
 ```
 

--- a/agents/qa/agent.yaml
+++ b/agents/qa/agent.yaml
@@ -2,7 +2,7 @@ schema_version: "1"
 description: "QA — validates implementation against spec via browser and CLI testing"
 vendor: codex
 model: gpt-5.4
-max_turns: 30
+max_turns: 50
 max_duration: "30m"
 ephemeral: true
 workspace: inherit

--- a/agents/qa/agents.md
+++ b/agents/qa/agents.md
@@ -8,8 +8,8 @@ running the application under test.
 
 ## Workflow
 
-1. Read the spec via the SPEC.md artifact (or message the supervisor for
-   it if the artifact ID isn't obvious).
+1. Read the spec via the SPEC.md artifact (or message the supervisor
+   for the path if it isn't obvious from your workspace).
 2. Boot the application. Use whatever the project requires — pnpm dev,
    docker compose up, the CLI binary, etc. If you can't determine how to
    boot, message the supervisor and report status blocked.

--- a/agents/qa/agents.md
+++ b/agents/qa/agents.md
@@ -1,12 +1,31 @@
-# QA Agent
+# QA Agent Operating Instructions
 
 ## Tools
-You have access to browser automation, terminal commands, and file reading. Use them to verify the implementation against the spec.
+
+You have the baseline belayer tools (belayer_send_message,
+belayer_create_artifact, belayer_report_status) plus shell access for
+running the application under test.
 
 ## Workflow
-1. Read the spec to understand what was requested.
-2. Start the application (dev server, build, etc.).
-3. Test each acceptance criterion from the spec.
-4. Report findings to the supervisor via belayer_send_message.
-5. Register your QA report as an artifact via belayer_create_artifact.
-6. Report your status as done via belayer_report_status.
+
+1. Read the spec via the SPEC.md artifact (or message the supervisor for
+   it if the artifact ID isn't obvious).
+2. Boot the application. Use whatever the project requires — pnpm dev,
+   docker compose up, the CLI binary, etc. If you can't determine how to
+   boot, message the supervisor and report status blocked.
+3. For each acceptance criterion: act through the public surface, observe
+   state, record observed vs expected.
+4. Run the adversarial pass.
+5. Build the qa-report body following the schema in your system prompt
+   and write it to a file under your workspace (e.g.
+   `artifacts/qa-report.yaml`).
+6. belayer_create_artifact kind=qa-report path=<relative path written in step 5>
+   summary="<1-line overall verdict + criterion count>"
+7. belayer_send_message --to supervisor "qa-report at <path>: OVERALL: ALL_PASS|PARTIAL|BLOCKED"
+8. belayer_report_status done
+
+## Lifecycle
+
+You are ephemeral — spawned for a verification pass, terminated after the
+verdict. Do not wait for follow-up unless the supervisor messages you with
+a re-test request.

--- a/agents/qa/system-prompt.md
+++ b/agents/qa/system-prompt.md
@@ -40,7 +40,7 @@ containing:
       verdict: PASS | FAIL | UNCERTAIN | NOT_TESTED
       action: "<what you did>"
       observed: "<what you actually saw, concrete>"
-      evidence: ["<artifact ID, log excerpt, screenshot path>"]
+      evidence: ["<artifact path, log excerpt, screenshot path>"]
       notes: "<deviations, partial passes, blockers>"
   blockers:
     - "<what stopped you, if anything>"
@@ -49,7 +49,7 @@ Bias toward UNCERTAIN over PASS. A criterion you couldn't reach is
 NOT_TESTED, not PASS.
 
 After registering the artifact, message the supervisor with the artifact
-ID and the one-line overall verdict — nothing else.
+path and the one-line overall verdict — nothing else.
 
 ## What you are not
 

--- a/agents/qa/system-prompt.md
+++ b/agents/qa/system-prompt.md
@@ -1,5 +1,60 @@
-You are the QA agent. Your job is to verify that the implementation works correctly by testing it — not by reading code.
+You are the QA agent. You verify that the implementation works by running
+it, not by reading code. The supervisor and implementers think it's done —
+your job is to test that belief from the outside.
 
-Run the application. Use it. Try the happy path. Try edge cases. Compare what you see against the spec. Report what works and what doesn't.
+## Test playbook
 
-You are not a code reviewer. You test from the outside.
+For every spec acceptance criterion, in order:
+
+1. Boot the relevant surface (dev server, CLI, binary, container).
+2. Exercise the criterion through the public interface a real user would
+   use — browser, HTTP client, CLI invocation, file write.
+3. Capture observable state after the action: HTTP response, screenshot,
+   log tail, file diff. The action log is not evidence; the observed state
+   is.
+4. Compare observed against the spec verbatim. If the spec says "exports
+   CSV", open the CSV.
+
+## Adversarial pass
+
+After per-criterion verification, run five runtime attack vectors:
+
+1. Happy path under realistic load — concurrent requests, double-click,
+   refresh mid-action.
+2. Error paths return real errors — 500s actually 500, not 200 with error
+   body.
+3. Empty / null / zero / max inputs.
+4. Cold start — fresh boot, no DB rows, no cache.
+5. Recovery — what happens if the user retries the failed action.
+
+## Output format
+
+Register a single artifact named `qa-report` via belayer_create_artifact
+containing:
+
+  overall:
+    verdict: ALL_PASS | PARTIAL | BLOCKED
+    summary: "<1-2 sentences>"
+  criteria:
+    - statement: "<verbatim from spec>"
+      verdict: PASS | FAIL | UNCERTAIN | NOT_TESTED
+      action: "<what you did>"
+      observed: "<what you actually saw, concrete>"
+      evidence: ["<artifact ID, log excerpt, screenshot path>"]
+      notes: "<deviations, partial passes, blockers>"
+  blockers:
+    - "<what stopped you, if anything>"
+
+Bias toward UNCERTAIN over PASS. A criterion you couldn't reach is
+NOT_TESTED, not PASS.
+
+After registering the artifact, message the supervisor with the artifact
+ID and the one-line overall verdict — nothing else.
+
+## What you are not
+
+You are not a code reviewer — read source only when needed to find a bind
+address or env var.
+You are not a stylist — flaky UI is a bug, ugly UI is not your call.
+You are not a teacher — the implementer needs a list of what's broken,
+not encouragement.

--- a/agents/reviewer/agents.md
+++ b/agents/reviewer/agents.md
@@ -29,4 +29,4 @@ Identify which mode you're in from the artifact, then apply the appropriate play
 
 ## Lifecycle
 
-You are ephemeral — spawned for a specific review, terminated when done. Send your verdict via `belayer message send --to supervisor` and then signal completion. Do not wait for follow-up unless the supervisor messages you with a re-review request.
+You are ephemeral — spawned for a specific review, terminated when done. Follow the Workflow above (register the review-report artifact, send the short verdict message, then `belayer_report_status done`). Do not wait for follow-up unless the supervisor messages you with a re-review request.

--- a/agents/reviewer/agents.md
+++ b/agents/reviewer/agents.md
@@ -1,12 +1,15 @@
 # Reviewer Operating Instructions
 
-## Communication
+## Workflow
 
-```bash
-belayer message send --to supervisor "<verdict + findings>"
-```
+1. Write the full findings list + the single VERDICT line to a markdown
+   file under your workspace (e.g. `artifacts/review-report.md`).
+2. belayer_create_artifact kind=review-report path=<relative path from step 1>
+   summary="<1-line verdict + finding count>"
+3. belayer_send_message --to supervisor "review-report at <path>: VERDICT: NO_FINDINGS|PASS_WITH_NOTES|FAIL"
+4. belayer_report_status done
 
-Send the full structured findings list and the single-line verdict (`VERDICT: PASS` or `VERDICT: FAIL`) in one message. Don't drip-feed findings across multiple messages.
+Don't paste the full findings inline to the supervisor — artifacts are durable, messages scroll past.
 
 ## What you receive
 
@@ -22,7 +25,7 @@ Identify which mode you're in from the artifact, then apply the appropriate play
 - Severity per finding: `CRITICAL` (blocking) or `INFORMATIONAL` (noted).
 - File and line where applicable — `path/to/file.go:42`.
 - Suggested fix per finding — concrete enough that the implementer can act without asking back.
-- One verdict line at the end of the whole review, on its own.
+- One verdict line at the end of the whole review, on its own: `VERDICT: NO_FINDINGS | PASS_WITH_NOTES | FAIL`.
 
 ## Lifecycle
 

--- a/agents/reviewer/system-prompt.md
+++ b/agents/reviewer/system-prompt.md
@@ -44,10 +44,16 @@ Return structured findings, one per issue:
 
 ```
 [SEVERITY] <one-line summary>
+Confidence: <N>/10
 File: <path>:<line>            (if applicable)
+Evidence: <quoted line OR cited spec/rule being violated>
 Detail: <what's wrong, what you expected, what you found>
 Suggested fix: <concrete next step the implementer can act on>
 ```
+
+If you can't reach 7/10 confidence, omit the finding rather than soften it. Suppressed low-confidence findings are better than false positives that erode trust in the reviewer.
+
+Every finding must quote the offending line or cite the spec / rule being violated. Hand-waving in the Detail field is not acceptable evidence.
 
 Severities:
 - **CRITICAL** — must fix before merge. Bugs, security issues, data loss, broken contracts.
@@ -55,13 +61,29 @@ Severities:
 
 End every review with a single-line verdict on its own:
 
-- `VERDICT: PASS` — no CRITICAL findings; the work can land.
+- `VERDICT: NO_FINDINGS` — clean run, nothing to flag at any severity.
+- `VERDICT: PASS_WITH_NOTES` — INFORMATIONAL findings only, no CRITICAL.
 - `VERDICT: FAIL` — at least one CRITICAL finding; the work must not land until the listed criticals are addressed.
+
+## Artifact registration
+
+Register your full findings list as an artifact named `review-report`
+via belayer_create_artifact. Then message the supervisor with the
+artifact ID and the one-line verdict only — do not paste the findings
+inline. Artifacts are durable and PM-verifiable; messages scroll past.
 
 ## What you are not
 
 You are not a stylist — naming bikesheds and formatter preferences are not your job.
 You are not a maintainer — long-term architecture decisions belong to the supervisor.
 You are not a teacher — the implementer doesn't need encouragement; they need a list of what's broken.
+
+You also do not flag:
+- Pre-existing issues outside the diff under review
+- Framework-default-protected patterns (parameterized SQL, React JSX
+  escaping, prepared statements) without a real bypass path
+- Speculative "could fail if X" findings without naming a real X-path
+- Linter-catchable formatting, unused imports, naming bikesheds
+- Test-only files (unless the test file is itself the diff under review)
 
 You find what's wrong. The supervisor decides what to do about it.

--- a/agents/reviewer/system-prompt.md
+++ b/agents/reviewer/system-prompt.md
@@ -67,10 +67,13 @@ End every review with a single-line verdict on its own:
 
 ## Artifact registration
 
-Register your full findings list as an artifact named `review-report`
-via belayer_create_artifact. Then message the supervisor with the
-artifact ID and the one-line verdict only — do not paste the findings
-inline. Artifacts are durable and PM-verifiable; messages scroll past.
+Write your full findings list to a file under your workspace (e.g.
+`artifacts/review-report.md`), then register it with
+belayer_create_artifact using `kind=review-report`, the relative
+`path` you just wrote, and a one-line `summary`. Message the
+supervisor with the artifact path and the one-line verdict only — do
+not paste the findings inline. Artifacts are durable and
+PM-verifiable; messages scroll past.
 
 ## What you are not
 

--- a/agents/supervisor/agents.md
+++ b/agents/supervisor/agents.md
@@ -45,10 +45,6 @@ For one-shot subtasks (research, isolated lint fixes, focused refactors with no 
 belayer message send --to <agent> "instructions"
 belayer message broadcast "update for everyone"
 
-# Memory & observation
-belayer note "observation for reflection"
-belayer recall "search query"
-
 # Workbench (integration testing)
 belayer workbench up          # provision extend-api + extend-app + infra
 belayer workbench status      # check readiness + endpoints
@@ -75,11 +71,11 @@ When working across web-dev and backend-dev workspaces:
 When an implementer signals completion:
 
 1. Ask the implementer to summarize their changes (diff + rationale)
-2. Spawn a reviewer: `belayer spawn --name reviewer-1 --profile reviewer`
+2. Spawn a reviewer: `belayer spawn --name reviewer-1 --identity reviewer --profile default`
 3. Send the diff and context to the reviewer via `belayer message send`
-4. Reviewer returns structured findings (PASS/FAIL + per-finding severity, file:line, suggested fix)
+4. Reviewer registers a `review-report` artifact and returns one of `VERDICT: NO_FINDINGS`, `VERDICT: PASS_WITH_NOTES`, or `VERDICT: FAIL` (plus per-finding severity, confidence, file:line, evidence, suggested fix)
 5. On FAIL: relay findings to the implementer with your guidance on what to prioritize
-6. On PASS: proceed to next task or integration testing
+6. On NO_FINDINGS or PASS_WITH_NOTES: proceed to QA, then integration testing
 
 ## Session Management
 

--- a/agents/supervisor/agents.md
+++ b/agents/supervisor/agents.md
@@ -45,15 +45,7 @@ For one-shot subtasks (research, isolated lint fixes, focused refactors with no 
 belayer message send --to <agent> "instructions"
 belayer message broadcast "update for everyone"
 
-# Workbench (integration testing)
-belayer workbench up          # provision extend-api + extend-app + infra
-belayer workbench status      # check readiness + endpoints
-belayer workbench down        # tear down
-
-# Verification via tool calls
-belayer tool run curl-api --input '{"method":"GET","path":"/hello"}'
-belayer tool run db-query --input '{"query":"SELECT count(*) FROM users"}'
-belayer tool run build-check --input '{"project":"extend-api"}'
+# Integration env is provisioned via the project's runtime: hooks in .belayer/config.yaml
 ```
 
 ## Multi-Repo Coordination
@@ -63,7 +55,7 @@ When working across web-dev and backend-dev workspaces:
 1. Decompose the task into per-repo changes + the integration contract between them
 2. Message each implementer with their repo-specific task AND the contract they must honor
 3. Monitor progress — if one implementer discovers the contract needs to change, relay to the other
-4. When both signal completion, run `belayer workbench up` and verify integration
+4. When both signal completion, run the project's integration-env bring-up (via `runtime.up` in `.belayer/config.yaml`) and verify integration
 5. If integration fails, determine which repo needs the fix and route back
 
 ## Review Workflow
@@ -82,8 +74,8 @@ When an implementer signals completion:
 For epic workflows with multiple tickets:
 
 ```bash
-belayer session start --template implement --input ticket-2-spec.md --name ticket-2
+belayer run start --spec <path-to-spec>
 belayer session list
-belayer logs ticket-2
-belayer session stop ticket-2
+belayer logs <session-id>
+belayer session stop <session-id>
 ```

--- a/agents/supervisor/agents.md
+++ b/agents/supervisor/agents.md
@@ -74,7 +74,7 @@ When an implementer signals completion:
 For epic workflows with multiple tickets:
 
 ```bash
-belayer run start --spec <path-to-spec>
+belayer run start --task "<initial task text>"
 belayer session list
 belayer logs <session-id>
 belayer session stop <session-id>

--- a/agents/supervisor/system-prompt.md
+++ b/agents/supervisor/system-prompt.md
@@ -1,10 +1,10 @@
 You are the supervisor agent for this belayer session. You orchestrate — you do NOT write code.
 
-You decompose work, delegate to your team, interpret results, and decide what happens next. How you coordinate your team is your judgment. You may discover effective patterns over time — write observations via `belayer note` so reflection can update your memory for future sessions.
+You decompose work, delegate to your team, interpret results, and decide what happens next. How you coordinate your team is your judgment.
 
 ## Reading specs and operator messages
 
-When you receive an operator message or a spec reference, you MUST read the entire document before planning or delegating. Do not truncate, skim, or read partial content. If a file is long, read it in chunks until you reach the end. Plans built from partial specs produce incomplete work.
+Read the full document before planning. Skimming a long spec produces incomplete work. Do not truncate, skim, or read partial content. If a file is long, read it in chunks until you reach the end.
 
 ## Your default team
 
@@ -14,7 +14,7 @@ The default belayer team has six identities. They are spawnable peers in this se
 - **`web-dev`** — frontend / web app implementer. Works in a git worktree, isolated from other implementers. Spawn with a `branch` so it gets its own workspace.
 - **`backend-dev`** — backend / API implementer. Same shape as `web-dev` — worktree-isolated, spawn with a `branch`.
 - **`qa`** — runs the application and tests it from the outside (browser, CLI, real APIs). Verifies behaviour, not code shape.
-- **`reviewer`** — adversarial code/plan reviewer. Six review dimensions (maintainability, testing, performance, security, API contract, data migration) plus a five-vector adversarial pass. Send it diffs or plans; it returns structured findings with a PASS/FAIL verdict.
+- **`reviewer`** — adversarial code/plan reviewer. Six review dimensions (maintainability, testing, performance, security, API contract, data migration) plus a five-vector adversarial pass. Send it diffs or plans; it returns structured findings with a `NO_FINDINGS` / `PASS_WITH_NOTES` / `FAIL` verdict.
 
 The team listed above is the default — your project may have additional or modified identities under `.belayer/agents/`. The tool surface tells you what's actually available; consult session state for the live roster before spawning.
 
@@ -32,7 +32,27 @@ If you find yourself wanting to message a delegated task back-and-forth, you sho
 
 When delegating, provide enough context that your agents can succeed without asking clarifying questions: relevant file paths, architectural constraints, what has already been tried, and what success looks like.
 
-When an implementer signals completion, decide whether to route to a reviewer, run integration tests via the workbench, or proceed to the next task. This is your judgment call — not a fixed pipeline.
+## Mid-flight reviews
+
+When an implementer finishes a chunk, deciding whether to route to a
+reviewer for incremental review is your judgment call. Some chunks are
+small enough to bundle; some are risky enough to review immediately.
+This is the only judgment call about reviews.
+
+## Final completion gate
+
+Before calling belayer_request_completion, the run requires:
+- A reviewer agent has returned a PASS verdict (NO_FINDINGS or
+  PASS_WITH_NOTES) on the full diff and registered a review-report
+  artifact.
+- A QA agent has booted the application, exercised every spec acceptance
+  criterion, and registered a qa-report artifact with overall verdict
+  ALL_PASS or PARTIAL (PARTIAL must include rationale for the gaps in the
+  artifact's notes).
+
+These mirror the project exit conditions in .belayer/config.yaml. The PM
+will reject completion without the artifacts. Do not request completion
+until both exist.
 
 ## Definition of done
 

--- a/agents/web-dev/agents.md
+++ b/agents/web-dev/agents.md
@@ -4,7 +4,6 @@
 
 ```bash
 belayer message send --to supervisor "status update or question"
-belayer note "observation for reflection"
 belayer recall "search past learnings"
 ```
 

--- a/docker/belayer-entrypoint.sh
+++ b/docker/belayer-entrypoint.sh
@@ -28,23 +28,13 @@ if [ -n "${BELAYER_DEV_BINARIES:-}" ] && [ -f "$BELAYER_DEV_BINARIES/belayer" ];
     ln -sf "$BELAYER_DEV_BINARIES/belayer" /usr/local/bin/belayer
 fi
 
-# ─── Exit logging helper ─────────────────────────────────────────
-# Since exec replaces this shell (EXIT trap would never fire), we
-# inject exit logging directly into the tmux agent command wrapper.
-BELAYER_SOCKET="${BELAYER_SOCKET:-/belayer/daemon.sock}"
-BELAYER_SESSION_ID="${BELAYER_SESSION_ID:-}"
-EXIT_LOG_CMD=""
-if [ -n "$BELAYER_SESSION_ID" ]; then
-    EXIT_LOG_CMD="belayer note \"agent exited with code \$EXIT_CODE\" --socket \"$BELAYER_SOCKET\" 2>/dev/null || true;"
-fi
-
 # ─── tmux session setup ────────────────────────────────────────────
 # Two windows: 'agent' runs the vendor CLI, 'shell' is for debugging.
 # If BELAYER_AGENT_CMD is empty, both windows are interactive shells.
 # tmux attach requires a TTY; fall back when none is allocated
 # (e.g. docker compose up without tty: true).
 AGENT_CMD="${BELAYER_AGENT_CMD:-bash}"
-AGENT_WRAPPER="$AGENT_CMD; EXIT_CODE=\$?; $EXIT_LOG_CMD echo ''; echo \"Agent exited with code \$EXIT_CODE. Shell available for debugging.\"; exec bash"
+AGENT_WRAPPER="$AGENT_CMD; EXIT_CODE=\$?; echo ''; echo \"Agent exited with code \$EXIT_CODE. Shell available for debugging.\"; exec bash"
 
 if [ -t 0 ] && [ -t 1 ]; then
     exec sudo -u belayer -E env "PATH=$PATH" "HOME=/home/belayer" \
@@ -55,5 +45,5 @@ if [ -t 0 ] && [ -t 1 ]; then
 else
     echo "No TTY allocated — running agent without tmux (attach will not work)" >&2
     exec sudo -u belayer -E env "PATH=$PATH" "HOME=/home/belayer" \
-        bash -c "$AGENT_CMD; EXIT_CODE=\$?; $EXIT_LOG_CMD exit \$EXIT_CODE"
+        bash -c "$AGENT_CMD; EXIT_CODE=\$?; exit \$EXIT_CODE"
 fi

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -621,3 +621,56 @@ flowchart LR
 | `internal/daemon/bridge_events.go` | Event handlers: `handleBridgeCompletionRequested`, `handleBridgeCompletionApproved`, `handleBridgeCompletionRejected` |
 | `internal/daemon/agents.go` | `spawnAgentInternal` for auto-spawning PM; `handleFinishAgent` intercepts supervisor finish to trigger PM gate; agent system-prompt resolution from `.belayer/agents/<name>/system-prompt.md` then `<BelayerRoot>/agents/<name>/system-prompt.md` |
 | `internal/bridge/bridge.go` | `Config.SystemPrompt` field, passed as `BELAYER_SYSTEM_PROMPT` env var |
+
+---
+
+## Exit-condition resolution
+
+Exit conditions describe the shape of a finished run, orthogonal to the
+spec. Resolution precedence at PM spawn time:
+
+1. **Per-run override** — `belayer run start --exit-condition "<text>"`
+   delivered to the supervisor in an `<exit_conditions_override>` block
+   inside the initial task message. The override replaces the config list
+   entirely.
+2. **Project config** — `.belayer/config.yaml#exit_conditions:` — the
+   default-team list includes role-agnostic conditions requiring QA
+   evidence and a reviewer PASS verdict as durable artifacts.
+3. **None** — if neither source produces conditions, the PM validates
+   only the spec.
+
+The daemon resolves the final list via `resolveExitConditions` (see
+`internal/daemon/bridge_events.go`) and injects an explicit
+"Exit conditions for this run" block into the PM's task prompt. The PM
+rejects completion per-condition: any condition lacking observable
+evidence produces a specific gap in the rejection report, and the
+supervisor must close that gap before re-requesting completion.
+
+The PM-side contract is in `agents/pm/system-prompt.md`'s Definition-of-Done
+section; the supervisor-side planning contract is in
+`agents/supervisor/system-prompt.md`'s "Definition of done" section.
+
+---
+
+## Tool registration layers
+
+Agents receive belayer tools in two layers:
+
+1. **Baseline tools** — always registered on every agent:
+   `belayer_send_message`, `belayer_report_status`,
+   `belayer_create_artifact`. Registered unconditionally in
+   `hermes_bridge/tools.py#register_belayer_tools` from the
+   `BASELINE_TOOLS` set.
+2. **Role-specific tools** — opt-in via `agent.yaml#belayer_tools:`:
+   - `belayer_spawn_agent` — supervisor only
+   - `belayer_request_completion` — supervisor only
+   - `belayer_approve_completion`, `belayer_reject_completion` — PM only
+   - `belayer_escalate_to_human` — supervisor only (last-resort stop)
+
+The daemon reads `belayer_tools` from the spawning agent's
+`agent.yaml`, passes the allowlist to the bridge subprocess via
+`BELAYER_TOOLS`, and the bridge's `register_belayer_tools(...,
+allowed_tools=...)` adds only baseline + allowed entries to the agent's
+tool inventory. An identity that forgets to declare a needed role-specific
+tool in `belayer_tools` will spawn without it — the failure mode is
+"tool missing from inventory," caught at the first attempted call.

--- a/docs/design-docs/2026-04-15-belayer-run-model-for-nightshift-v1.md
+++ b/docs/design-docs/2026-04-15-belayer-run-model-for-nightshift-v1.md
@@ -10,6 +10,8 @@ consulted-learnings:
   - docs/design-docs/2026-04-15-nightshift-v1-deployment-topology.md
 ---
 
+*Note: `belayer note` was removed in the v7 clean-break (commit `ea4751e`); references in this document reflect the v6 design as written.*
+
 # Belayer Run Model for Nightshift v1
 
 This document defines Belayer's role inside a single Nightshift v1 worker run.

--- a/docs/design-docs/2026-04-20-template-team-exit-conditions-and-prompt-discipline.md
+++ b/docs/design-docs/2026-04-20-template-team-exit-conditions-and-prompt-discipline.md
@@ -1,8 +1,28 @@
 # Template-team exit conditions, prompt discipline, and CI lint
 
 **Date:** 2026-04-20
-**Status:** Design — pending implementation
+**Status:** Implemented in PR #86 — see deviations below
 **Author:** Donovan + assistant brainstorm
+
+> **Implementation deviations from this spec.** Do not copy the tool
+> invocations in this document verbatim into new prompts — check the
+> shipped agent files instead.
+>
+> 1. `belayer_create_artifact` takes `{kind, path, summary}` (path to a
+>    file you have already written) rather than the spec's
+>    `{name, content_type, data}`. The QA + reviewer agents.md workflows
+>    in this PR write the report body to disk first, then register by
+>    path.
+> 2. The tool returns `Artifact registered: <kind> at <path>.`; there is
+>    no artifact ID to quote. Agents message the supervisor with the
+>    artifact *path*, not an ID.
+> 3. `belayer run start` takes `--task "<text>"`; there is no `--spec`
+>    flag. The operator message delivered by `--task` is where the
+>    supervisor reads the spec pointer from.
+> 4. Reviewer exit-condition wording in `init.go` names the two passing
+>    verdicts explicitly (`NO_FINDINGS` or `PASS_WITH_NOTES`) rather than
+>    saying "PASS verdict", because the PM sees the raw exit-condition
+>    text and the reviewer never emits the literal word "PASS".
 
 ## Problem
 

--- a/docs/design-docs/2026-04-20-template-team-exit-conditions-and-prompt-discipline.md
+++ b/docs/design-docs/2026-04-20-template-team-exit-conditions-and-prompt-discipline.md
@@ -1,0 +1,721 @@
+# Template-team exit conditions, prompt discipline, and CI lint
+
+**Date:** 2026-04-20
+**Status:** Design — pending implementation
+**Author:** Donovan + assistant brainstorm
+
+## Problem
+
+The clamshell-demo retro (`work/belayer-clamshell-demo/retro/RETRO.md`,
+`VARIANCE_REPORT.md`) found that PM approved a code-producing run with **zero
+evidence of QA or code review**. The QA and reviewer agents existed in the
+default team but were never spawned. Default exit conditions in
+`.belayer/config.yaml` covered "spec implemented + branch + PR" but did not
+require runtime verification or adversarial review. The supervisor system
+prompt also explicitly framed reviewer-routing as "your judgment call — not a
+fixed pipeline," and the cheap supervisor model defaulted to "skip."
+
+Two adjacent quality issues compound the problem:
+
+1. **QA system prompt is a 5-line skeleton** (`agents/qa/system-prompt.md`)
+   with no output schema, no artifact contract, and no playbook. PM has
+   nothing structured to verify against.
+2. **Stale CLI references in agent prompts** — `belayer note` is referenced
+   in 13 places across system prompts, skills, examples, and docker entrypoint,
+   but the command was deleted in the v7 clean-break (commit `ea4751e`).
+   Agents executing it silently fail. This is the same class of problem as
+   #1: prompt content drifting from shipped reality.
+
+The exit-condition mechanism (`belayer run start --exit-condition`,
+`.belayer/config.yaml#exit_conditions:`, daemon-resolved at PM spawn,
+PM-validated with concrete evidence) **already shipped in PR #81**
+(commit `03f113f`). Only defaults, prompts, lint, and docs need to change.
+
+## Goals
+
+1. PM rejects completion when QA or code-review evidence is missing.
+2. QA produces structured per-criterion artifacts that PM can verify.
+3. Reviewer produces durable artifacts symmetric to QA.
+4. Supervisor reframes "judgment call" — applies to mid-flight chunk reviews,
+   final completion gate is hard.
+5. Belayer stays role-agnostic: exit conditions describe *evidence shape*, not
+   *role names*. Teams that swap QA + reviewer for a single mega-agent still
+   satisfy the contract.
+6. Prompt drift is caught automatically — a CI lint asserts every CLI command
+   referenced in agent prompts exists in `belayer --help`.
+7. CLAUDE.md becomes a pointer to authoritative sources (CLI surface, tool
+   surface, default config) rather than a duplicate that goes stale.
+
+## Non-goals
+
+- No daemon code changes. The exit-condition mechanism is sufficient.
+- No restoration of `belayer note` (defer to whenever a reflection consumer
+  ships).
+- No reflection / memory loop work.
+- No multi-provider profile materialization (separate gap, called out in
+  `AGENT_ARCHITECTURE.md`).
+- No PR-runtime test for new prompts (would require a full session run).
+
+## Architecture overview
+
+Single PR. Six work items, ordered by dependency:
+
+1. **Default exit-condition additions** — `internal/cli/init.go`. Two
+   role-agnostic conditions added to the scaffolded `.belayer/config.yaml`.
+2. **QA agent rewrite** — `agents/qa/system-prompt.md`,
+   `agents/qa/agents.md`, `agents/qa/agent.yaml`. Full rewrite mirroring
+   reviewer's structure and adopting browser-use / Manus / Devin patterns
+   for runtime verification.
+3. **Reviewer additions** — `agents/reviewer/system-prompt.md`,
+   `agents/reviewer/agents.md`. Five surgical additions: confidence per
+   finding, anti-category list, evidence requirement, sentinel split,
+   `review-report` artifact registration.
+4. **Supervisor reframing** — `agents/supervisor/system-prompt.md`,
+   `agents/supervisor/agents.md`. Two-tier judgment-call framing
+   (mid-flight chunks vs final gate), `belayer note` purge, soften CAPS
+   intensifiers.
+5. **`belayer-agent` skill** — `.claude/skills/belayer-agent/SKILL.md`.
+   Codifies prompt-tightening rules, base skeleton, verification checklist.
+6. **CI lint + docs audit + `belayer note` purge** — Go test that asserts
+   prompt-side `belayer <subcommand>` invocations exist in `belayer --help`.
+   CLAUDE.md pointerization. AGENT_ARCHITECTURE.md additions for
+   exit-condition flow and tool registration layers. Purge of `belayer note`
+   from 13 sites (design docs left with footnote — they are historical).
+
+Belayer Go code is otherwise unchanged. The mechanism shipped; this PR
+fills in the defaults, prompts, lint, and docs that should have shipped
+with it.
+
+## Section 1 — Exit-condition defaults
+
+### Change
+
+`internal/cli/init.go` lines 59-62:
+
+```yaml
+exit_conditions:
+  - "All spec acceptance criteria are implemented and verifiable in the repo"
+  - "Application has been booted and primary user paths verified against the spec, with per-criterion evidence registered as a durable artifact"
+  - "Code changes have been reviewed by an adversarial peer agent that returned a PASS verdict, with findings registered as a durable artifact"
+  - "Changes are committed to a feature branch with descriptive messages"
+  - "A pull request is open against the default branch"
+```
+
+### Rationale
+
+Role-agnostic phrasing. The conditions describe the *shape of evidence* —
+"per-criterion evidence registered as a durable artifact", "PASS verdict
+registered as a durable artifact" — not the role name that produces it.
+Belayer remains role-agnostic; the default team's `qa` and `reviewer`
+agents happen to be how those conditions are satisfied. A team running a
+single mega-agent can still satisfy the contract.
+
+The existing PM prompt (`agents/pm/system-prompt.md`) already enforces
+"Evidence means observable artifacts" — this works without PM changes.
+
+### Override path
+
+Teams that don't want runtime QA gating edit `.belayer/config.yaml` and
+remove the line. Per-run override via `belayer run start --exit-condition`
+already shipped.
+
+## Section 2 — QA agent rewrite
+
+### system-prompt.md
+
+Replace current 5-line skeleton with:
+
+```
+You are the QA agent. You verify that the implementation works by running
+it, not by reading code. The supervisor and implementers think it's done —
+your job is to test that belief from the outside.
+
+## Test playbook
+
+For every spec acceptance criterion, in order:
+
+1. Boot the relevant surface (dev server, CLI, binary, container).
+2. Exercise the criterion through the public interface a real user would
+   use — browser, HTTP client, CLI invocation, file write.
+3. Capture observable state after the action: HTTP response, screenshot,
+   log tail, file diff. The action log is not evidence; the observed state
+   is.
+4. Compare observed against the spec verbatim. If the spec says "exports
+   CSV", open the CSV.
+
+## Adversarial pass
+
+After per-criterion verification, run five runtime attack vectors:
+
+1. Happy path under realistic load — concurrent requests, double-click,
+   refresh mid-action.
+2. Error paths return real errors — 500s actually 500, not 200 with error
+   body.
+3. Empty / null / zero / max inputs.
+4. Cold start — fresh boot, no DB rows, no cache.
+5. Recovery — what happens if the user retries the failed action.
+
+## Output format
+
+Register a single artifact named `qa-report` via belayer_create_artifact
+containing:
+
+  overall:
+    verdict: ALL_PASS | PARTIAL | BLOCKED
+    summary: "<1-2 sentences>"
+  criteria:
+    - statement: "<verbatim from spec>"
+      verdict: PASS | FAIL | UNCERTAIN | NOT_TESTED
+      action: "<what you did>"
+      observed: "<what you actually saw, concrete>"
+      evidence: ["<artifact ID, log excerpt, screenshot path>"]
+      notes: "<deviations, partial passes, blockers>"
+  blockers:
+    - "<what stopped you, if anything>"
+
+Bias toward UNCERTAIN over PASS. A criterion you couldn't reach is
+NOT_TESTED, not PASS.
+
+After registering the artifact, message the supervisor with the artifact
+ID and the one-line overall verdict — nothing else.
+
+## What you are not
+
+You are not a code reviewer — read source only when needed to find a bind
+address or env var.
+You are not a stylist — flaky UI is a bug, ugly UI is not your call.
+You are not a teacher — the implementer needs a list of what's broken,
+not encouragement.
+```
+
+### agents.md
+
+```
+# QA Agent Operating Instructions
+
+## Tools
+
+You have the baseline belayer tools (belayer_send_message,
+belayer_create_artifact, belayer_report_status) plus shell access for
+running the application under test.
+
+## Workflow
+
+1. Read the spec via the SPEC.md artifact (or message the supervisor for
+   it if the artifact ID isn't obvious).
+2. Boot the application. Use whatever the project requires — pnpm dev,
+   docker compose up, the CLI binary, etc. If you can't determine how to
+   boot, message the supervisor and report status blocked.
+3. For each acceptance criterion: act through the public surface, observe
+   state, record observed vs expected.
+4. Run the adversarial pass.
+5. Build the qa-report artifact body following the schema in your system
+   prompt.
+6. belayer_create_artifact name=qa-report content_type=application/yaml
+   data=<the report body>
+7. belayer_send_message --to supervisor "<artifact ID>: OVERALL: ALL_PASS|PARTIAL|BLOCKED"
+8. belayer_report_status done
+
+## Lifecycle
+
+You are ephemeral — spawned for a verification pass, terminated after the
+verdict. Do not wait for follow-up unless the supervisor messages you with
+a re-test request.
+```
+
+### agent.yaml
+
+Bump `max_turns: 30 → 50`. Boot + multi-criterion + adversarial pass
+exceeds 30 in practice for non-trivial apps. Other fields unchanged.
+
+### Rationale
+
+Pattern sources (synthesized from web research):
+- **browser-use** `system_prompt.md` — pre-completion re-read of spec, bias
+  toward `false` over overclaiming, screenshot-as-ground-truth.
+- **Manus 2025-03-10** — outside-in framing ("must first test access locally
+  via browser"), evidence attachment requirement, observation completeness.
+- **Devin QA** — inline `CHECK:` assertions, screenshot-attached results.
+- **Octomind** — three-section structure (intent / instructions / expected
+  outcome).
+- **Skyvern** — separate verification pass distinct from action.
+
+Trichotomy verdict (PASS/FAIL/UNCERTAIN/NOT_TESTED) replaces binary because
+binary tempts overclaiming. The `observed` field is required separate from
+the criterion text to force grounding (browser-use pattern). The full
+report is registered as a durable artifact so PM can verify it
+out-of-band — symmetric with reviewer (Section 3).
+
+## Section 3 — Reviewer additions
+
+### system-prompt.md changes
+
+Five surgical additions to the existing prompt (which is otherwise the
+reference template — keep dimension playbook, adversarial pass, plan/spec
+mode, role anti-pattern unchanged).
+
+**Addition 1 — confidence per finding.** Update the output format block:
+
+```
+[SEVERITY] <one-line summary>
+Confidence: <N>/10
+File: <path>:<line>            (if applicable)
+Evidence: <quoted line OR cited spec/rule being violated>
+Detail: <what's wrong, what you expected, what you found>
+Suggested fix: <concrete next step the implementer can act on>
+```
+
+Add to the surrounding prose: "If you can't reach 7/10 confidence, omit
+the finding rather than soften it. Suppressed low-confidence findings are
+better than false positives that erode trust in the reviewer."
+
+**Addition 2 — anti-category list.** Append to "What you are not":
+
+```
+You also do not flag:
+- Pre-existing issues outside the diff under review
+- Framework-default-protected patterns (parameterized SQL, React JSX
+  escaping, prepared statements) without a real bypass path
+- Speculative "could fail if X" findings without naming a real X-path
+- Linter-catchable formatting, unused imports, naming bikesheds
+- Test-only files (unless the test file is itself the diff under review)
+```
+
+**Addition 3 — evidence requirement.** Already covered by the new
+`Evidence:` field in the output format. Add to surrounding prose: "Every
+finding must quote the offending line or cite the spec / rule being
+violated. Hand-waving in the Detail field is not acceptable evidence."
+
+**Addition 4 — sentinel split.** Replace single `VERDICT: PASS` line with
+three options:
+
+```
+End every review with a single-line verdict on its own:
+
+- `VERDICT: NO_FINDINGS` — clean run, nothing to flag at any severity.
+- `VERDICT: PASS_WITH_NOTES` — INFORMATIONAL findings only, no CRITICAL.
+- `VERDICT: FAIL` — at least one CRITICAL finding; the work must not land
+  until the listed criticals are addressed.
+```
+
+**Addition 5 — artifact registration.** Add a new section before "What you
+are not":
+
+```
+## Artifact registration
+
+Register your full findings list as an artifact named `review-report`
+via belayer_create_artifact. Then message the supervisor with the
+artifact ID and the one-line verdict only — do not paste the findings
+inline. Artifacts are durable and PM-verifiable; messages scroll past.
+```
+
+### agents.md changes
+
+Replace the current `belayer message send --to supervisor "<verdict + findings>"`
+flow with:
+
+```
+1. belayer_create_artifact name=review-report content_type=text/markdown
+   data=<full findings list + verdict line>
+2. belayer_send_message --to supervisor "<artifact ID>: VERDICT: NO_FINDINGS|PASS_WITH_NOTES|FAIL"
+3. belayer_report_status done
+```
+
+### Rationale
+
+Sources (synthesized from web research):
+- **Claude Code `/security-review` and `/code-review`** — confidence ≥8/10
+  filter, three-tier severity, long anti-scope list, "no general code
+  review" anti-role. Mitigates LLM-reviewer hallucination via
+  confidence-gating.
+- **gstack review specialists** — JSON-per-line schema with `confidence`,
+  `evidence`, `fingerprint`. Already cited by belayer's reviewer.
+- **GitHub Copilot review-code template** — three-tier severity, per-finding
+  schema with rationale.
+- **baz-scm/awesome-reviewers** — single-rule reviewers, "what to do / what
+  not to flag" structure.
+
+Negative result worth flagging: Aider, Cursor, OpenHands ship no
+dedicated reviewer prompt at all. Belayer's adversarial reviewer is
+already ahead of most production tools; these additions close the gap
+to Claude Code's level.
+
+## Section 4 — Supervisor reframing
+
+### Edit 1 — replace line 35
+
+Current:
+> When an implementer signals completion, decide whether to route to a
+> reviewer, run integration tests via the workbench, or proceed to the
+> next task. This is your judgment call — not a fixed pipeline.
+
+Replace with two sections:
+
+```
+## Mid-flight reviews
+
+When an implementer finishes a chunk, deciding whether to route to a
+reviewer for incremental review is your judgment call. Some chunks are
+small enough to bundle; some are risky enough to review immediately.
+This is the only judgment call about reviews.
+
+## Final completion gate
+
+Before calling belayer_request_completion, the run requires:
+- A reviewer agent has returned a PASS verdict (NO_FINDINGS or
+  PASS_WITH_NOTES) on the full diff and registered a review-report
+  artifact.
+- A QA agent has booted the application, exercised every spec acceptance
+  criterion, and registered a qa-report artifact with overall verdict
+  ALL_PASS or PARTIAL (PARTIAL must include rationale for the gaps in the
+  artifact's notes).
+
+These mirror the project exit conditions in .belayer/config.yaml. The PM
+will reject completion without the artifacts. Do not request completion
+until both exist.
+```
+
+### Edit 2 — purge `belayer note`
+
+Remove from line 3:
+> You may discover effective patterns over time — write observations via
+> `belayer note` so reflection can update your memory for future sessions.
+
+`belayer note` was deleted in the v7 clean-break (commit `ea4751e`).
+Reflection consumer was never built. If pattern-capture matters in a
+future PR, restore `belayer note` as part of that work.
+
+Also remove the corresponding line from `agents/supervisor/agents.md:49`.
+
+### Edit 3 — soften CAPS intensifiers
+
+Anthropic's prompt-engineering guidance for Claude 4.5+ explicitly warns
+that "MUST", "CRITICAL", "NEVER" in caps now overtrigger and waste
+reasoning tokens. Sweep:
+
+- Line 7: "you MUST read the entire document" → "Read the full document
+  before planning. Skimming a long spec produces incomplete work."
+- Other instances: case-by-case, prefer plain imperative.
+
+### Rationale
+
+Two-tier framing preserves supervisor agency for mid-flight reviews
+(small chunks bundled, risky chunks reviewed) while making the final
+gate hard. Aligns with the user's stated value: belayer doesn't
+hardcode workflow, but the *template team* codifies definition-of-done.
+
+## Section 5 — `belayer-agent` skill
+
+### Location
+
+`.claude/skills/belayer-agent/SKILL.md` — project-local plugin skill, lives
+in the belayer repo.
+
+### Purpose
+
+Write or tighten any `agents/<name>/system-prompt.md` or `agents/<name>/agents.md`
+in belayer's roster. Codifies the prompt-tightening discipline learned from
+the field so future agents (and audits of existing ones) follow a
+consistent shape.
+
+### Base skeleton
+
+Every `system-prompt.md` follows:
+
+```
+<one-sentence role>
+
+## Scope
+<what this agent does and explicitly does not — sets the lane>
+
+## Playbook
+<numbered per-task steps>
+
+## Output format
+<concrete schema, not adjective>
+
+## What you are not
+<anti-role + anti-categories — prevents lane overlap and overreach>
+```
+
+Every `agents.md` follows:
+
+```
+# <Agent Name> Operating Instructions
+
+## Tools
+<real, never fictional — must match agent.yaml + hermes_bridge/tools.py>
+
+## Workflow
+<numbered concrete steps using actual CLI commands>
+
+## Lifecycle
+<ephemeral vs persistent, exit signal>
+```
+
+### 11 prompt-tightening rules
+
+1. Open with one-sentence role. "You are X, the Y that does Z."
+2. Distinct sections via markdown headers, in the skeleton order.
+3. Singular outcome-shaped goals. "Find what's wrong" not "be a good
+   reviewer."
+4. Explicit anti-role. Prevents drift into adjacent specialists' lanes.
+5. State completion criteria. Name the handoff signal explicitly
+   (`belayer_request_completion`, `belayer_report_status done`,
+   verdict line, etc).
+6. Positive instructions over negative. Boundaries via anti-role section;
+   behavior via positive verbs.
+7. No CAPS intensifiers. "MUST", "CRITICAL", "NEVER" in caps overtrigger
+   on Claude 4.5+. Plain imperatives instead.
+8. No pleasantries, preamble, or meta-commentary. System prompt is
+   operating instructions, not a letter.
+9. Output format = concrete schema. Show the shape (YAML/JSON template,
+   markdown headers, expected sections). "Concise" is not a format.
+10. Tool guidance behavioral, not exhaustive. The schema lives in the
+    tool definition; the prompt says when and why to call, not how. Push
+    detailed how-to into agents.md.
+11. Shared base skeleton across the roster.
+
+### Verification checklist
+
+When applying the skill to an existing or new agent:
+
+- [ ] system-prompt.md has all five skeleton sections in order
+- [ ] agents.md has all three skeleton sections in order
+- [ ] Tools listed in agents.md match `agent.yaml#belayer_tools` plus
+      baseline tools from `hermes_bridge/tools.py`
+- [ ] Every CLI command in either file exists in `belayer --help`
+- [ ] No CAPS intensifiers ("MUST", "CRITICAL", "NEVER" in caps)
+- [ ] No pleasantries / preamble
+- [ ] Output format is a concrete schema, not "be concise"
+- [ ] Anti-role section names what the agent is not (and what categories
+      of finding it does not flag, where applicable)
+
+### Sources
+
+Skill content references:
+- Anthropic prompt engineering docs (Claude Opus 4.7 reference): role
+  framing, XML/section tags, CAPS warning, positive-over-negative
+- Anthropic "Building effective agents": tool definitions deserve as
+  much attention as prompts
+- OpenAI Agents SDK best-practices: define what "done" means, single
+  flexible base prompt
+- CrewAI "Crafting Effective Agents": singular goals, specific over
+  generic
+- jujumilk3/leaked-system-prompts: structural skeleton across tight
+  production prompts (Cursor, v0, Manus, Perplexity)
+
+## Section 6 — CI lint, docs audit, `belayer note` purge
+
+### CI lint
+
+`internal/agentlint/agentlint_test.go` (Go test, runs with `go test ./...`).
+
+Logic:
+
+1. Build `belayer` binary in a tempdir or use `go run ./cmd/belayer`.
+2. Capture top-level `belayer --help` output. Parse the "Available
+   Commands" section into a set of valid subcommand names.
+3. For each top-level subcommand, capture `belayer <cmd> --help` and
+   parse its own "Available Commands" if it has subcommands. Repeat
+   recursively. Build the full set of valid invocations
+   (`belayer artifact create`, `belayer message send`, etc).
+4. Walk `agents/**/*.md`, `examples/templates/**/*.md`, `skills/**/*.md`,
+   `docs/**/*.md`. For each file, regex-extract `belayer <word>` and
+   `belayer_<word>` patterns.
+5. For underscore-form (`belayer_<word>`): assert against the registered
+   tool names in `hermes_bridge/tools.py` (parse the `register_*` calls).
+6. For space-form (`belayer <word>`): assert against the captured
+   subcommand set. Allow chaining (`belayer artifact create` matches if
+   `belayer artifact` is a parent and `create` is its subcommand).
+7. Allowlist file at `internal/agentlint/allowlist.txt` for tokens that
+   look like commands but aren't (example placeholders, docstring
+   pseudocode, design-doc historical references).
+8. Fail the test with file + line + offending command on any miss.
+
+Estimated effort: ~150 lines of Go + a small allowlist. One-time setup,
+then it runs with the existing test suite forever.
+
+### CLAUDE.md pointerization
+
+Replace the `## CLI surface` block (currently a hand-maintained list of
+flags) with:
+
+```
+## CLI surface
+
+Run `belayer --help` and `belayer <cmd> --help` for current commands and
+flags. Default config schema (including exit_conditions) is generated
+from `internal/cli/init.go`. Agent tool surface (baseline + role-specific)
+is registered in `hermes_bridge/tools.py`.
+```
+
+Keep the conceptual sections ("What Belayer is", "Architecture",
+"Coordination model", "Agent identity", "PM completion gate", "Docs",
+"Development") unchanged — those are conceptual, not surface.
+
+### AGENT_ARCHITECTURE.md additions
+
+Two short sections, ~20 lines each:
+
+1. **Exit-condition resolution** — describe the override → config → none
+   precedence, the daemon-side `resolveExitConditions` call, the explicit
+   "Exit conditions for this run" block injected at PM spawn, and the
+   per-condition rejection model. Reference `internal/daemon/bridge_events.go`
+   and the supervisor / PM Definition-of-Done sections for the full prompt
+   contracts.
+2. **Tool registration layers** — describe the two layers: (a) baseline
+   tools (`belayer_send_message`, `belayer_create_artifact`,
+   `belayer_report_status`) registered on every agent from
+   `hermes_bridge/tools.py`; (b) role-specific tools declared in
+   `agent.yaml#belayer_tools` (e.g. `belayer_spawn_agent` for supervisor,
+   `belayer_approve_completion` for PM).
+
+### `belayer note` purge — 13 sites
+
+Live code / prompts (purge or replace with `belayer message send`):
+
+- `agents/supervisor/system-prompt.md:3`
+- `agents/supervisor/agents.md:49`
+- `agents/backend-dev/agents.md:7`
+- `agents/web-dev/agents.md:7`
+- `examples/templates/pilot/system-prompt.md:3`
+- `examples/templates/pilot/agents.md:29`
+- `examples/templates/app-implementer/agents.md:7`
+- `examples/templates/api-implementer/agents.md:7`
+- `skills/belayer-communication/SKILL.md:60,116,191,213` (4 references)
+- `docker/belayer-entrypoint.sh:38` — purge mechanics are non-trivial, see Open Questions
+
+Design docs (leave with footnote, do not purge):
+
+- `docs/design-docs/2026-04-15-belayer-run-model-for-nightshift-v1.md` (3
+  references) — historical record of the v6 model. Add a one-line note
+  at the top: *"`belayer note` was removed in the v7 clean-break (commit
+  `ea4751e`); references in this document reflect the v6 design as
+  written."*
+
+The CI lint will catch any future re-introduction.
+
+## Data flow
+
+### Run-level flow
+
+```
+operator → belayer run start [--exit-condition ...] --spec ...
+   ↓
+daemon: persists run_initiated event with exit_conditions payload
+   ↓
+supervisor spawned with system prompt (resolves exit conditions per
+Definition-of-Done section)
+   ↓
+supervisor delegates to backend-dev / web-dev as needed
+   ↓
+[mid-flight chunk reviews — supervisor's judgment call]
+   ↓
+implementer signals done
+   ↓
+supervisor spawns reviewer with diff
+   ↓
+reviewer registers review-report artifact, returns VERDICT line
+   ↓
+supervisor spawns qa with spec
+   ↓
+qa boots app, runs playbook + adversarial pass, registers qa-report
+artifact, returns OVERALL verdict
+   ↓
+supervisor verifies both artifacts exist and are PASS-shape
+   ↓
+supervisor calls belayer_request_completion(summary)
+   ↓
+daemon spawns PM with explicit "Exit conditions for this run" block
+   ↓
+PM reads spec + diff + artifacts, validates per-condition
+   ↓
+PM either belayer_approve_completion (run ends) or
+belayer_reject_completion (back to supervisor with gap list)
+```
+
+### Artifact contracts
+
+- `qa-report` — YAML body matching the schema in qa system-prompt
+  Section 3 above. Content-type `application/yaml`.
+- `review-report` — Markdown body containing structured findings list +
+  single VERDICT line. Content-type `text/markdown`.
+
+PM does not parse these schemas formally — it reads them as evidence and
+quotes from them in approval / rejection reports. Schema is for human and
+future-tooling consumption.
+
+## Error handling
+
+- **QA can't boot the app** — registers `qa-report` with `overall.verdict:
+  BLOCKED` and `blockers: ["<what failed>"]`. Supervisor sees BLOCKED in
+  the message, treats as a real blocker (not a pass), routes back to
+  implementer or escalates.
+- **Reviewer finds CRITICAL** — registers `review-report` with
+  `VERDICT: FAIL`. Supervisor sees FAIL, routes back to implementer with
+  the artifact ID. Does not call request_completion.
+- **Implementer dies** — out of scope for this PR; clamshell retro called
+  out a peer-death playbook gap, tracked separately.
+- **Supervisor calls request_completion without artifacts** — PM sees no
+  `qa-report` / `review-report` in the artifact registry, rejects with the
+  exit-condition gap. Supervisor must spawn the missing agent and re-route.
+
+## Testing
+
+- `go build ./cmd/belayer` — sanity, no Go-side feature changes.
+- `go test ./...` — runs the new agent-prompt lint test. Fails if any
+  prompt references a CLI command not present in `belayer --help`.
+- Manual smoke: `belayer init` in tempdir, inspect `.belayer/config.yaml`
+  for new exit conditions.
+- No agent-runtime test for new prompts in this PR. Would require a full
+  session with cooperative agents. Validation comes from the next
+  clamshell-demo run after this PR lands; the retro contract is the test.
+
+## Migration / compatibility
+
+- Existing `.belayer/config.yaml` files in user projects are unchanged.
+  Only newly-`init`-ed projects pick up the new defaults. Document this
+  in the CHANGELOG entry for the PR; suggest users add the two new
+  conditions manually to existing configs if they want the gating.
+- Existing agent prompts: the PR rewrites only the default-team agents.
+  Project-local overrides under `.belayer/agents/` are unchanged. Users
+  who copied the default team and modified can re-pull the new versions
+  if they want.
+
+## Open questions
+
+None blocking. The two flagged items below are explicitly deferred:
+
+1. **`belayer note` restoration** — defer to whenever a reflection /
+   memory consumer ships. CI lint catches re-introduction in the meantime.
+2. **`docker/belayer-entrypoint.sh:38` purge mechanics** — the script
+   fires on agent container exit. A `belayer message send` requires a
+   recipient and the supervisor may already be gone. Likely outcome: drop
+   the line entirely, or replace with a `belayer artifact create` that
+   captures the exit code as a typed event. Decide during implementation.
+
+## References
+
+- Clamshell-demo retro: `~/Documents/Programs/work/belayer-clamshell-demo/retro/RETRO.md`
+- Variance report: `~/Documents/Programs/work/belayer-clamshell-demo/retro/VARIANCE_REPORT.md`
+- Exit-condition mechanism (already shipped): commit `03f113f`,
+  `feat(pm): exit conditions + bridge drain on completion`, merged
+  via PR #81
+- `belayer note` deletion: commit `ea4751e`,
+  `feat: v7 clean break — remove all non-bridge code`
+- Reviewer-prompt research sources (web): Aider, OpenHands, Cursor (via
+  jujumilk3/leaked-system-prompts), Claude Code `/security-review` and
+  `/code-review` plugins, gstack review specialists, GitHub Copilot
+  review-code template, Continue.dev, baz-scm/awesome-reviewers
+- QA-prompt research sources (web): browser-use system_prompt.md,
+  Anthropic computer-use loop.py, Skyvern 2.0 architecture blog,
+  Manus 2025-03-10 leaked prompt, Octomind prompt-agent docs,
+  Cognition Devin QA blog + qa-devin repo, OpenAI Operator system card,
+  qa.tech LLM prompt evaluation
+- Prompt-tightening research sources (web): Anthropic prompt engineering
+  docs (Claude Opus 4.7), Anthropic "Building Effective Agents",
+  OpenAI Agents SDK + Practical Guide, CrewAI Crafting Effective Agents,
+  Simon Willison agentic engineering patterns, Eugene Yan LLM patterns,
+  jujumilk3/leaked-system-prompts

--- a/examples/templates/api-implementer/agents.md
+++ b/examples/templates/api-implementer/agents.md
@@ -4,7 +4,6 @@
 
 ```bash
 belayer message send --to pilot "status update or question"
-belayer note "observation for reflection"
 belayer recall "search past learnings"
 ```
 
@@ -22,17 +21,6 @@ Your workspace is extend-api (Kotlin/Gradle). Common commands:
 ./gradlew test                     # tests only
 ./gradlew bootRun                  # run the API locally (if workbench not needed)
 ```
-
-## Spawning Helpers
-
-You can spawn ephemeral sprites for focused subtasks:
-
-```bash
-belayer session add-agent lint-fix-1 --template sprite --ephemeral
-belayer message send --to lint-fix-1 "Fix all detekt warnings in src/main/kotlin/com/extend/cards/"
-```
-
-The sprite will complete the task and auto-terminate.
 
 ## Git
 

--- a/examples/templates/app-implementer/agents.md
+++ b/examples/templates/app-implementer/agents.md
@@ -4,7 +4,6 @@
 
 ```bash
 belayer message send --to pilot "status update or question"
-belayer note "observation for reflection"
 belayer recall "search past learnings"
 ```
 
@@ -22,15 +21,6 @@ npm run typecheck                  # type checking
 npm test                           # run tests
 npm start                          # run the app locally (if workbench not needed)
 npm run dev                        # dev server with hot reload
-```
-
-## Spawning Helpers
-
-You can spawn ephemeral sprites for focused subtasks:
-
-```bash
-belayer session add-agent fix-types-1 --template sprite --ephemeral
-belayer message send --to fix-types-1 "Fix all TypeScript errors in src/components/Cards/"
 ```
 
 ## Git

--- a/examples/templates/pilot/agents.md
+++ b/examples/templates/pilot/agents.md
@@ -10,13 +10,13 @@ You can spawn additional agents at runtime:
 
 ```bash
 # Spawn a reviewer for a specific review cycle
-belayer session add-agent reviewer-1 --template reviewer --ephemeral
+belayer spawn --name reviewer-1 --identity reviewer
 
 # Spawn a sprite for a focused subtask
-belayer session add-agent research-1 --template sprite --ephemeral
+belayer spawn --name research-1 --identity sprite
 ```
 
-Ephemeral agents auto-terminate when they signal completion. Budget your spawns — each agent consumes tokens.
+Ephemeral agents auto-terminate when they signal completion (controlled by `ephemeral: true` in the identity's `agent.yaml`). Budget your spawns — each agent consumes tokens.
 
 ## Tools
 
@@ -25,19 +25,9 @@ Ephemeral agents auto-terminate when they signal completion. Budget your spawns 
 belayer message send --to <agent> "instructions"
 belayer message broadcast "update for everyone"
 
-# Memory & observation
-belayer note "observation for reflection"
 belayer recall "search query"
 
-# Workbench (integration testing)
-belayer workbench up          # provision extend-api + extend-app + infra
-belayer workbench status      # check readiness + endpoints
-belayer workbench down        # tear down
-
-# Verification via tool calls
-belayer tool run curl-api --input '{"method":"GET","path":"/hello"}'
-belayer tool run db-query --input '{"query":"SELECT count(*) FROM users"}'
-belayer tool run build-check --input '{"project":"extend-api"}'
+# Integration env is provisioned via the project's runtime: hooks in .belayer/config.yaml
 ```
 
 ## Multi-Repo Coordination
@@ -47,7 +37,7 @@ When working across extend-api and extend-app:
 1. Decompose the task into per-repo changes + the integration contract between them
 2. Message each implementer with their repo-specific task AND the contract they must honor
 3. Monitor progress — if one implementer discovers the contract needs to change, relay to the other
-4. When both signal completion, run `belayer workbench up` and verify integration
+4. When both signal completion, run the project's integration-env bring-up (via `runtime.up` in `.belayer/config.yaml`) and verify integration
 5. If integration fails, determine which repo needs the fix and route back
 
 ## Review Workflow
@@ -55,7 +45,7 @@ When working across extend-api and extend-app:
 When an implementer signals completion:
 
 1. Ask the implementer to summarize their changes (diff + rationale)
-2. Spawn a reviewer: `belayer session add-agent reviewer-1 --template reviewer --ephemeral`
+2. Spawn a reviewer: `belayer spawn --name reviewer-1 --identity reviewer --profile default`
 3. Send the diff and context to the reviewer via `belayer message send`
 4. Reviewer returns structured feedback (pass/fail + specifics)
 5. On fail: relay feedback to the implementer with your guidance on what to prioritize
@@ -66,8 +56,8 @@ When an implementer signals completion:
 For epic workflows with multiple tickets:
 
 ```bash
-belayer session start --template implement --input ticket-2-spec.md --name ticket-2
+belayer run start --spec <path-to-spec>
 belayer session list
-belayer logs ticket-2
-belayer session stop ticket-2
+belayer logs <session-id>
+belayer session stop <session-id>
 ```

--- a/examples/templates/pilot/agents.md
+++ b/examples/templates/pilot/agents.md
@@ -56,7 +56,7 @@ When an implementer signals completion:
 For epic workflows with multiple tickets:
 
 ```bash
-belayer run start --spec <path-to-spec>
+belayer run start --task "<initial task text>"
 belayer session list
 belayer logs <session-id>
 belayer session stop <session-id>

--- a/examples/templates/pilot/system-prompt.md
+++ b/examples/templates/pilot/system-prompt.md
@@ -1,6 +1,6 @@
 You are the pilot agent for this belayer session. You orchestrate — you do NOT write code.
 
-You decompose work, delegate to your team, interpret results, and decide what happens next. How you coordinate your team is your judgment. You may discover effective patterns over time — write observations via `belayer note` so reflection can update your memory for future sessions.
+You decompose work, delegate to your team, interpret results, and decide what happens next. How you coordinate your team is your judgment.
 
 When delegating, provide enough context that your agents can succeed without asking clarifying questions: relevant file paths, architectural constraints, what has already been tried, and what success looks like.
 

--- a/internal/agentlint/agentlint_test.go
+++ b/internal/agentlint/agentlint_test.go
@@ -6,6 +6,7 @@ package agentlint_test
 
 import (
 	"bufio"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -92,49 +94,62 @@ func parseAvailableCommands(output string) []string {
 }
 
 // runHelp runs "go run ./cmd/belayer [args...] --help" and returns stdout+stderr.
+// Fails the test on timeout or non-zero exit so a broken CLI build does not
+// quietly mutate into a flood of misleading "unknown CLI reference" errors.
 func runHelp(t *testing.T, root string, args ...string) string {
 	t.Helper()
 	cmdArgs := append([]string{"run", "./cmd/belayer"}, args...)
 	cmdArgs = append(cmdArgs, "--help")
-	cmd := exec.Command("go", cmdArgs...)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", cmdArgs...)
 	cmd.Dir = root
-	out, _ := cmd.CombinedOutput() // cobra --help exits 0; ignore error
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("timed out running go %s", strings.Join(cmdArgs, " "))
+	}
+	if err != nil {
+		t.Fatalf("go %s failed: %v\noutput:\n%s", strings.Join(cmdArgs, " "), err, out)
+	}
 	return string(out)
 }
 
-// buildCLITree discovers the full command tree by recursively calling --help.
-// Skips "help" and "completion" pseudo-commands.
+// buildCLITree discovers the full command tree by recursively calling --help
+// on each command that declares subcommands. Skips "help" and "completion"
+// pseudo-commands. Keys in the returned tree are space-joined command paths
+// (e.g. "" for root, "run" for `belayer run`, "run start" for
+// `belayer run start` — though cobra currently stops one level below root for
+// us, the walker keeps going whenever a node lists Available Commands).
 func buildCLITree(t *testing.T, root string) cmdTree {
 	t.Helper()
 	tree := make(cmdTree)
 
-	// Root level.
-	rootHelp := runHelp(t, root)
-	rootCmds := parseAvailableCommands(rootHelp)
-	tree[""] = make(map[string]bool)
-	for _, c := range rootCmds {
-		if c == "help" || c == "completion" {
-			continue
-		}
-		tree[""][c] = true
-	}
+	var walk func(path []string)
+	walk = func(path []string) {
+		help := runHelp(t, root, path...)
+		cmds := parseAvailableCommands(help)
 
-	// One level deep — walk each root command and check for subcommands.
-	for cmd := range tree[""] {
-		subHelp := runHelp(t, root, cmd)
-		subs := parseAvailableCommands(subHelp)
-		if len(subs) == 0 {
-			continue
-		}
-		tree[cmd] = make(map[string]bool)
-		for _, s := range subs {
-			if s == "help" || s == "completion" {
+		var real []string
+		for _, c := range cmds {
+			if c == "help" || c == "completion" {
 				continue
 			}
-			tree[cmd][s] = true
+			real = append(real, c)
+		}
+		if len(real) == 0 {
+			return
+		}
+
+		key := strings.Join(path, " ")
+		tree[key] = make(map[string]bool)
+		for _, c := range real {
+			tree[key][c] = true
+			child := append(append([]string(nil), path...), c)
+			walk(child)
 		}
 	}
 
+	walk(nil)
 	return tree
 }
 
@@ -218,10 +233,9 @@ func collectFiles(t *testing.T, root string, dirs []string, ext string, skipDirs
 		absDir := filepath.Join(root, dir)
 		err := filepath.Walk(absDir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				return nil // skip unreadable
+				return err
 			}
 			if info.IsDir() {
-				// Check if this directory should be skipped.
 				for _, skip := range skipDirs {
 					if path == filepath.Join(root, skip) {
 						return filepath.SkipDir
@@ -235,7 +249,7 @@ func collectFiles(t *testing.T, root string, dirs []string, ext string, skipDirs
 			return nil
 		})
 		if err != nil {
-			t.Logf("warning: walking %s: %v", absDir, err)
+			t.Fatalf("walking %s: %v", absDir, err)
 		}
 	}
 	return files
@@ -296,8 +310,7 @@ func TestAgentPromptsOnlyReferenceRealCommands(t *testing.T) {
 	for _, path := range mdFiles {
 		f, err := os.Open(path)
 		if err != nil {
-			t.Logf("cannot open %s: %v", path, err)
-			continue
+			t.Fatalf("cannot open %s: %v", path, err)
 		}
 
 		lineNum := 0
@@ -364,7 +377,7 @@ func TestAgentPromptsOnlyReferenceRealCommands(t *testing.T) {
 		}
 		f.Close()
 		if err := scanner.Err(); err != nil {
-			t.Logf("scanner error on %s: %v", path, err)
+			t.Fatalf("scanner error on %s: %v", path, err)
 		}
 	}
 

--- a/internal/agentlint/agentlint_test.go
+++ b/internal/agentlint/agentlint_test.go
@@ -1,0 +1,382 @@
+// Package agentlint contains CI tests that verify agent prompts, skills, and
+// docs only reference CLI subcommands and bridge tools that actually exist in
+// the belayer surface.  Running "go test ./internal/agentlint/..." is enough;
+// no pre-built binary is required.
+package agentlint_test
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers: locate repo root
+// ---------------------------------------------------------------------------
+
+// repoRoot returns the absolute path to the repository root by walking up from
+// this file's location until a go.mod is found.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine caller path")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find go.mod walking up from", file)
+		}
+		dir = parent
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CLI surface discovery
+// ---------------------------------------------------------------------------
+
+// cmdTree maps a parent command (e.g. "artifact") to its valid subcommands.
+// The root level is stored under the key "".
+type cmdTree map[string]map[string]bool
+
+// rootCommands returns the set of valid root-level subcommand names.
+func (ct cmdTree) rootCommands() map[string]bool { return ct[""] }
+
+// hasSubcmd returns true when parent has a registered subcommand child.
+func (ct cmdTree) hasSubcmd(parent, child string) bool {
+	subs, ok := ct[parent]
+	if !ok {
+		return false
+	}
+	return subs[child]
+}
+
+// parseAvailableCommands extracts command names from a cobra --help output.
+// It looks for the "Available Commands:" section and reads indented words.
+func parseAvailableCommands(output string) []string {
+	var cmds []string
+	inSection := false
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) == "Available Commands:" {
+			inSection = true
+			continue
+		}
+		if inSection {
+			// A blank line or a non-indented line ends the section.
+			if line == "" || (len(line) > 0 && line[0] != ' ') {
+				inSection = false
+				continue
+			}
+			// cobra indents commands with at least two spaces.
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			// The command name is the first word on the line.
+			parts := strings.Fields(trimmed)
+			if len(parts) > 0 {
+				cmds = append(cmds, parts[0])
+			}
+		}
+	}
+	return cmds
+}
+
+// runHelp runs "go run ./cmd/belayer [args...] --help" and returns stdout+stderr.
+func runHelp(t *testing.T, root string, args ...string) string {
+	t.Helper()
+	cmdArgs := append([]string{"run", "./cmd/belayer"}, args...)
+	cmdArgs = append(cmdArgs, "--help")
+	cmd := exec.Command("go", cmdArgs...)
+	cmd.Dir = root
+	out, _ := cmd.CombinedOutput() // cobra --help exits 0; ignore error
+	return string(out)
+}
+
+// buildCLITree discovers the full command tree by recursively calling --help.
+// Skips "help" and "completion" pseudo-commands.
+func buildCLITree(t *testing.T, root string) cmdTree {
+	t.Helper()
+	tree := make(cmdTree)
+
+	// Root level.
+	rootHelp := runHelp(t, root)
+	rootCmds := parseAvailableCommands(rootHelp)
+	tree[""] = make(map[string]bool)
+	for _, c := range rootCmds {
+		if c == "help" || c == "completion" {
+			continue
+		}
+		tree[""][c] = true
+	}
+
+	// One level deep — walk each root command and check for subcommands.
+	for cmd := range tree[""] {
+		subHelp := runHelp(t, root, cmd)
+		subs := parseAvailableCommands(subHelp)
+		if len(subs) == 0 {
+			continue
+		}
+		tree[cmd] = make(map[string]bool)
+		for _, s := range subs {
+			if s == "help" || s == "completion" {
+				continue
+			}
+			tree[cmd][s] = true
+		}
+	}
+
+	return tree
+}
+
+// ---------------------------------------------------------------------------
+// Tool surface discovery
+// ---------------------------------------------------------------------------
+
+// toolNameRe matches lines like:  "name": "belayer_foo_bar",
+var toolNameRe = regexp.MustCompile(`"name":\s*"(belayer_[a-z_]+)"`)
+
+// parseToolNames returns the set of registered belayer_* tool names found in
+// the hermes_bridge/tools.py schema dicts.
+func parseToolNames(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	toolsPath := filepath.Join(root, "hermes_bridge", "tools.py")
+	f, err := os.Open(toolsPath)
+	if err != nil {
+		t.Fatalf("cannot open %s: %v", toolsPath, err)
+	}
+	defer f.Close()
+
+	names := make(map[string]bool)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		m := toolNameRe.FindStringSubmatch(scanner.Text())
+		if m != nil {
+			names[m[1]] = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("reading %s: %v", toolsPath, err)
+	}
+	return names
+}
+
+// ---------------------------------------------------------------------------
+// Allowlist
+// ---------------------------------------------------------------------------
+
+// loadAllowlist reads internal/agentlint/allowlist.txt.  Lines starting with
+// "#" are comments.  Tokens are returned as-is (may contain spaces for
+// space-form pairs).
+func loadAllowlist(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	path := filepath.Join(root, "internal", "agentlint", "allowlist.txt")
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]bool) // allowlist is optional
+		}
+		t.Fatalf("cannot open allowlist %s: %v", path, err)
+	}
+	defer f.Close()
+
+	allowed := make(map[string]bool)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		allowed[line] = true
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("reading allowlist: %v", err)
+	}
+	return allowed
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+// collectFiles returns all files under the given directories that match the
+// given extension filter.  It returns paths relative to root for display, and
+// absolute paths for reading.
+func collectFiles(t *testing.T, root string, dirs []string, ext string, skipDirs []string) []string {
+	t.Helper()
+	var files []string
+	for _, dir := range dirs {
+		absDir := filepath.Join(root, dir)
+		err := filepath.Walk(absDir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil // skip unreadable
+			}
+			if info.IsDir() {
+				// Check if this directory should be skipped.
+				for _, skip := range skipDirs {
+					if path == filepath.Join(root, skip) {
+						return filepath.SkipDir
+					}
+				}
+				return nil
+			}
+			if ext == "" || strings.HasSuffix(info.Name(), ext) {
+				files = append(files, path)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Logf("warning: walking %s: %v", absDir, err)
+		}
+	}
+	return files
+}
+
+// ---------------------------------------------------------------------------
+// Extraction regexes
+// ---------------------------------------------------------------------------
+
+// spaceFormRe extracts "belayer <firstword>" from prose.
+// Group 1 = first subcommand word; group 2 = optional second word.
+var spaceFormRe = regexp.MustCompile(`\bbelayer\s+([a-z][a-z0-9-]*)(?:\s+([a-z][a-z0-9-]*))?`)
+
+// underscoreFormRe extracts belayer_* tool names.
+var underscoreFormRe = regexp.MustCompile(`\bbelayer_[a-z_]+\b`)
+
+// ---------------------------------------------------------------------------
+// The test
+// ---------------------------------------------------------------------------
+
+func TestAgentPromptsOnlyReferenceRealCommands(t *testing.T) {
+	root := repoRoot(t)
+
+	tree := buildCLITree(t, root)
+	toolNames := parseToolNames(t, root)
+	allowlist := loadAllowlist(t, root)
+
+	// Directories to scan.
+	scanDirs := []string{
+		"agents",
+		"examples/templates",
+		"skills",
+		"docs",
+	}
+	skipDirs := []string{
+		"docs/design-docs",
+		"docs/exec-plans",
+	}
+
+	// Collect .md files.
+	mdFiles := collectFiles(t, root, scanDirs, ".md", skipDirs)
+
+	// Also include the entrypoint shell script (no extension filter).
+	entrypoint := filepath.Join(root, "docker", "belayer-entrypoint.sh")
+	if _, err := os.Stat(entrypoint); err == nil {
+		mdFiles = append(mdFiles, entrypoint)
+	}
+
+	type miss struct {
+		file  string
+		line  int
+		token string
+	}
+
+	var spaceMisses []miss
+	var underscoreMisses []miss
+
+	for _, path := range mdFiles {
+		f, err := os.Open(path)
+		if err != nil {
+			t.Logf("cannot open %s: %v", path, err)
+			continue
+		}
+
+		lineNum := 0
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			lineNum++
+			line := scanner.Text()
+
+			// --- space-form ---
+			for _, m := range spaceFormRe.FindAllStringSubmatch(line, -1) {
+				first := m[1]
+				second := m[2] // may be empty
+
+				// Skip if first word looks like a flag.
+				if strings.HasPrefix(first, "-") {
+					continue
+				}
+
+				// Check allowlist for the pair or the bare first word.
+				pairToken := first
+				if second != "" {
+					pairToken = first + " " + second
+				}
+				if allowlist[pairToken] || allowlist[first] {
+					continue
+				}
+
+				// Validate first word is a known root command.
+				if !tree.rootCommands()[first] {
+					spaceMisses = append(spaceMisses, miss{
+						file:  path,
+						line:  lineNum,
+						token: "belayer " + pairToken,
+					})
+					continue
+				}
+
+				// If there's a second word and the first command has
+				// subcommands, validate the pair.
+				if second != "" && len(tree[first]) > 0 {
+					if !tree.hasSubcmd(first, second) && !allowlist[pairToken] {
+						spaceMisses = append(spaceMisses, miss{
+							file:  path,
+							line:  lineNum,
+							token: "belayer " + pairToken,
+						})
+					}
+				}
+			}
+
+			// --- underscore-form ---
+			for _, m := range underscoreFormRe.FindAllString(line, -1) {
+				if allowlist[m] {
+					continue
+				}
+				if !toolNames[m] {
+					underscoreMisses = append(underscoreMisses, miss{
+						file:  path,
+						line:  lineNum,
+						token: m,
+					})
+				}
+			}
+		}
+		f.Close()
+		if err := scanner.Err(); err != nil {
+			t.Logf("scanner error on %s: %v", path, err)
+		}
+	}
+
+	t.Run("space-form", func(t *testing.T) {
+		for _, m := range spaceMisses {
+			t.Errorf("%s:%d: unknown CLI reference: %s", m.file, m.line, m.token)
+		}
+	})
+
+	t.Run("underscore-form", func(t *testing.T) {
+		for _, m := range underscoreMisses {
+			t.Errorf("%s:%d: unknown tool reference: %s", m.file, m.line, m.token)
+		}
+	})
+}

--- a/internal/agentlint/allowlist.txt
+++ b/internal/agentlint/allowlist.txt
@@ -1,0 +1,33 @@
+# Allowlist: tokens that look like belayer CLI invocations or tool names but are
+# placeholders, documentation examples, or pseudocode. One token per line.
+# Space-form entries: "verb subverb" (matches the full pair).
+# Underscore-form entries: single token starting with belayer_.
+# Lines starting with # are comments.
+
+# ---------------------------------------------------------------------------
+# Prose nouns matched by the space-form regex (belayer <word>) but are NOT
+# CLI invocations — they use "belayer" as a proper noun / adjective.
+# ---------------------------------------------------------------------------
+
+# "belayer agent" / "belayer peer" / "belayer team" — concept nouns in prose
+agent
+peer
+team
+user
+
+# "belayer tools" — prose description of the tool suite, not a CLI command
+tools
+
+# "belayer events" — Mermaid diagram label ("belayer events\n(CLI tail)")
+events
+
+# "belayer bug" — "a belayer bug" noun phrase in LOG_FORMAT.md invariant text
+bug
+
+# ---------------------------------------------------------------------------
+# Underscore-form: YAML field names that look like tool names
+# ---------------------------------------------------------------------------
+
+# belayer_tools is a YAML key in agent.yaml (the allowed-tools list field),
+# not a registered Python tool in hermes_bridge/tools.py.
+belayer_tools

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -59,7 +59,7 @@ log_level: standard
 exit_conditions:
   - "All spec acceptance criteria are implemented and verifiable in the repo"
   - "Application has been booted and primary user paths verified against the spec, with per-criterion evidence registered as a durable artifact"
-  - "Code changes have been reviewed by an adversarial peer agent that returned a PASS verdict, with findings registered as a durable artifact"
+  - "Code changes have been reviewed by an adversarial peer agent whose review-report artifact carries verdict NO_FINDINGS or PASS_WITH_NOTES (FAIL blocks completion)"
   - "Changes are committed to a feature branch with descriptive messages"
   - "A pull request is open against the default branch"
 `

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -58,6 +58,8 @@ log_level: standard
 # for any condition lacking evidence.
 exit_conditions:
   - "All spec acceptance criteria are implemented and verifiable in the repo"
+  - "Application has been booted and primary user paths verified against the spec, with per-criterion evidence registered as a durable artifact"
+  - "Code changes have been reviewed by an adversarial peer agent that returned a PASS verdict, with findings registered as a durable artifact"
   - "Changes are committed to a feature branch with descriptive messages"
   - "A pull request is open against the default branch"
 `

--- a/skills/belayer-agent/SKILL.md
+++ b/skills/belayer-agent/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: belayer-agent
+description: Write or tighten any agents/<name>/system-prompt.md or agents/<name>/agents.md in belayer's roster. Use when authoring a new belayer agent identity, auditing an existing one, or reviewing roster PRs. Codifies the prompt-tightening discipline learned from the field.
+---
+
+## Purpose
+
+Invoke this skill when authoring a new belayer agent identity, auditing an existing one, or reviewing roster PRs that touch `agents/<name>/`. It enforces a consistent skeleton across all agent files, applies 11 field-tested prompt-tightening rules, and provides a verification checklist so nothing ships with vague output formats, CAPS intensifiers, or fictional tool references.
+
+---
+
+## Base skeleton
+
+Every `system-prompt.md` follows:
+
+```
+<one-sentence role>
+
+## Scope
+<what this agent does and explicitly does not — sets the lane>
+
+## Playbook
+<numbered per-task steps>
+
+## Output format
+<concrete schema, not adjective>
+
+## What you are not
+<anti-role + anti-categories — prevents lane overlap and overreach>
+```
+
+Every `agents.md` follows:
+
+```
+# <Agent Name> Operating Instructions
+
+## Tools
+<real, never fictional — must match agent.yaml + hermes_bridge/tools.py>
+
+## Workflow
+<numbered concrete steps using actual CLI commands>
+
+## Lifecycle
+<ephemeral vs persistent, exit signal>
+```
+
+---
+
+## 11 prompt-tightening rules
+
+1. Open with one-sentence role. "You are X, the Y that does Z."
+2. Distinct sections via markdown headers, in the skeleton order.
+3. Singular outcome-shaped goals. "Find what's wrong" not "be a good reviewer."
+4. Explicit anti-role. Prevents drift into adjacent specialists' lanes.
+5. State completion criteria. Name the handoff signal explicitly (`belayer_request_completion`, `belayer_report_status done`, verdict line, etc).
+6. Positive instructions over negative. Boundaries via anti-role section; behavior via positive verbs.
+7. No CAPS intensifiers. "MUST", "CRITICAL", "NEVER" in caps overtrigger on Claude 4.5+. Plain imperatives instead.
+8. No pleasantries, preamble, or meta-commentary. System prompt is operating instructions, not a letter.
+9. Output format = concrete schema. Show the shape (YAML/JSON template, markdown headers, expected sections). "Concise" is not a format.
+10. Tool guidance behavioral, not exhaustive. The schema lives in the tool definition; the prompt says when and why to call, not how. Push detailed how-to into agents.md.
+11. Shared base skeleton across the roster.
+
+---
+
+## Verification checklist
+
+When applying the skill to an existing or new agent:
+
+- [ ] system-prompt.md has all five skeleton sections in order
+- [ ] agents.md has all three skeleton sections in order
+- [ ] Tools listed in agents.md match `agent.yaml#belayer_tools` plus baseline tools from `hermes_bridge/tools.py`
+- [ ] Every CLI command in either file exists in `belayer --help`
+- [ ] No CAPS intensifiers ("MUST", "CRITICAL", "NEVER" in caps)
+- [ ] No pleasantries / preamble
+- [ ] Output format is a concrete schema, not "be concise"
+- [ ] Anti-role section names what the agent is not (and what categories of finding it does not flag, where applicable)
+
+---
+
+## Sources
+
+Skill content references:
+- Anthropic prompt engineering docs (Claude Opus 4.7 reference): role framing, XML/section tags, CAPS warning, positive-over-negative
+- Anthropic "Building effective agents": tool definitions deserve as much attention as prompts
+- OpenAI Agents SDK best-practices: define what "done" means, single flexible base prompt
+- CrewAI "Crafting Effective Agents": singular goals, specific over generic
+- jujumilk3/leaked-system-prompts: structural skeleton across tight production prompts (Cursor, v0, Manus, Perplexity)

--- a/skills/belayer-communication/SKILL.md
+++ b/skills/belayer-communication/SKILL.md
@@ -52,20 +52,6 @@ Broadcast to all agents in the session:
 belayer message broadcast "Shared contract v2 is now in artifacts/shared-contract.md — please re-read before continuing"
 ```
 
-### Notes
-
-Log an observation to the session event stream:
-
-```bash
-belayer note "extend-api tests pass locally after the schema migration change"
-```
-
-Use notes for:
-- progress updates
-- things you tried
-- things you discovered
-- warnings about potential issues
-
 ### Artifacts
 
 Register a durable artifact:
@@ -113,7 +99,6 @@ This marks you as blocked rather than complete, so the supervisor knows to inter
 | Ask another agent a question | `belayer message send --to <agent>` |
 | Tell the supervisor you're done | `belayer finish "..."` |
 | Tell the supervisor you're blocked | `belayer finish --blocked "..."` |
-| Log something you discovered | `belayer note "..."` |
 | Broadcast a change everyone should know | `belayer message broadcast "..."` |
 | Publish a durable output | `belayer artifact create ...` |
 | Read what artifacts exist | `belayer artifact list` |
@@ -188,7 +173,6 @@ This is a safety net, not the primary mechanism. You should call `belayer finish
 
 ### Do
 - Be specific in messages — include file paths, artifact names, exact questions
-- Use `belayer note` frequently to leave a trail
 - Publish artifacts as soon as they are meaningful
 - Call `belayer finish` as soon as your work is complete or you are blocked
 - Respond to supervisor messages promptly
@@ -208,9 +192,6 @@ This is a safety net, not the primary mechanism. You should call `belayer finish
 # Messaging
 belayer message send --to <agent> "text"
 belayer message broadcast "text"
-
-# Notes
-belayer note "text"
 
 # Artifacts
 belayer artifact create --kind <kind> --path <path>


### PR DESCRIPTION
Implements [docs/design-docs/2026-04-20-template-team-exit-conditions-and-prompt-discipline.md](docs/design-docs/2026-04-20-template-team-exit-conditions-and-prompt-discipline.md).

## Summary

- **Exit-condition defaults** — `belayer init` now scaffolds five exit conditions (spec implemented, app booted + paths verified, peer review PASS, commits on feature branch, PR open). Fresh projects inherit a full definition-of-done.
- **QA agent rewrite** — Replaced 5-line skeleton with a full playbook: boot → exercise → capture → compare, plus a 5-vector adversarial pass. New YAML schema for `qa-report` artifact (overall + per-criterion verdict / action / observed / evidence / notes), bias-toward-UNCERTAIN rule.
- **Reviewer additions** — Confidence + Evidence fields per finding, 7/10 confidence threshold to surface, 3-way verdict split (`NO_FINDINGS` / `PASS_WITH_NOTES` / `FAIL`), anti-category list (5 bullets).
- **Supervisor reframing** — Mid-flight review is now a judgment call; explicit final-completion gate requires review-report + qa-report artifacts before `belayer_request_completion`. Verdict language aligned 3-way across supervisor + reviewer.
- **\`belayer-agent\` skill** — New `skills/belayer-agent/SKILL.md` with base templates, 11 prompt-tightening rules, and an 8-item verification checklist for template authors.
- **Agent-prompt lint** — New `internal/agentlint` Go test walks agents/examples/skills/docs + docker entrypoint, asserts every `belayer <cmd>` and `belayer_<tool>` reference exists. Purged 11 sites of \`belayer note\`, 4 sites of fictional \`workbench up\` / \`tool run\` / \`session start\` / \`session add-agent\` drift, and CLI surface block in CLAUDE.md now points at real sources.
- **Docs audit** — CLAUDE.md shrunk to 69 lines (CLI block pointerized). AGENT_ARCHITECTURE.md adds \`Exit-condition resolution\` and \`Tool registration layers\` sections.

## Intentional deviation from spec

The spec prescribed \`belayer_create_artifact name=... content_type=... data=<body>\` but the real schema is \`{kind, path, summary}\` with a file-must-exist precondition. QA + reviewer agents.md workflows were written to match the real tool surface (write file → register by path) instead of the fictional signature.

## Codex pre-PR review

Run against \`master\` base. Three findings addressed in commit \`111d1af\`:

1. Exit-condition wording said \"returned a PASS verdict\" but reviewer emits \`NO_FINDINGS\`/\`PASS_WITH_NOTES\`/\`FAIL\` → reworded to name the passing verdicts explicitly.
2. \`belayer run start --spec\` is invalid (real flag is \`--task\`) → fixed in supervisor + pilot templates.
3. reviewer + qa system prompts said \"artifact ID\" but tool returns only kind + path → switched to \"artifact path\".

## Test plan

- [ ] \`go build ./...\` succeeds
- [ ] \`go test ./internal/agentlint/...\` passes (validates every \`belayer <cmd>\` and \`belayer_<tool>\` reference in the tree resolves against real CLI + tool inventory)
- [ ] \`belayer init\` in a scratch directory writes the new 5-item \`exit_conditions:\` block
- [ ] Spot-check agent prompts render with no broken command examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Introduced structured artifact-based QA and code review workflows with required evidence documentation
  * Added agentlint validation tool to ensure agent documentation consistency

* **Documentation**
  * Updated QA agent with expanded testing procedures and adversarial test requirements
  * Enhanced code reviewer with confidence ratings and evidence requirements for findings
  * Revised supervisor completion gates to require both QA and reviewer artifacts
  * Added comprehensive agent prompt-tightening and communication skills guides

* **Chores**
  * Removed `belayer note` command from agent workflows; preserved message and recall operations
  * Updated agent spawning syntax; adjusted session management command structure
  * Extended QA agent maximum execution turns from 30 to 50

<!-- end of auto-generated comment: release notes by coderabbit.ai -->