### PR TITLE
feat(daemon): attach stderr tail to peer-exit notification

### DIFF
--- a/agents/supervisor/system-prompt.md
+++ b/agents/supervisor/system-prompt.md
@@ -94,11 +94,15 @@ Check the roster. If any peer agent other than you is still in `starting`, `runn
 
 ## When a peer exits without finishing the task
 
-If a specialist you spawned transitions terminal (status=blocked, status=incomplete, or unexpectedly exits) before the task it was given is done, the daemon will send you an urgent broker message — don't ignore it:
+If a specialist you spawned transitions terminal (status=blocked, status=incomplete, or unexpectedly exits) before the task it was given is done, the daemon will send you an urgent broker message — don't ignore it.
 
-1. Read the peer's bridge-stderr log at `.belayer/runs/<session-id>/<agent>/bridge-stderr.log` (tail the last ~50 lines) and skim its last few bridge events for context.
-2. If the exit reason looks transient (seccomp kill, empty-message bridge bug, brief network fail, OOM), respawn the same identity ONCE with refined instructions that cite the prior failure so the peer doesn't repeat it.
-3. If a second spawn also dies terminal before finishing, do NOT self-implement the peer's work. Mark the run blocked, run your persistence_strategy, and escalate.
+The message body includes the last 50 lines of the peer's `bridge-stderr.log`. **Read it.** Diagnose before acting:
+
+- **Missing Python module or missing file under `.belayer/`** (e.g. `No module named hermes_bridge`, `ModuleNotFoundError`, missing `.belayer/agents/` file) → the belayer runtime is damaged; do not respawn. Call `belayer_escalate_to_human` immediately with the stderr tail quoted verbatim.
+- **Recognizable transient error** (network 403, rate limit, OOM, brief connection reset) → respawn the same identity ONCE with refined instructions that cite the prior failure so the peer doesn't repeat it.
+- **Unrecognized error** → respawn once at most, then escalate if the respawn also fails.
+
+If the message body shows `(stderr log missing or empty)`, skim the peer's last few bridge events for context before deciding.
 
 Self-implementation bypasses worktree isolation and review gates — it is forbidden. Your job is to coordinate, not to code.
 

--- a/internal/agentlint/allowlist.txt
+++ b/internal/agentlint/allowlist.txt
@@ -24,6 +24,9 @@ events
 # "belayer bug" — "a belayer bug" noun phrase in LOG_FORMAT.md invariant text
 bug
 
+# "belayer runtime" — prose description of the installed belayer runtime environment
+runtime
+
 # ---------------------------------------------------------------------------
 # Underscore-form: YAML field names that look like tool names
 # ---------------------------------------------------------------------------

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -620,12 +620,22 @@ func (d *Daemon) watchBridgeExit(run store.AgentRun, proc *bridge.Process) {
 
 		// Notify supervisor.
 		if run.Name != "supervisor" {
+			// Reconstruct the run directory for this agent. If the agent was
+			// spawned on a branch it has a worktree; otherwise it uses Workdir.
+			runBase := run.Workdir
+			if run.WorktreePath != "" {
+				runBase = run.WorktreePath
+			}
+			stderrPath := filepath.Join(runBase, ".belayer", "runs", run.SessionID, run.Name, "bridge-stderr.log")
+			stderrTail := bridgelog.TailLines(stderrPath, 50)
+			content := fmt.Sprintf("%s bridge exited unexpectedly (exit_err: %v). Marked blocked.\n\nLast 50 lines of bridge-stderr.log:\n%s",
+				run.Name, exitErr, stderrTail)
 			msg := broker.Message{
 				SessionID:   run.SessionID,
 				SenderID:    run.Name,
 				RecipientID: "supervisor",
 				Type:        broker.MessageStateChange,
-				Content:     run.Name + " bridge process exited unexpectedly and was marked blocked",
+				Content:     content,
 				Urgent:      true,
 				Timestamp:   time.Now().UTC(),
 			}

--- a/internal/daemon/bridgelog/tail.go
+++ b/internal/daemon/bridgelog/tail.go
@@ -1,0 +1,63 @@
+package bridgelog
+
+import (
+	"bufio"
+	"log"
+	"os"
+	"strings"
+)
+
+// TailLines returns the last n lines of the file at path as a single string
+// with newlines between lines. It returns a sentinel string on any error
+// (including ENOENT) and on an empty file, with debug logging.
+//
+// Implementation uses a ring-buffer over a bufio.Scanner so it handles
+// files of any size without loading the full content into memory; for
+// the typical bridge-stderr.log (<10 MB) this is more than adequate.
+func TailLines(path string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("bridgelog.TailLines: %s: file not found", path)
+		} else {
+			log.Printf("bridgelog.TailLines: %s: open: %v", path, err)
+		}
+		return "(stderr log missing or empty)"
+	}
+	defer f.Close()
+
+	// Ring buffer of the last n lines seen.
+	ring := make([]string, n)
+	head := 0  // next write position
+	count := 0 // total lines seen
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		ring[head%n] = scanner.Text()
+		head++
+		count++
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("bridgelog.TailLines: %s: scan: %v", path, err)
+		return "(stderr log missing or empty)"
+	}
+	if count == 0 {
+		log.Printf("bridgelog.TailLines: %s: file is empty", path)
+		return "(stderr log missing or empty)"
+	}
+
+	// Reconstruct in order.
+	take := count
+	if take > n {
+		take = n
+	}
+	lines := make([]string, take)
+	start := head - take
+	for i := 0; i < take; i++ {
+		lines[i] = ring[(start+i)%n]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/daemon/bridgelog/tail_test.go
+++ b/internal/daemon/bridgelog/tail_test.go
@@ -1,0 +1,89 @@
+package bridgelog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTailLines_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	got := TailLines(filepath.Join(dir, "does-not-exist.log"), 50)
+	if got != "(stderr log missing or empty)" {
+		t.Fatalf("missing file: want sentinel, got %q", got)
+	}
+}
+
+func TestTailLines_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.log")
+	if err := os.WriteFile(path, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := TailLines(path, 50)
+	if got != "(stderr log missing or empty)" {
+		t.Fatalf("empty file: want sentinel, got %q", got)
+	}
+}
+
+func TestTailLines_FewerLinesThanN(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "short.log")
+	lines := []string{"line1", "line2", "line3"}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := TailLines(path, 50)
+	want := strings.Join(lines, "\n")
+	if got != want {
+		t.Fatalf("short file: got %q, want %q", got, want)
+	}
+}
+
+func TestTailLines_ExactlyNLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "exact.log")
+	n := 5
+	lines := make([]string, n)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line%d", i+1)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := TailLines(path, n)
+	want := strings.Join(lines, "\n")
+	if got != want {
+		t.Fatalf("exact N lines: got %q, want %q", got, want)
+	}
+}
+
+func TestTailLines_MoreThanNLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.log")
+	total := 200
+	n := 50
+	all := make([]string, total)
+	for i := range all {
+		all[i] = fmt.Sprintf("line%d", i+1)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(all, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := TailLines(path, n)
+	gotLines := strings.Split(got, "\n")
+	if len(gotLines) != n {
+		t.Fatalf("want %d lines, got %d", n, len(gotLines))
+	}
+	// Last line must be the last line of the file.
+	if gotLines[n-1] != fmt.Sprintf("line%d", total) {
+		t.Fatalf("last line: got %q, want %q", gotLines[n-1], fmt.Sprintf("line%d", total))
+	}
+	// First line of the tail must be line(total-n+1).
+	wantFirst := fmt.Sprintf("line%d", total-n+1)
+	if gotLines[0] != wantFirst {
+		t.Fatalf("first tail line: got %q, want %q", gotLines[0], wantFirst)
+	}
+}


### PR DESCRIPTION
## Summary

- Addresses Gap 13 from retro/VARIANCE_REPORT.md (run 8): `backend-dev-fix` and `web-dev-fix` both exited in <15ms with `No module named hermes_bridge` in their bridge-stderr.log; supervisor received the generic "bridge exited" message, never read stderr, and sat idle for 25m.
- `watchBridgeExit` now tails the last 50 lines of `bridge-stderr.log` and embeds them directly in the broker interrupt sent to supervisor, so no manual file navigation is required.
- New `bridgelog.TailLines(path, n)` helper (ring-buffer scanner, graceful ENOENT/empty handling) with 5 unit tests.
- Supervisor triage rules updated: escalate immediately on missing-module errors (runtime damage — do not respawn), respawn once on transient errors, respawn-then-escalate on unrecognized errors.

## Test plan

- [ ] `go build ./cmd/belayer` passes
- [ ] `go test ./...` passes (all packages green)
- [ ] `TestTailLines_*` (5 cases): missing file, empty file, <N lines, exactly N lines, >N lines
- [ ] Manual: spawn a bridge with broken hermes_bridge install; confirm supervisor interrupt message contains the `ModuleNotFoundError` traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)