### PR TITLE
fix(bridge): drop empty messages before model dispatch

### DIFF
--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -92,12 +92,27 @@ def fetch_roster(socket_path: str, session_id: str) -> list[dict] | None:
     return data
 
 
+def _msg_field(msg: dict, *keys: str) -> str:
+    """Return the first non-empty string value found among the given keys.
+
+    The daemon serialises store.Message without json struct tags, so field
+    names arrive as PascalCase (Content, SenderID, ID).  Some call sites may
+    also pass snake_case dicts (e.g. test fixtures or future tagged versions).
+    Checking both casings here keeps the bridge tolerant of either shape.
+    """
+    for key in keys:
+        val = msg.get(key)
+        if val is not None and val != "":
+            return str(val)
+    return ""
+
+
 def format_messages(messages: list[dict]) -> str:
     """Format a list of pending message dicts into a single user-turn string."""
     parts = []
     for msg in messages:
-        sender = msg.get("sender_id", "unknown")
-        content = msg.get("content", "")
+        sender = _msg_field(msg, "SenderID", "sender_id") or "unknown"
+        content = _msg_field(msg, "Content", "content")
         parts.append(f"[Message from {sender}]: {content}")
     return "\n\n".join(parts)
 
@@ -108,15 +123,15 @@ def filter_and_format_messages(
     session_id: str,
     agent_id: str,
 ) -> str:
-    """Drop empty-content messages (post bridge:warning for each), format rest."""
+    """Drop empty-content messages, post one batched bridge:warning if any are dropped, and format the rest."""
     valid = []
     dropped = []
     for msg in messages:
-        content = msg.get("content", "") or ""
+        content = _msg_field(msg, "Content", "content")
         if not content.strip():
             dropped.append({
-                "sender": msg.get("sender_id") or "unknown",
-                "message_id": msg.get("id") or "",
+                "sender": _msg_field(msg, "SenderID", "sender_id") or "unknown",
+                "message_id": _msg_field(msg, "ID", "id"),
             })
             continue
         valid.append(msg)
@@ -411,8 +426,11 @@ def main() -> None:
     pending = fetch_pending_messages(socket_path, session_id, agent_id)
     if pending:
         queued = filter_and_format_messages(pending, socket_path, session_id, agent_id)
-        user_message = f"{user_message}\n\n{queued}"
-        log.info("Prepended %d pre-queued message(s) to initial turn", len(pending))
+        if queued:
+            user_message = f"{user_message}\n\n{queued}"
+            valid_count = queued.count("\n\n") + 1
+            log.info("Prepended %d valid pre-queued message(s) to initial turn (%d total fetched)",
+                     valid_count, len(pending))
 
     while True:
         try:
@@ -438,10 +456,20 @@ def main() -> None:
             try:
                 interrupt_msg = stdin_queue.get_nowait()
                 sender = interrupt_msg.get("from", "system")
-                content = interrupt_msg.get("content", "")
-                user_message = f"[Urgent from {sender}]: {content}"
-                log.info("Continuing after interrupt from %s", sender)
-                continue
+                content = interrupt_msg.get("content", "") or ""
+                if not content.strip():
+                    post_event(
+                        socket_path, session_id, agent_id,
+                        "bridge:warning",
+                        {"kind": "empty_message_dropped", "count": 1,
+                         "dropped": [{"sender": sender, "message_id": ""}]},
+                    )
+                    log.warning("Dropped empty interrupt message from %s", sender)
+                    # Treat as no interrupt — fall through to terminal state checks.
+                else:
+                    user_message = f"[Urgent from {sender}]: {content}"
+                    log.info("Continuing after interrupt from %s", sender)
+                    continue
             except queue.Empty:
                 # Interrupted but no pending stdin command — treat as stop.
                 log.info("Interrupted with no queued message; treating as stop")
@@ -455,9 +483,15 @@ def main() -> None:
         # --- Check for non-urgent messages from other agents ---------------
         pending = fetch_pending_messages(socket_path, session_id, agent_id)
         if pending:
