### PR TITLE
feat(supervisor): peer-death recovery + pre-escalate exit-condition verify

### DIFF
--- a/agents/supervisor/agents.md
+++ b/agents/supervisor/agents.md
@@ -69,6 +69,10 @@ When an implementer signals completion:
 5. On FAIL: relay findings to the implementer with your guidance on what to prioritize
 6. On NO_FINDINGS or PASS_WITH_NOTES: proceed to QA, then integration testing
 
+## Peer terminal transitions
+
+When a spawned peer transitions terminal (blocked, incomplete, or an unexpected bridge exit), the daemon delivers an urgent broker message like `<name> has finished with status=<x>`. Treat those messages as wake-ups: investigate (bridge-stderr tail, last events), respawn once if the failure looks transient, escalate if it doesn't. Do not let these messages sit in the queue while you sleep on the idle timer — the run will time out and escalate without ever attempting recovery.
+
 ## Session Management
 
 For epic workflows with multiple tickets:

--- a/agents/supervisor/system-prompt.md
+++ b/agents/supervisor/system-prompt.md
@@ -69,3 +69,22 @@ When `belayer_request_completion` returns a rejection, read the rejection reason
 ## Before calling `belayer_request_completion`
 
 Check the roster. If any peer agent other than you is still in `starting`, `running`, or `pending_verification`, wait for them to finish or message them for a final report; if they appear hung, escalate rather than requesting completion. PM approval is terminal: the daemon shuts down every live bridge when the session is marked complete, so approving while a peer is mid-work discards their partial output and emits a `completion_approved_with_busy_agents` warning. If you are genuinely done, the roster should be quiet.
+
+## When a peer exits without finishing the task
+
+If a specialist you spawned transitions terminal (status=blocked, status=incomplete, or unexpectedly exits) before the task it was given is done, the daemon will send you an urgent broker message — don't ignore it:
+
+1. Read the peer's bridge-stderr log at `.belayer/runs/<session-id>/<agent>/bridge-stderr.log` (tail the last ~50 lines) and skim its last few bridge events for context.
+2. If the exit reason looks transient (seccomp kill, empty-message bridge bug, brief network fail, OOM), respawn the same identity ONCE with refined instructions that cite the prior failure so the peer doesn't repeat it.
+3. If a second spawn also dies terminal before finishing, do NOT self-implement the peer's work. Mark the run blocked, run your persistence_strategy, and escalate.
+
+Self-implementation bypasses worktree isolation and review gates — it is forbidden. Your job is to coordinate, not to code.
+
+## Before reporting status=incomplete
+
+Before you call `belayer_report_status` with `status=incomplete`, re-read every item in your exit_conditions (they were delivered in your spawn message and mirror `.belayer/config.yaml`). For each:
+
+- If the text describes a concrete action you can still attempt (e.g. "pull request open against main" → run `git push` then `gh pr create`; "commits on the feature branch" → `git add` + `git commit`), attempt it now. Exit conditions are commitments, not aspirations. Delegating the final step to a peer is fine; silently giving up is not.
+- If an item genuinely cannot be satisfied (external blocker, missing credential, upstream outage), log *why* in your final_response so the operator can unblock it on the next run.
+
+Do NOT escalate because quality feels imperfect — emit `incomplete` only if you cannot physically make further progress on the literal exit conditions.

--- a/internal/daemon/bridge_events.go
+++ b/internal/daemon/bridge_events.go
@@ -205,6 +205,35 @@ func (d *Daemon) processAgentStatusEvent(sessionID, eventType, data string) {
 				d.archiver.ArchiveTerminal(sessionID)
 				d.terminateSandbox(d.startCtx, sessionID)
 			}
