### PR TITLE
feat(persistence): persistence_strategy config

### DIFF
--- a/agents/supervisor/system-prompt.md
+++ b/agents/supervisor/system-prompt.md
@@ -66,6 +66,28 @@ The conditions describe the *shape* of a finished run (committed? merged? deploy
 
 When `belayer_request_completion` returns a rejection, read the rejection reason carefully. A rejection on a spec item means an implementer has more work; a rejection on an exit condition means you (or a delegate) need to take the final step the project requires — commit and push, open the PR, publish the artifact, whatever the condition names. Don't re-request completion until you have done it.
 
+## Persistence before escalating incomplete
+
+If you conclude the run is `incomplete`, do NOT emit that status until you
+have executed every item in the project's `persistence_strategy`. Resolve
+the list in the same order as exit conditions: a
+`<persistence_strategy_override>` block in your initial task message wins,
+otherwise read `.belayer/config.yaml#persistence_strategy:`. If neither
+source produces steps, escalate with a detailed diagnostic message at
+minimum.
+
+Those steps are literal — `git push`, open a draft PR with diagnostics,
+register a persistence-notes artifact. The point is that even a blocked
+run should leave the next operator and retry with a committed branch, an
+open draft PR, and a summary of what actually happened. A 6000-line
+implementation sitting uncommitted in a local workspace helps no one.
+
+The daemon enforces this: if you call `belayer_report_status incomplete`
+without a `persistence-notes` artifact (kind=persistence-notes) registered
+in the session, it will reprompt you once to execute the strategy first
+and bounce your incomplete. After you push, open the draft PR, and
+register the artifact, report incomplete again and it will go through.
+
 ## Before calling `belayer_request_completion`
 
 Check the roster. If any peer agent other than you is still in `starting`, `running`, or `pending_verification`, wait for them to finish or message them for a final report; if they appear hung, escalate rather than requesting completion. PM approval is terminal: the daemon shuts down every live bridge when the session is marked complete, so approving while a peer is mid-work discards their partial output and emits a `completion_approved_with_busy_agents` warning. If you are genuinely done, the roster should be quiet.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -62,6 +62,22 @@ exit_conditions:
   - "Code changes have been reviewed by an adversarial peer agent whose review-report artifact carries verdict NO_FINDINGS or PASS_WITH_NOTES (FAIL blocks completion)"
   - "Changes are committed to a feature branch with descriptive messages"
   - "A pull request is open against the default branch"
+
+# Persistence strategy — the literal steps the supervisor must execute BEFORE
+# reporting status=incomplete. Analog to exit_conditions, but fires on the
+# escalation path: when a run cannot finish, these steps guarantee that
+# in-progress work and diagnostics are saved so the next operator or retry
+# has something to pick up. If the list is empty, the supervisor escalates
+# immediately.
+#
+# The daemon intercepts a premature incomplete (no persistence-notes artifact
+# registered) and reprompts the supervisor once to execute the strategy
+# first. Set to [] to bypass the gate entirely.
+persistence_strategy:
+  - "Commit any uncommitted changes on a branch named incomplete/<session-id>"
+  - "Push the branch to origin"
+  - "Open a draft pull request to the default branch with a body describing: what was completed, what blocked progress, and next steps"
+  - "Register a persistence-notes artifact (kind=persistence-notes) summarizing the above and linking the PR"
 `
 
 // defaultPolicyYAML is a minimal placeholder so .belayer/policies/ is not

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -54,6 +54,39 @@ func TestInitFirstRunScaffoldsDefaults(t *testing.T) {
 	}
 }
 
+func TestInitScaffoldsPersistenceStrategyBlock(t *testing.T) {
+	dir := t.TempDir()
+	cmd := newInitCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--target", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	cfg, err := os.ReadFile(filepath.Join(dir, ".belayer", "config.yaml"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	got := string(cfg)
+	if !strings.Contains(got, "\npersistence_strategy:\n") {
+		t.Fatalf("expected 'persistence_strategy:' block in config.yaml, got:\n%s", got)
+	}
+	// Each scaffolded bullet must be present — these are the contract with
+	// the supervisor prompt and the daemon intercept. If one is removed
+	// silently, operators lose the default persistence behavior.
+	for _, want := range []string{
+		"incomplete/<session-id>",
+		"Push the branch to origin",
+		"draft pull request",
+		"persistence-notes",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in persistence_strategy block, got:\n%s", want, got)
+		}
+	}
+}
+
 func TestInitWritesLogLevelStandardToConfig(t *testing.T) {
 	dir := t.TempDir()
 	cmd := newInitCmd()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -22,6 +22,7 @@ func newRunCmd() *cobra.Command {
 func newRunStartCmd() *cobra.Command {
 	var socket, name, task, supervisorProfile, workdir, reposFlag string
 	var exitConditions []string
+	var persistenceStrategy []string
 	var logLevel string
 	cmd := &cobra.Command{
 		Use:   "start",
@@ -56,6 +57,33 @@ func newRunStartCmd() *cobra.Command {
 				b.WriteString(task)
 				task = b.String()
 			}
+
+			// Same shape as --exit-condition above: --persistence-strategy lets
+			// the operator override .belayer/config.yaml#persistence_strategy
+			// for this run only. These are the literal steps the supervisor
+			// must execute before reporting status=incomplete. Empty values are
+			// dropped so `--persistence-strategy ""` falls through to the
+			// project config instead of injecting an authoritative empty list.
+			normalizedPersistenceStrategy := make([]string, 0, len(persistenceStrategy))
+			for _, p := range persistenceStrategy {
+				if p = strings.TrimSpace(p); p != "" {
+					normalizedPersistenceStrategy = append(normalizedPersistenceStrategy, p)
+				}
+			}
+			if len(normalizedPersistenceStrategy) > 0 {
+				var b strings.Builder
+				b.WriteString("<persistence_strategy_override>\n")
+				b.WriteString("These persistence steps replace .belayer/config.yaml#persistence_strategy for this run. Execute every step BEFORE reporting status=incomplete — the daemon will intercept and reprompt if no persistence-notes artifact is registered.\n")
+				for _, p := range normalizedPersistenceStrategy {
+					b.WriteString("- ")
+					b.WriteString(p)
+					b.WriteString("\n")
+				}
+				b.WriteString("</persistence_strategy_override>\n\n")
+				b.WriteString(task)
+				task = b.String()
+			}
+
 			if strings.TrimSpace(supervisorProfile) == "" {
 				supervisorProfile = "default"
 			}
@@ -117,9 +145,10 @@ func newRunStartCmd() *cobra.Command {
 			}
 			// Log the initial prompt as telemetry so post-mortems can see what started the run.
 			initData, _ := json.Marshal(map[string]any{
-				"task":               task,
-				"supervisor_profile": supervisorProfile,
-				"exit_conditions":    normalizedExitConditions,
+				"task":                 task,
+				"supervisor_profile":   supervisorProfile,
+				"exit_conditions":      normalizedExitConditions,
+				"persistence_strategy": normalizedPersistenceStrategy,
 			})
 			_ = c.LogEvent(sess.ID, "run_initiated", string(initData))
 
@@ -146,6 +175,7 @@ func newRunStartCmd() *cobra.Command {
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Working directory (defaults to cwd)")
 	cmd.Flags().StringVar(&reposFlag, "repos", "", "Repos to include: name=path,name=path (e.g. frontend=../fe,backend=../be)")
 	cmd.Flags().StringArrayVar(&exitConditions, "exit-condition", nil, "Override .belayer/config.yaml#exit_conditions for this run. Repeatable. When present, these replace the file's list entirely.")
+	cmd.Flags().StringArrayVar(&persistenceStrategy, "persistence-strategy", nil, "Override .belayer/config.yaml#persistence_strategy for this run. Repeatable. Literal steps the supervisor must execute before reporting status=incomplete.")
 	cmd.Flags().StringVar(&logLevel, "log-level", "", "Log tier for this run: standard|verbose|trace. Falls back to BELAYER_LOG_LEVEL, then daemon default.")
 	return cmd
 }

--- a/internal/daemon/bridge_events.go
+++ b/internal/daemon/bridge_events.go
@@ -17,6 +17,15 @@ import (
 
 const maxRejectionCycles = 3
 
+// maxPersistenceReprompts bounds how many times the daemon will bounce a
+// supervisor-reported incomplete back for missing persistence work before
+// accepting the escalation. One reprompt is the design target: supervisor
+// either executes the persistence_strategy and registers a persistence-notes
+// artifact, or the daemon gives up on the next incomplete and escalates
+// as usual. Prevents a livelock if the supervisor is genuinely unable to
+// persist (e.g. no network, no remote, stuck credentials).
+const maxPersistenceReprompts = 1
+
 // processBridgeEvent handles side effects for bridge:* events.
 // It is called after the event has already been persisted to the event log.
 func (d *Daemon) processBridgeEvent(sessionID, eventType, data string) {
@@ -195,8 +204,17 @@ func (d *Daemon) processAgentStatusEvent(sessionID, eventType, data string) {
 			log.Printf("WARNING: processAgentStatusEvent: failed to log agent_escalated event in session %s: %v", sessionID, err)
 		}
 
-		// If the supervisor reports incomplete, escalate the session.
+		// If the supervisor reports incomplete, check the persistence gate
+		// before escalating. This mirrors how the PM gate intercepts a
+		// request for completion: a non-empty persistence_strategy is a hard
+		// requirement — the supervisor must execute it (and register a
+		// persistence-notes artifact) before the run is allowed to bail.
+		// Otherwise a blocked overnight run ends with uncommitted local work
+		// and no diagnostics for the next operator.
 		if agentName == "supervisor" {
+			if d.maybeRepromptForPersistence(sessionID, detail) {
+				return
+			}
 			if err := d.store.UpdateSessionStatus(sessionID, "needs_human_review"); err != nil {
 				log.Printf("ERROR: processAgentStatusEvent: failed to escalate session %s to needs_human_review: %v", sessionID, err)
 			} else {
@@ -365,6 +383,196 @@ func (d *Daemon) resolveExitConditions(sessionID string) ([]string, string) {
 		return nil, "none"
 	}
 	return file.ExitConditions, "config"
+}
+
+// resolvePersistenceStrategy returns the authoritative persistence-strategy
+// list for the session plus the source it came from ("override" for a
+// --persistence-strategy flag at run start, "config" for .belayer/config.yaml,
+// or "none"). These are the literal steps the supervisor must execute before
+// reporting status=incomplete — committing, pushing, opening a draft PR,
+// registering a persistence-notes artifact — so a blocked run still leaves
+// the next operator with something to pick up.
+//
+// Shape mirrors resolveExitConditions: run-initiated override wins, then the
+// config file, then empty. See docs/AGENT_ARCHITECTURE.md for the resolution
+// order discussion; this sibling keeps the two gates symmetric.
+func (d *Daemon) resolvePersistenceStrategy(sessionID string) ([]string, string) {
+	// First: check run_initiated event for a per-run override.
+	events, _ := d.store.QueryEvents(sessionID)
+	for _, ev := range events {
+		if ev.Type != "run_initiated" || ev.Data == "" {
+			continue
+		}
+		var payload struct {
+			PersistenceStrategy []string `json:"persistence_strategy"`
+		}
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err == nil && len(payload.PersistenceStrategy) > 0 {
+			return payload.PersistenceStrategy, "override"
+		}
+		break // only the first run_initiated event is authoritative
+	}
+
+	// Fallback: read .belayer/config.yaml from the session's workspace.
+	sess, err := d.store.GetSession(sessionID)
+	if err != nil || sess.WorkspaceDir == "" {
+		return nil, "none"
+	}
+	cfgPath := filepath.Join(sess.WorkspaceDir, ".belayer", "config.yaml")
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return nil, "none"
+	}
+	var file struct {
+		PersistenceStrategy []string `yaml:"persistence_strategy"`
+	}
+	if err := yaml.Unmarshal(raw, &file); err != nil || len(file.PersistenceStrategy) == 0 {
+		return nil, "none"
+	}
+	return file.PersistenceStrategy, "config"
+}
+
+// hasPersistenceNotesArtifact returns true when at least one artifact in the
+// session has kind=persistence-notes — the simplest signal that the supervisor
+// actually executed its persistence_strategy. Used as the heuristic for the
+// pre-incomplete intercept: no artifact, no escalation.
+func (d *Daemon) hasPersistenceNotesArtifact(sessionID string) bool {
+	artifacts, err := d.store.ListArtifacts(sessionID)
+	if err != nil {
+		// Treat lookup errors as "present" — the store failure is the wrong
+		// place to wedge a retry loop; better to let the escalation proceed.
+		log.Printf("hasPersistenceNotesArtifact: ListArtifacts failed for session %s: %v (treating as present)", sessionID, err)
+		return true
+	}
+	for _, a := range artifacts {
+		if a.Kind == "persistence-notes" {
+			return true
+		}
+	}
+	return false
+}
+
+// countPersistenceReprompts counts how many times the daemon has already
+// bounced a supervisor-reported incomplete back for missing persistence work
+// in this session. Bounded by maxPersistenceReprompts so a supervisor that
+// genuinely cannot persist (no network, no remote) still escalates.
+func (d *Daemon) countPersistenceReprompts(sessionID string) int {
+	events, err := d.store.QueryEvents(sessionID)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, ev := range events {
+		if ev.Type == "persistence_reprompt" {
+			n++
+		}
+	}
+	return n
+}
+
+// maybeRepromptForPersistence decides whether to intercept a supervisor-
+// reported incomplete and bounce it back to execute the persistence_strategy
+// first. Returns true if the event was intercepted (the caller should NOT
+// proceed to escalate). Returns false to let the normal escalation path run.
+//
+// Acceptance heuristic: a persistence-notes artifact exists in the session.
+// That's the simplest signal the supervisor actually walked its strategy; the
+// alternatives (scan tool-call logs for `git push`, inspect remote) are
+// higher-complexity and not worth the maintenance cost for a prompt-level
+// gate. Operators who want to bypass the gate set persistence_strategy: [] in
+// config.yaml or pass no --persistence-strategy flags.
+//
+// Bounded by maxPersistenceReprompts so a supervisor that genuinely cannot
+// persist (no network, stuck credentials) still escalates on the next
+// incomplete rather than looping forever.
+func (d *Daemon) maybeRepromptForPersistence(sessionID, supervisorDetail string) bool {
+	strategy, source := d.resolvePersistenceStrategy(sessionID)
+	if len(strategy) == 0 {
+		return false // nothing to enforce
+	}
+	if d.hasPersistenceNotesArtifact(sessionID) {
+		return false // supervisor already executed the strategy (artifact registered)
+	}
+	if d.countPersistenceReprompts(sessionID) >= maxPersistenceReprompts {
+		// Already reprompted once — accept this incomplete so a genuinely
+		// blocked supervisor can still escalate. Log the shortfall for the
+		// post-mortem so operators see the gap.
+		log.Printf("Session %s: accepting incomplete without persistence-notes artifact (reprompt limit %d reached)",
+			sessionID, maxPersistenceReprompts)
+		_ = d.store.LogEvent(store.SessionEvent{
+			SessionID: sessionID,
+			Type:      "persistence_gate_bypassed",
+			Data: mustJSON(map[string]any{
+				"reason": "reprompt_limit_reached",
+				"limit":  maxPersistenceReprompts,
+				"source": source,
+			}),
+		})
+		return false
+	}
+
+	// Revert supervisor back to running so it can act on the reprompt. The
+	// bridge process is still alive; we just set the row that
+	// processAgentStatusEvent already flipped to "incomplete" back to
+	// something active. Without this, checkSessionStalled (or a subsequent
+	// status query) would see the supervisor as terminal.
+	if err := d.store.UpdateAgentRunStatus(sessionID, "supervisor", "running"); err != nil {
+		log.Printf("maybeRepromptForPersistence: revert supervisor status failed for session %s: %v", sessionID, err)
+		return false // can't safely continue the intercept — let escalation run
+	}
+
+	// Render the strategy back to the supervisor as an urgent state change.
+	// The supervisor already has the list in its spawn message, but restating
+	// it here makes the reprompt self-contained in the live message stream.
+	var b strings.Builder
+	fmt.Fprintf(&b, "You reported status=incomplete but the persistence_strategy (source: %s) has not been executed: no persistence-notes artifact is registered in this session.\n\n", source)
+	b.WriteString("Execute each step below, THEN call belayer_report_status with status=incomplete again:\n")
+	for _, step := range strategy {
+		b.WriteString("- ")
+		b.WriteString(step)
+		b.WriteString("\n")
+	}
+	b.WriteString("\nThe point: even a blocked run should leave the next operator with a committed branch, a draft PR, and a summary. Register the artifact with kind=persistence-notes summarizing what you did (or why a step was impossible).")
+	if strings.TrimSpace(supervisorDetail) != "" {
+		b.WriteString("\n\nYour reported reason for incomplete was preserved: ")
+		b.WriteString(supervisorDetail)
+	}
+	content := b.String()
+
+	msgID := uuid.New().String()
+	msg := broker.Message{
+		ID:          msgID,
+		SessionID:   sessionID,
+		SenderID:    "system",
+		RecipientID: "supervisor",
+		Type:        broker.MessageStateChange,
+		Content:     content,
+		Urgent:      true,
+		Timestamp:   time.Now().UTC(),
+	}
+	_, _ = d.store.CreateMessage(store.Message{
+		ID:          msgID,
+		SessionID:   sessionID,
+		SenderID:    "system",
+		RecipientID: "supervisor",
+		Type:        string(broker.MessageStateChange),
+		Content:     content,
+		Urgent:      true,
+	})
+	_ = d.broker.Interrupt(sessionID, "supervisor", msg)
+
+	_ = d.store.LogEvent(store.SessionEvent{
+		SessionID: sessionID,
+		Type:      "persistence_reprompt",
+		Data: mustJSON(map[string]any{
+			"source":           source,
+			"steps":            strategy,
+			"reported_detail":  supervisorDetail,
+			"reprompts_so_far": d.countPersistenceReprompts(sessionID) + 1,
+		}),
+	})
+	log.Printf("Session %s: reprompted supervisor to execute persistence_strategy (source=%s) before incomplete",
+		sessionID, source)
+	return true
 }
 
 func (d *Daemon) handleBridgeCompletionRequested(sessionID, agentName string, data map[string]any) {

--- a/internal/daemon/bridge_events.go
+++ b/internal/daemon/bridge_events.go
@@ -192,18 +192,6 @@ func (d *Daemon) processAgentStatusEvent(sessionID, eventType, data string) {
 			log.Printf("ERROR: processAgentStatusEvent: failed to update agent %s to incomplete in session %s: %v", agentName, sessionID, err)
 		}
 
-		if err := d.store.LogEvent(store.SessionEvent{
-			SessionID: sessionID,
-			Type:      "agent_escalated",
-			Data: mustJSON(map[string]string{
-				"agent":  agentName,
-				"reason": "incomplete",
-				"detail": detail,
-			}),
-		}); err != nil {
-			log.Printf("WARNING: processAgentStatusEvent: failed to log agent_escalated event in session %s: %v", sessionID, err)
-		}
-
 		// If the supervisor reports incomplete, check the persistence gate
 		// before escalating. This mirrors how the PM gate intercepts a
 		// request for completion: a non-empty persistence_strategy is a hard
@@ -211,9 +199,25 @@ func (d *Daemon) processAgentStatusEvent(sessionID, eventType, data string) {
 		// persistence-notes artifact) before the run is allowed to bail.
 		// Otherwise a blocked overnight run ends with uncommitted local work
 		// and no diagnostics for the next operator.
+		//
+		// agent_escalated is only emitted after the gate decides — emitting
+		// before would record an escalation that never happened when the gate
+		// intercepts and reprompts instead.
 		if agentName == "supervisor" {
 			if d.maybeRepromptForPersistence(sessionID, detail) {
 				return
+			}
+			// Gate did not intercept — the supervisor is genuinely escalating.
+			if err := d.store.LogEvent(store.SessionEvent{
+				SessionID: sessionID,
+				Type:      "agent_escalated",
+				Data: mustJSON(map[string]string{
+					"agent":  agentName,
+					"reason": "incomplete",
+					"detail": detail,
+				}),
+			}); err != nil {
+				log.Printf("WARNING: processAgentStatusEvent: failed to log agent_escalated event in session %s: %v", sessionID, err)
 			}
 			if err := d.store.UpdateSessionStatus(sessionID, "needs_human_review"); err != nil {
 				log.Printf("ERROR: processAgentStatusEvent: failed to escalate session %s to needs_human_review: %v", sessionID, err)
@@ -224,6 +228,19 @@ func (d *Daemon) processAgentStatusEvent(sessionID, eventType, data string) {
 				d.terminateSandbox(d.startCtx, sessionID)
 			}
 		} else {
+			// Non-supervisor agent gave up. Emit escalated event immediately —
+			// no persistence gate applies to specialist agents.
+			if err := d.store.LogEvent(store.SessionEvent{
+				SessionID: sessionID,
+				Type:      "agent_escalated",
+				Data: mustJSON(map[string]string{
+					"agent":  agentName,
+					"reason": "incomplete",
+					"detail": detail,
+				}),
+			}); err != nil {
+				log.Printf("WARNING: processAgentStatusEvent: failed to log agent_escalated event in session %s: %v", sessionID, err)
+			}
 			// A specialist gave up. Wake the supervisor so it can decide whether
 			// to respawn, hand off, or escalate — otherwise it will sleep on the
 			// idle timer and escalate the whole run without attempting recovery.
@@ -479,7 +496,8 @@ func (d *Daemon) countPersistenceReprompts(sessionID string) int {
 // alternatives (scan tool-call logs for `git push`, inspect remote) are
 // higher-complexity and not worth the maintenance cost for a prompt-level
 // gate. Operators who want to bypass the gate set persistence_strategy: [] in
-// config.yaml or pass no --persistence-strategy flags.
+// config.yaml or omit the persistence_strategy block entirely so the resolved
+// strategy is empty.
 //
 // Bounded by maxPersistenceReprompts so a supervisor that genuinely cannot
 // persist (no network, stuck credentials) still escalates on the next
@@ -492,7 +510,13 @@ func (d *Daemon) maybeRepromptForPersistence(sessionID, supervisorDetail string)
 	if d.hasPersistenceNotesArtifact(sessionID) {
 		return false // supervisor already executed the strategy (artifact registered)
 	}
-	if d.countPersistenceReprompts(sessionID) >= maxPersistenceReprompts {
+
+	// Cache the reprompt count once — countPersistenceReprompts scans the
+	// event log, and we use the value in two places below (limit check and
+	// the reprompt event payload).
+	repromptCount := d.countPersistenceReprompts(sessionID)
+
+	if repromptCount >= maxPersistenceReprompts {
 		// Already reprompted once — accept this incomplete so a genuinely
 		// blocked supervisor can still escalate. Log the shortfall for the
 		// post-mortem so operators see the gap.
@@ -549,7 +573,7 @@ func (d *Daemon) maybeRepromptForPersistence(sessionID, supervisorDetail string)
 		Urgent:      true,
 		Timestamp:   time.Now().UTC(),
 	}
-	_, _ = d.store.CreateMessage(store.Message{
+	if _, err := d.store.CreateMessage(store.Message{
 		ID:          msgID,
 		SessionID:   sessionID,
 		SenderID:    "system",
@@ -557,8 +581,22 @@ func (d *Daemon) maybeRepromptForPersistence(sessionID, supervisorDetail string)
 		Type:        string(broker.MessageStateChange),
 		Content:     content,
 		Urgent:      true,
-	})
-	_ = d.broker.Interrupt(sessionID, "supervisor", msg)
+	}); err != nil {
+		// Durable store failure: the supervisor won't receive the reprompt on
+		// its next polling cycle either. Revert and let normal escalation run
+		// rather than wedging the session with a supervisor that is marked
+		// running but has no pending instruction.
+		log.Printf("ERROR: maybeRepromptForPersistence: CreateMessage failed for session %s agent supervisor: %v; falling through to escalation", sessionID, err)
+		_ = d.store.UpdateAgentRunStatus(sessionID, "supervisor", "incomplete")
+		return false
+	}
+	// broker.Interrupt is best-effort live push; message already durably
+	// persisted above, so the supervisor will poll and receive it even if
+	// this in-memory delivery fails (e.g. no active subscriber in tests or
+	// during a brief bridge reconnect).
+	if err := d.broker.Interrupt(sessionID, "supervisor", msg); err != nil {
+		log.Printf("WARNING: maybeRepromptForPersistence: broker.Interrupt failed for session %s agent supervisor: %v (message persisted; supervisor will receive on next poll)", sessionID, err)
+	}
 
 	_ = d.store.LogEvent(store.SessionEvent{
 		SessionID: sessionID,
@@ -567,7 +605,7 @@ func (d *Daemon) maybeRepromptForPersistence(sessionID, supervisorDetail string)
 			"source":           source,
 			"steps":            strategy,
 			"reported_detail":  supervisorDetail,
-			"reprompts_so_far": d.countPersistenceReprompts(sessionID) + 1,
+			"reprompts_so_far": repromptCount + 1,
 		}),
 	})
 	log.Printf("Session %s: reprompted supervisor to execute persistence_strategy (source=%s) before incomplete",

--- a/internal/daemon/bridge_events_test.go
+++ b/internal/daemon/bridge_events_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -576,6 +578,315 @@ func TestProcessAgentStatusMissingAgentFieldDoesNotPanic(t *testing.T) {
 }
 
 // --- Tests for handleBridgeFinished status overwrite guard ---
+
+// --- Tests for resolvePersistenceStrategy ---
+
+// setupSessionWithWorkspace creates a session whose WorkspaceDir points at a
+// fresh temp dir, so tests can seed a .belayer/config.yaml that the daemon's
+// config readers will find.
+func setupSessionWithWorkspace(t *testing.T, d *Daemon, configYAML string) string {
+	t.Helper()
+	ws := t.TempDir()
+	if configYAML != "" {
+		if err := os.MkdirAll(filepath.Join(ws, ".belayer"), 0o755); err != nil {
+			t.Fatalf("mkdir .belayer: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(ws, ".belayer", "config.yaml"), []byte(configYAML), 0o644); err != nil {
+			t.Fatalf("write config.yaml: %v", err)
+		}
+	}
+	sessID, err := d.store.CreateSession(store.Session{Name: "persistence-test", WorkspaceDir: ws})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	return sessID
+}
+
+// TestResolvePersistenceStrategy_Override verifies that a run_initiated event
+// carrying persistence_strategy wins over any config file on disk.
+func TestResolvePersistenceStrategy_Override(t *testing.T) {
+	d := testDaemon(t)
+	// Config file says one thing; the override should win.
+	sessID := setupSessionWithWorkspace(t, d, "persistence_strategy:\n  - from-config\n")
+
+	overrideData, _ := json.Marshal(map[string]any{
+		"persistence_strategy": []string{"override-step-1", "override-step-2"},
+	})
+	if err := d.store.LogEvent(store.SessionEvent{
+		SessionID: sessID,
+		Type:      "run_initiated",
+		Data:      string(overrideData),
+	}); err != nil {
+		t.Fatalf("log run_initiated: %v", err)
+	}
+
+	got, source := d.resolvePersistenceStrategy(sessID)
+	if source != "override" {
+		t.Fatalf("expected source=override, got %q", source)
+	}
+	if len(got) != 2 || got[0] != "override-step-1" || got[1] != "override-step-2" {
+		t.Fatalf("expected override steps, got %v", got)
+	}
+}
+
+// TestResolvePersistenceStrategy_Config verifies that the config file is used
+// when no run_initiated override is present.
+func TestResolvePersistenceStrategy_Config(t *testing.T) {
+	d := testDaemon(t)
+	sessID := setupSessionWithWorkspace(t, d,
+		"persistence_strategy:\n  - commit-work\n  - push-branch\n")
+
+	got, source := d.resolvePersistenceStrategy(sessID)
+	if source != "config" {
+		t.Fatalf("expected source=config, got %q", source)
+	}
+	if len(got) != 2 || got[0] != "commit-work" || got[1] != "push-branch" {
+		t.Fatalf("expected config steps, got %v", got)
+	}
+}
+
+// TestResolvePersistenceStrategy_None verifies that an absent config block
+// produces source=none and an empty list (no false signal to the intercept).
+func TestResolvePersistenceStrategy_None(t *testing.T) {
+	d := testDaemon(t)
+	sessID := setupSessionWithWorkspace(t, d, "# no persistence_strategy here\n")
+
+	got, source := d.resolvePersistenceStrategy(sessID)
+	if source != "none" {
+		t.Fatalf("expected source=none, got %q", source)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty list, got %v", got)
+	}
+}
+
+// TestResolvePersistenceStrategy_EmptyOverrideFallsThroughToConfig verifies
+// that an override payload with an empty persistence_strategy array does NOT
+// shadow the config file — mirrors the --persistence-strategy flag normalization
+// in run.go, where a blank value falls through to the project config.
+func TestResolvePersistenceStrategy_EmptyOverrideFallsThroughToConfig(t *testing.T) {
+	d := testDaemon(t)
+	sessID := setupSessionWithWorkspace(t, d,
+		"persistence_strategy:\n  - config-step\n")
+
+	overrideData, _ := json.Marshal(map[string]any{
+		"persistence_strategy": []string{},
+	})
+	_ = d.store.LogEvent(store.SessionEvent{
+		SessionID: sessID,
+		Type:      "run_initiated",
+		Data:      string(overrideData),
+	})
+
+	got, source := d.resolvePersistenceStrategy(sessID)
+	if source != "config" {
+		t.Fatalf("expected fall-through to config, got source=%q", source)
+	}
+	if len(got) != 1 || got[0] != "config-step" {
+		t.Fatalf("expected config step, got %v", got)
+	}
+}
+
+// --- Tests for the persistence intercept on agent_status:incomplete ---
+
+// TestSupervisorIncompleteRepromptedWhenNoPersistenceArtifact verifies that
+// when the supervisor reports incomplete and a persistence_strategy is
+// configured but no persistence-notes artifact exists, the daemon reprompts
+// the supervisor instead of escalating the session.
+func TestSupervisorIncompleteRepromptedWhenNoPersistenceArtifact(t *testing.T) {
+	d := testDaemon(t)
+	sessID := setupSessionWithWorkspace(t, d,
+		"persistence_strategy:\n  - commit-and-push\n  - register-persistence-notes\n")
+	_ = d.store.UpdateSessionStatus(sessID, "running")
+	if _, err := d.store.CreateAgentRun(store.AgentRun{
+		SessionID: sessID, Name: "supervisor", Role: "supervisor",
+		Profile: "default", Status: "running", Transport: "bridge",
+	}); err != nil {
+		t.Fatalf("create supervisor: %v", err)
+	}
+
+	data, _ := json.Marshal(map[string]any{
+		"agent":  "supervisor",
+		"status": "incomplete",
+		"detail": "stuck on DB migration",
+	})
+	d.processAgentStatusEvent(sessID, "agent_status:incomplete", string(data))
+
+	// Session must NOT escalate — the supervisor should be reprompted and
+	// kept alive for another pass.
+	sess, err := d.store.GetSession(sessID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.Status == "needs_human_review" {
+		t.Fatalf("session escalated despite persistence reprompt being applicable")
+	}
+
+	// Supervisor row must be flipped back to running so downstream checks
+	// don't treat it as terminal.
+	run, err := d.store.GetAgentRun(sessID, "supervisor")
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if run.Status != "running" {
+		t.Fatalf("expected supervisor status=running after reprompt, got %q", run.Status)
+	}
+
+	// Reprompt event must be logged so post-mortems can see the gate fired.
+	events, _ := d.store.QueryEvents(sessID)
+	var foundReprompt bool
+	for _, e := range events {
+		if e.Type == "persistence_reprompt" {
+			foundReprompt = true
+			if !strings.Contains(e.Data, "commit-and-push") {
+				t.Errorf("expected reprompt event to include strategy steps, got: %s", e.Data)
+			}
+		}
+	}
+	if !foundReprompt {
+		t.Fatalf("expected persistence_reprompt event")
+	}
+
+	// Supervisor must receive an urgent message listing the strategy steps.
+	msgs, err := d.store.PendingMessages(sessID, "supervisor", "")
+	if err != nil {
+		t.Fatalf("PendingMessages: %v", err)
+	}
+	var foundMsg bool
+	for _, m := range msgs {
+		if m.RecipientID == "supervisor" && m.Urgent && strings.Contains(m.Content, "persistence_strategy") {
+			foundMsg = true
+		}
+	}
+	if !foundMsg {
+		t.Fatalf("expected urgent reprompt message to supervisor, got %#v", msgs)
+	}
+}
+
+// TestSupervisorIncompleteAcceptedWhenPersistenceArtifactPresent verifies
+// that an incomplete is accepted and the session escalates normally when the
+// supervisor has already registered a persistence-notes artifact.
+func TestSupervisorIncompleteAcceptedWhenPersistenceArtifactPresent(t *testing.T) {
+	d := testDaemon(t)
+	sessID := setupSessionWithWorkspace(t, d,
+		"persistence_strategy:\n  - commit-and-push\n")
+	_ = d.store.UpdateSessionStatus(sessID, "running")
+	if _, err := d.store.CreateAgentRun(store.AgentRun{
+		SessionID: sessID, Name: "supervisor", Role: "supervisor",
+		Profile: "default", Status: "running", Transport: "bridge",
+	}); err != nil {
+		t.Fatalf("create supervisor: %v", err)
+	}
+
+	// Supervisor already registered persistence-notes — the gate should
+	// let this incomplete through.
+	if _, err := d.store.CreateArtifact(store.Artifact{
+		SessionID: sessID,
+		Kind:      "persistence-notes",
+		Path:      "(inline)",
+		Producer:  "supervisor",
+		Summary:   "pushed branch incomplete/foo, opened draft PR #123",
+	}); err != nil {
+		t.Fatalf("create persistence-notes artifact: %v", err)
+	}
+
+	data, _ := json.Marshal(map[string]any{
+		"agent":  "supervisor",
+		"status": "incomplete",
+		"detail": "blocked on upstream API",
+	})
+	d.processAgentStatusEvent(sessID, "agent_status:incomplete", string(data))
+
+	sess, err := d.store.GetSession(sessID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.Status != "needs_human_review" {
+		t.Fatalf("expected session escalated to needs_human_review, got %q", sess.Status)
+	}
+}
+
+// TestSupervisorIncompleteEscalatesWhenPersistenceStrategyEmpty verifies that
+// the intercept is a no-op when no persistence_strategy is declared —
+// preserves the existing escalation behavior for projects that opt out.
+func TestSupervisorIncompleteEscalatesWhenPersistenceStrategyEmpty(t *testing.T) {
+	d := testDaemon(t)
+	// No config file, no override — persistence_strategy is empty.
+	sessID := setupSessionWithWorkspace(t, d, "")
+	_ = d.store.UpdateSessionStatus(sessID, "running")
+	if _, err := d.store.CreateAgentRun(store.AgentRun{
+		SessionID: sessID, Name: "supervisor", Role: "supervisor",
+		Profile: "default", Status: "running", Transport: "bridge",
+	}); err != nil {
+		t.Fatalf("create supervisor: %v", err)
+	}
+
+	data, _ := json.Marshal(map[string]any{
+		"agent":  "supervisor",
+		"status": "incomplete",
+		"detail": "done bailing",
+	})
+	d.processAgentStatusEvent(sessID, "agent_status:incomplete", string(data))
+
+	sess, err := d.store.GetSession(sessID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.Status != "needs_human_review" {
+		t.Fatalf("expected session escalated to needs_human_review, got %q", sess.Status)
+	}
+}
+
+// TestSupervisorIncompleteAcceptedAfterMaxReprompts verifies that after the
+// reprompt limit is reached, the next incomplete escalates normally even
+// without a persistence-notes artifact. Prevents a livelock when the
+// supervisor genuinely cannot persist (no network, stuck credentials).
+func TestSupervisorIncompleteAcceptedAfterMaxReprompts(t *testing.T) {
+	d := testDaemon(t)
+	sessID := setupSessionWithWorkspace(t, d,
+		"persistence_strategy:\n  - commit-and-push\n")
+	_ = d.store.UpdateSessionStatus(sessID, "running")
+	if _, err := d.store.CreateAgentRun(store.AgentRun{
+		SessionID: sessID, Name: "supervisor", Role: "supervisor",
+		Profile: "default", Status: "running", Transport: "bridge",
+	}); err != nil {
+		t.Fatalf("create supervisor: %v", err)
+	}
+
+	// First incomplete: should be intercepted (reprompt #1).
+	data, _ := json.Marshal(map[string]any{
+		"agent": "supervisor", "status": "incomplete", "detail": "first try",
+	})
+	d.processAgentStatusEvent(sessID, "agent_status:incomplete", string(data))
+
+	sess, _ := d.store.GetSession(sessID)
+	if sess.Status == "needs_human_review" {
+		t.Fatalf("expected first incomplete to be intercepted, got escalation")
+	}
+
+	// Second incomplete: limit reached, should escalate normally.
+	data2, _ := json.Marshal(map[string]any{
+		"agent": "supervisor", "status": "incomplete", "detail": "second try",
+	})
+	d.processAgentStatusEvent(sessID, "agent_status:incomplete", string(data2))
+
+	sess, _ = d.store.GetSession(sessID)
+	if sess.Status != "needs_human_review" {
+		t.Fatalf("expected second incomplete to escalate after reprompt limit, got %q", sess.Status)
+	}
+
+	// Bypass event must be logged so operators see the gate was skipped.
+	events, _ := d.store.QueryEvents(sessID)
+	var foundBypass bool
+	for _, e := range events {
+		if e.Type == "persistence_gate_bypassed" {
+			foundBypass = true
+		}
+	}
+	if !foundBypass {
+		t.Fatalf("expected persistence_gate_bypassed event after reprompt limit")
+	}
+}
 
 // TestBridgeFinishedDoesNotOverwriteIncomplete verifies that when an agent
 // has already been marked incomplete, bridge:finished does not overwrite


### PR DESCRIPTION
## Summary
- New `persistence_strategy` config block + `--persistence-strategy` flag (analog to `exit_conditions`)
- Supervisor prompt-level rule: execute literal steps before emitting `incomplete`
- Daemon intercepts premature `incomplete` (no `persistence-notes` artifact) and reprompts once before allowing escalation

## Why
Overnight clamshell demo runs had supervisor escalate `incomplete` with 6800+ lines of local-only commits, no push, no PR, despite exit-condition literal demanding a PR. This adds the missing "save in-progress work before bailing" gate without hardcoding actions into code — stays prompt-level like exit_conditions so operators customize the steps. The daemon intercept is minimal: one reprompt bounded by event count, artifact-based heuristic, opt-out via empty list in config.

## Pattern match with 479524a
Mirrored exactly where possible:
- `init.go` scaffolds a commented-adjacent `persistence_strategy:` block below the `exit_conditions:` block with default bullets operators can edit.
- `run.go` adds `--persistence-strategy` (repeatable, trims blanks) and renders `<persistence_strategy_override>` into the initial task, parallel to `<exit_conditions_override>`. `run_initiated` event payload gains the field.
- `bridge_events.go` adds `resolvePersistenceStrategy` with identical shape to `resolveExitConditions` (override -> config -> none, same source labels).
- Supervisor system-prompt section uses the same tone as the exit-conditions section, naming the override/config resolution order and the artifact requirement.

## Deviation note
The task brief said "when supervisor spawns, the daemon currently injects exit_conditions into the spawn message" — that's not actually how exit_conditions flows today. Exit conditions are CLI-injected into the initial task message (`run.go` renders the `<exit_conditions_override>` block), and `resolveExitConditions` on the daemon is only called by the PM path at completion time. I matched that real pattern: `<persistence_strategy_override>` flows via the initial task, supervisor reads config directly per its prompt, and `resolvePersistenceStrategy` is called on the daemon's intercept path (not at spawn).

## Test plan
- [x] `go test ./...` passes (all packages green, including agentlint)
- [x] New tests: `TestInitScaffoldsPersistenceStrategyBlock`, `TestResolvePersistenceStrategy_{Override,Config,None,EmptyOverrideFallsThroughToConfig}`, `TestSupervisorIncomplete{RepromptedWhenNoPersistenceArtifact,AcceptedWhenPersistenceArtifactPresent,EscalatesWhenPersistenceStrategyEmpty,AcceptedAfterMaxReprompts}`
- [x] `go build ./cmd/belayer` clean
- [ ] Manual: `belayer init` writes persistence_strategy block to config.yaml
- [ ] Manual: next overnight run — supervisor pushes + draft PRs + registers persistence-notes on incomplete instead of silent escalation

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>