-            user_message = filter_and_format_messages(pending, socket_path, session_id, agent_id)
-            log.info("Continuing with %d pending message(s)", len(pending))
-            continue
+            formatted = filter_and_format_messages(pending, socket_path, session_id, agent_id)
+            if not formatted:
+                # All pending messages were empty-content; do not invoke model.
+                log.info("Skipping turn: all %d pending message(s) had empty content", len(pending))
+            else:
+                user_message = formatted
+                log.info("Continuing with %d valid pending message(s) (%d total fetched)",
+                         formatted.count("\n\n") + 1 if formatted else 0, len(pending))
+                continue
 
         # --- Terminal states -----------------------------------------------
         if result.get("failed"):
@@ -539,14 +573,21 @@ def main() -> None:
                 # Poll for pending messages.
                 pending = fetch_pending_messages(socket_path, session_id, agent_id)
                 if pending:
-                    user_message = (
-                        "[System] You have been idle waiting for specialist agents. "
-                        "One or more have reported in. Process their updates and continue "
-                        "coordinating the session (verify work, merge branches, spawn next agents, create PRs, etc.).\n\n"
-                        + filter_and_format_messages(pending, socket_path, session_id, agent_id)
-                    )
-                    log.info("Resuming from idle with %d pending message(s)", len(pending))
-                    break
+                    formatted = filter_and_format_messages(pending, socket_path, session_id, agent_id)
+                    if not formatted:
+                        log.info("Idle poll: all %d pending message(s) had empty content; continuing to wait",
+                                 len(pending))
+                    else:
+                        valid_count = formatted.count("\n\n") + 1
+                        user_message = (
+                            "[System] You have been idle waiting for specialist agents. "
+                            "One or more have reported in. Process their updates and continue "
+                            "coordinating the session (verify work, merge branches, spawn next agents, create PRs, etc.).\n\n"
+                            + formatted
+                        )
+                        log.info("Resuming from idle with %d valid pending message(s) (%d total fetched)",
+                                 valid_count, len(pending))
+                        break
 
                 # Peer-awareness: only advance the idle counter when all peer
                 # agents are in a terminal state. While any peer is still

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -102,6 +102,34 @@ def format_messages(messages: list[dict]) -> str:
     return "\n\n".join(parts)
 
 
+def filter_and_format_messages(
+    messages: list[dict],
+    socket_path: str,
+    session_id: str,
+    agent_id: str,
+) -> str:
+    """Drop empty-content messages (post bridge:warning for each), format rest."""
+    valid = []
+    dropped = []
+    for msg in messages:
+        content = msg.get("content", "") or ""
+        if not content.strip():
+            dropped.append({
+                "sender": msg.get("sender_id") or "unknown",
+                "message_id": msg.get("id") or "",
+            })
+            continue
+        valid.append(msg)
+    if dropped:
+        post_event(
+            socket_path, session_id, agent_id,
+            "bridge:warning",
+            {"kind": "empty_message_dropped", "count": len(dropped), "dropped": dropped},
+        )
+        log.warning("Dropped %d empty message(s): %s", len(dropped), dropped)
+    return format_messages(valid)
+
+
 def extract_turn_usage(result: dict) -> dict:
     """Extract token usage fields from a run_conversation() result dict."""
     fields = (
@@ -382,7 +410,7 @@ def main() -> None:
     # Check for messages that were queued before this agent was spawned.
     pending = fetch_pending_messages(socket_path, session_id, agent_id)
     if pending:
-        queued = format_messages(pending)
+        queued = filter_and_format_messages(pending, socket_path, session_id, agent_id)
         user_message = f"{user_message}\n\n{queued}"
         log.info("Prepended %d pre-queued message(s) to initial turn", len(pending))
 
@@ -427,7 +455,7 @@ def main() -> None:
         # --- Check for non-urgent messages from other agents ---------------
         pending = fetch_pending_messages(socket_path, session_id, agent_id)
         if pending:
-            user_message = format_messages(pending)
+            user_message = filter_and_format_messages(pending, socket_path, session_id, agent_id)
             log.info("Continuing with %d pending message(s)", len(pending))
             continue
 
@@ -488,7 +516,16 @@ def main() -> None:
                         )
                         break
                     sender = interrupt_msg.get("from", "system")