+		} else {
+			// A specialist gave up. Wake the supervisor so it can decide whether
+			// to respawn, hand off, or escalate — otherwise it will sleep on the
+			// idle timer and escalate the whole run without attempting recovery.
+			content := fmt.Sprintf("%s has finished with status=incomplete", agentName)
+			if detail != "" {
+				content += ". Detail: " + detail
+			}
+			msgID := uuid.New().String()
+			msg := broker.Message{
+				ID:          msgID,
+				SessionID:   sessionID,
+				SenderID:    agentName,
+				RecipientID: "supervisor",
+				Type:        broker.MessageStateChange,
+				Content:     content,
+				Urgent:      true,
+				Timestamp:   time.Now().UTC(),
+			}
+			_, _ = d.store.CreateMessage(store.Message{
+				ID:          msgID,
+				SessionID:   sessionID,
+				SenderID:    agentName,
+				RecipientID: "supervisor",
+				Type:        string(broker.MessageStateChange),
+				Content:     content,
+				Urgent:      true,
+			})
+			_ = d.broker.Interrupt(sessionID, "supervisor", msg)
 		}
 
 	default:

--- a/internal/daemon/bridge_events.go
+++ b/internal/daemon/bridge_events.go
@@ -234,6 +234,14 @@ func (d *Daemon) processAgentStatusEvent(sessionID, eventType, data string) {
 				Urgent:      true,
 			})
 			_ = d.broker.Interrupt(sessionID, "supervisor", msg)
+
+			// If the supervisor was already idle (or has itself exited) and this
+			// was the last running agent, the interrupt above won't wake anyone —
+			// surface the stall now so operators see it rather than waiting for
+			// the idle-timeout to fire. When the supervisor is still running this
+			// call returns immediately because at least one agent (supervisor) is
+			// still active.
+			d.checkSessionStalled(sessionID)
 		}
 
 	default:

--- a/internal/daemon/bridge_events_test.go
+++ b/internal/daemon/bridge_events_test.go
@@ -466,6 +466,94 @@ func TestProcessAgentStatusIncompleteSupervisorEscalatesSession(t *testing.T) {
 	}
 }
 
+// TestProcessAgentStatusIncompleteSpecialistNotifiesSupervisor verifies that
+// when a specialist (non-supervisor) reports incomplete, the daemon sends an
+// urgent broker message to the supervisor. Without this nudge the supervisor
+// would sleep on its idle timer and escalate the whole run without ever
+// attempting to respawn the dead peer or take corrective action.
+func TestProcessAgentStatusIncompleteSpecialistNotifiesSupervisor(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "web-1", "supervisor")
+
+	data, _ := json.Marshal(map[string]any{
+		"agent":  "web-1",
+		"status": "incomplete",
+		"detail": "ran out of retries after seccomp kill",
+	})
+	d.processAgentStatusEvent(sessionID, "agent_status:incomplete", string(data))
+
+	// Specialist status must be updated.
+	run, err := d.store.GetAgentRun(sessionID, "web-1")
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if run.Status != "incomplete" {
+		t.Fatalf("expected agent status=incomplete, got %q", run.Status)
+	}
+
+	// Supervisor must have an urgent pending message from the peer.
+	msgs, err := d.store.PendingMessages(sessionID, "supervisor", "")
+	if err != nil {
+		t.Fatalf("PendingMessages: %v", err)
+	}
+	found := false
+	for _, m := range msgs {
+		if m.SenderID != "web-1" || m.RecipientID != "supervisor" {
+			continue
+		}
+		if !m.Urgent {
+			continue
+		}
+		if !strings.Contains(m.Content, "incomplete") {
+			continue
+		}
+		if !strings.Contains(m.Content, "seccomp") {
+			continue
+		}
+		found = true
+		break
+	}
+	if !found {
+		t.Fatalf("expected urgent incomplete-notice from web-1 to supervisor containing detail, got %#v", msgs)
+	}
+
+	// Session itself must not be escalated — only supervisor reporting incomplete
+	// should tear the run down.
+	sess, err := d.store.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.Status == "needs_human_review" {
+		t.Fatalf("specialist-incomplete must not escalate session; got %q", sess.Status)
+	}
+}
+
+// TestProcessAgentStatusIncompleteSupervisorSendsNoSelfMessage verifies that
+// when the supervisor itself reports incomplete, no self-directed broker
+// message is generated (the session-escalation path handles it).
+func TestProcessAgentStatusIncompleteSupervisorSendsNoSelfMessage(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "supervisor")
+	_ = d.store.UpdateSessionStatus(sessionID, "running")
+
+	data, _ := json.Marshal(map[string]any{
+		"agent":  "supervisor",
+		"status": "incomplete",
+		"detail": "idle timeout",
+	})
+	d.processAgentStatusEvent(sessionID, "agent_status:incomplete", string(data))
+
+	msgs, err := d.store.PendingMessages(sessionID, "supervisor", "")
+	if err != nil {
+		t.Fatalf("PendingMessages: %v", err)
+	}
+	for _, m := range msgs {
+		if m.SenderID == "supervisor" && m.RecipientID == "supervisor" {
+			t.Fatalf("supervisor reporting incomplete must not generate self-message: %#v", m)
+		}
+	}
+}
+
 // TestProcessAgentStatusMalformedJSONDoesNotPanic verifies that malformed event
 // data does not panic and is handled gracefully.
 func TestProcessAgentStatusMalformedJSONDoesNotPanic(t *testing.T) {

--- a/internal/daemon/bridge_events_test.go
+++ b/internal/daemon/bridge_events_test.go
@@ -474,6 +474,7 @@ func TestProcessAgentStatusIncompleteSupervisorEscalatesSession(t *testing.T) {
 func TestProcessAgentStatusIncompleteSpecialistNotifiesSupervisor(t *testing.T) {
 	d := testDaemon(t)
 	sessionID := setupSessionWithAgents(t, d, "web-1", "supervisor")
+	_ = d.store.UpdateSessionStatus(sessionID, "running")
 
 	data, _ := json.Marshal(map[string]any{
 		"agent":  "web-1",
@@ -517,14 +518,15 @@ func TestProcessAgentStatusIncompleteSpecialistNotifiesSupervisor(t *testing.T) 
 		t.Fatalf("expected urgent incomplete-notice from web-1 to supervisor containing detail, got %#v", msgs)
 	}
 
-	// Session itself must not be escalated — only supervisor reporting incomplete
-	// should tear the run down.
+	// Session must remain "running" — supervisor is still active and should
+	// decide whether to respawn. Any terminal transition (needs_human_review,
+	// stalled, complete) here means we incorrectly acted on a specialist exit.
 	sess, err := d.store.GetSession(sessionID)
 	if err != nil {
 		t.Fatalf("GetSession: %v", err)
 	}
-	if sess.Status == "needs_human_review" {
-		t.Fatalf("specialist-incomplete must not escalate session; got %q", sess.Status)
+	if sess.Status != "running" {
+		t.Fatalf("specialist-incomplete must leave session running while supervisor is active; got %q", sess.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Daemon sends supervisor an urgent broker message when a specialist reports `agent_status:incomplete` (previously only `bridge:failed` nudged supervisor; `agent_status:incomplete` updated the peer row silently, so supervisor kept sleeping until the idle timer escalated the whole run).
- Supervisor prompt codifies respawn-once-then-escalate discipline for any peer terminal transition; self-implementation explicitly forbidden.
- Supervisor prompt requires re-reading `exit_conditions` and attempting each literal action (push, open PR, publish artifact) before emitting `status=incomplete`.
- Supervisor `agents.md` notes that peer-terminal broker messages are wake-ups, not noise.

## Why
Overnight demo runs surfaced two patterns:
- `web-1` / `backend-1` died terminal (SIGABRT from futex_waitv seccomp kill, "empty message from unknown sender" bridge bug) → supervisor waited the full 900s idle timer and escalated `incomplete` without a single respawn attempt.
- Run 5 had 6826 lines of local commits that never reached the remote; exit condition demanded "pull request open against main" but supervisor never ran `git push` / `gh pr create` before reporting incomplete.

Builds on commit 479524a (exit conditions + QA/reviewer artifacts). Complementary to sibling `feat/persistence-strategy` PR, which tackles the broader "save work before any incomplete" case; this PR narrows to peer-death awareness + literal exit-condition gate.

## Test plan
- [x] `go test ./internal/daemon/...` passes, including new `TestProcessAgentStatusIncompleteSpecialistNotifiesSupervisor` and `TestProcessAgentStatusIncompleteSupervisorSendsNoSelfMessage`
- [x] `go test ./...` green (agentlint included)
- [x] `go build ./cmd/belayer` clean
- [ ] Manual: next clamshell demo run — supervisor respawns dead peer, runs `git push` + `gh pr create` before `incomplete`

Generated with [Claude Code](https://claude.com/claude-code)