-                    content = interrupt_msg.get("content", "")
+                    content = interrupt_msg.get("content", "") or ""
+                    if not content.strip():
+                        post_event(
+                            socket_path, session_id, agent_id,
+                            "bridge:warning",
+                            {"kind": "empty_message_dropped", "count": 1,
+                             "dropped": [{"sender": sender, "message_id": ""}]},
+                        )
+                        log.warning("Dropped empty idle-interrupt message from %s", sender)
+                        continue
                     user_message = (
                         "[System] You have been idle. An urgent message arrived. "
                         "Process it and continue coordinating.\n\n"
@@ -506,7 +543,7 @@ def main() -> None:
                         "[System] You have been idle waiting for specialist agents. "
                         "One or more have reported in. Process their updates and continue "
                         "coordinating the session (verify work, merge branches, spawn next agents, create PRs, etc.).\n\n"
-                        + format_messages(pending)
+                        + filter_and_format_messages(pending, socket_path, session_id, agent_id)
                     )
                     log.info("Resuming from idle with %d pending message(s)", len(pending))
                     break

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -329,6 +329,11 @@ func TestSendRejectsEmptyContent(t *testing.T) {
 		})
 	}
 
+	// Nothing should have been delivered to the subscriber.
+	if col.count() != 0 {
+		t.Errorf("expected 0 delivered messages after empty-content sends, got %d", col.count())
+	}
+
 	// Valid content must still succeed.
 	msg := Message{SessionID: "sess1", SenderID: "sender", Type: MessageInstruction, Content: "hello", Urgent: true}
 	if err := b.Send("sess1", "agent1", msg); err != nil {
@@ -358,6 +363,11 @@ func TestBroadcastRejectsEmptyContent(t *testing.T) {
 		})
 	}
 
+	// Nothing should have been delivered to the subscriber.
+	if col.count() != 0 {
+		t.Errorf("expected 0 delivered messages after empty-content broadcasts, got %d", col.count())
+	}
+
 	// Valid content must still succeed.
 	msg := Message{SessionID: "sess1", SenderID: "sender2", Type: MessageStateChange, Content: "state-update"}
 	if err := b.Broadcast("sess1", msg); err != nil {
@@ -385,6 +395,11 @@ func TestInterruptRejectsEmptyContent(t *testing.T) {
 				t.Fatalf("expected error for content %q, got nil", tc.content)
 			}
 		})
+	}
+
+	// Nothing should have been delivered to the subscriber.
+	if col.count() != 0 {
+		t.Errorf("expected 0 delivered messages after empty-content interrupts, got %d", col.count())
 	}
 
 	// Valid content must still succeed.

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -306,6 +306,94 @@ func TestMessageHistoryLoggedToStore(t *testing.T) {
 	}
 }
 
+func TestSendRejectsEmptyContent(t *testing.T) {
+	b := newTestBroker()
+	col := &collector{}
+	_ = b.Subscribe("sess1", "agent1", col.handler())
+
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"empty string", ""},
+		{"whitespace only", "   "},
+		{"tab only", "\t"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := Message{SessionID: "sess1", SenderID: "sender", Type: MessageInstruction, Content: tc.content}
+			err := b.Send("sess1", "agent1", msg)
+			if err == nil {
+				t.Fatalf("expected error for content %q, got nil", tc.content)
+			}
+		})
+	}
+
+	// Valid content must still succeed.
+	msg := Message{SessionID: "sess1", SenderID: "sender", Type: MessageInstruction, Content: "hello", Urgent: true}
+	if err := b.Send("sess1", "agent1", msg); err != nil {
+		t.Fatalf("expected no error for valid content, got: %v", err)
+	}
+}
+
+func TestBroadcastRejectsEmptyContent(t *testing.T) {
+	b := newTestBroker()
+	col := &collector{}
+	_ = b.Subscribe("sess1", "agent1", col.handler())
+
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"empty string", ""},
+		{"whitespace only", "   "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := Message{SessionID: "sess1", SenderID: "sender2", Type: MessageStateChange, Content: tc.content}
+			err := b.Broadcast("sess1", msg)
+			if err == nil {
+				t.Fatalf("expected error for content %q, got nil", tc.content)
+			}
+		})
+	}
+
+	// Valid content must still succeed.
+	msg := Message{SessionID: "sess1", SenderID: "sender2", Type: MessageStateChange, Content: "state-update"}
+	if err := b.Broadcast("sess1", msg); err != nil {
+		t.Fatalf("expected no error for valid content, got: %v", err)
+	}
+}
+
+func TestInterruptRejectsEmptyContent(t *testing.T) {
+	b := newTestBroker()
+	col := &collector{}
+	_ = b.Subscribe("sess1", "agent1", col.handler())
+
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"empty string", ""},
+		{"whitespace only", "   "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := Message{SessionID: "sess1", SenderID: "sender", Type: MessageInstruction, Content: tc.content}
+			err := b.Interrupt("sess1", "agent1", msg)
+			if err == nil {
+				t.Fatalf("expected error for content %q, got nil", tc.content)
+			}
+		})
+	}
+
+	// Valid content must still succeed.
+	msg := Message{SessionID: "sess1", SenderID: "sender", Type: MessageInstruction, Content: "interrupt!"}
+	if err := b.Interrupt("sess1", "agent1", msg); err != nil {
+		t.Fatalf("expected no error for valid content, got: %v", err)
+	}
+}
+
 func TestConcurrentSendIsSafe(t *testing.T) {
 	b := newTestBroker()
 	var delivered int64

--- a/internal/broker/memory.go
+++ b/internal/broker/memory.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -84,6 +85,9 @@ func (b *MemoryBroker) Send(sessionID, agentID string, msg Message) error {
 	if msg.Timestamp.IsZero() {
 		msg.Timestamp = time.Now().UTC()
 	}
+	if strings.TrimSpace(msg.Content) == "" {
+		return fmt.Errorf("broker: refusing to send message with empty content (sender=%q recipient=%q)", msg.SenderID, agentID)
+	}
 
 	handler := b.lookupHandler(sessionID, agentID)
 	if handler == nil {
@@ -140,6 +144,9 @@ func (b *MemoryBroker) Broadcast(sessionID string, msg Message) error {
 	if msg.Timestamp.IsZero() {
 		msg.Timestamp = time.Now().UTC()
 	}
+	if strings.TrimSpace(msg.Content) == "" {
+		return fmt.Errorf("broker: refusing to broadcast message with empty content (sender=%q recipient=%q)", msg.SenderID, "<broadcast>")
+	}
 
 	b.mu.RLock()
 	agents := b.subscribers[sessionID]
@@ -170,6 +177,9 @@ func (b *MemoryBroker) Interrupt(sessionID, agentID string, msg Message) error {
 	}
 	if msg.Timestamp.IsZero() {
 		msg.Timestamp = time.Now().UTC()
+	}
+	if strings.TrimSpace(msg.Content) == "" {
+		return fmt.Errorf("broker: refusing to interrupt with empty content (sender=%q recipient=%q)", msg.SenderID, agentID)
 	}
 
 	handler := b.lookupHandler(sessionID, agentID)

--- a/internal/broker/memory.go
+++ b/internal/broker/memory.go
@@ -79,14 +79,14 @@ func (b *MemoryBroker) Unsubscribe(sessionID, agentID string) error {
 // Send delivers msg to a specific agent. Non-urgent messages are debounced;
 // urgent messages flush the buffer and deliver immediately.
 func (b *MemoryBroker) Send(sessionID, agentID string, msg Message) error {
+	if strings.TrimSpace(msg.Content) == "" {
+		return fmt.Errorf("broker: refusing to send message with empty content (sender=%q recipient=%q)", msg.SenderID, agentID)
+	}
 	if msg.ID == "" {
 		msg.ID = uuid.New().String()
 	}
 	if msg.Timestamp.IsZero() {
 		msg.Timestamp = time.Now().UTC()
-	}
-	if strings.TrimSpace(msg.Content) == "" {
-		return fmt.Errorf("broker: refusing to send message with empty content (sender=%q recipient=%q)", msg.SenderID, agentID)
 	}
 
 	handler := b.lookupHandler(sessionID, agentID)
@@ -138,14 +138,14 @@ func (b *MemoryBroker) Send(sessionID, agentID string, msg Message) error {
 
 // Broadcast delivers msg to all subscribers in sessionID except the sender.
 func (b *MemoryBroker) Broadcast(sessionID string, msg Message) error {
+	if strings.TrimSpace(msg.Content) == "" {
+		return fmt.Errorf("broker: refusing to broadcast message with empty content (sender=%q recipient=%q)", msg.SenderID, "<broadcast>")
+	}
 	if msg.ID == "" {
 		msg.ID = uuid.New().String()
 	}
 	if msg.Timestamp.IsZero() {
 		msg.Timestamp = time.Now().UTC()
-	}
-	if strings.TrimSpace(msg.Content) == "" {
-		return fmt.Errorf("broker: refusing to broadcast message with empty content (sender=%q recipient=%q)", msg.SenderID, "<broadcast>")
 	}
 
 	b.mu.RLock()
@@ -172,14 +172,14 @@ func (b *MemoryBroker) Broadcast(sessionID string, msg Message) error {
 // bypassing debounce entirely. The Ctrl+C convention was tmux-specific and is not
 // used for bridge agents, which receive interrupts via stdin directly.
 func (b *MemoryBroker) Interrupt(sessionID, agentID string, msg Message) error {
+	if strings.TrimSpace(msg.Content) == "" {
+		return fmt.Errorf("broker: refusing to interrupt with empty content (sender=%q recipient=%q)", msg.SenderID, agentID)
+	}
 	if msg.ID == "" {
 		msg.ID = uuid.New().String()
 	}
 	if msg.Timestamp.IsZero() {
 		msg.Timestamp = time.Now().UTC()
-	}
-	if strings.TrimSpace(msg.Content) == "" {
-		return fmt.Errorf("broker: refusing to interrupt with empty content (sender=%q recipient=%q)", msg.SenderID, agentID)
 	}
 
 	handler := b.lookupHandler(sessionID, agentID)


### PR DESCRIPTION
## Summary
- Bridge `format_messages` is wrapped by new `filter_and_format_messages` which drops empty-content messages and emits a `bridge:warning` `empty_message_dropped` event with sender/count for diagnostics instead of passing garbage to the model
- Broker `Send`/`Broadcast`/`Interrupt` now reject empty content at entry as defense in depth (daemon HTTP already rejects, but broker had no guardrail)

## Why
Overnight clamshell demo runs had `web-dev` / `backend-dev` agents terminate with `final_response: "I received an empty message from an unknown sender."` — model's defensive reply to a structurally empty user turn. Daemon HTTP rejects empty at messages.go:42 but broker's direct Send path had no guardrail, and bridge formatted whatever it received.

## Test plan
- [x] `go test ./internal/broker/... -run "TestSendRejects|TestBroadcastRejects|TestInterruptRejects" -v` — all 7 sub-cases pass
- [x] `go test ./...` — all packages pass
- [x] `go build ./cmd/belayer` — clean build
- [ ] Manual: next clamshell demo run shows `bridge:warning` events instead of silent model self-termination (if empty delivery still occurs, root cause is now diagnosable)

Note: Python unit tests for `filter_and_format_messages` are not feasible without refactoring — the function lives in `__main__.py` which calls `sys.exit(1)` on import if `hermes-agent` is not installed, making it non-importable in the test environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Messages with empty or whitespace-only content are now rejected in send, broadcast, and interrupt operations. Warning events are emitted and logged for dropped messages.

* **Tests**
  * Added validation tests to ensure empty and whitespace-only messages are properly rejected across messaging operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->