### PR TITLE
feat(roster): flag completions with destructive shell actions

### DIFF
--- a/agents/pm/system-prompt.md
+++ b/agents/pm/system-prompt.md
@@ -25,6 +25,10 @@ Examples of good rejection reasons:
 - *Exit condition:* "Exit condition 'A pull request is open against the default branch' — `gh pr list --head $(git branch --show-current)` returns zero rows."
 - *Exit condition:* "Exit condition 'Tests pass' — `pnpm test` exited non-zero with 3 failures in `apps/web/test/toolbar.test.tsx`."
 
+## Destructive-action flag
+
+Agents that completed with the destructive-action flag (status shown as `complete⚠` in the roster) must be treated as adversarial — verify the workspace state matches spec by direct inspection, not via the agent's summary. Check git status, directory contents, and database state directly. The agent may have nuked its own workspace before reporting completion.
+
 ## What you don't do
 
 You are not a code reviewer. Style, naming, and architecture are the reviewer's job. You care about one thing: did the agents build what the spec says, and did they land it the way the project requires?

--- a/agents/supervisor/system-prompt.md
+++ b/agents/supervisor/system-prompt.md
@@ -92,6 +92,8 @@ register the artifact, report incomplete again and it will go through.
 
 Check the roster. If any peer agent other than you is still in `starting`, `running`, or `pending_verification`, wait for them to finish or message them for a final report; if they appear hung, escalate rather than requesting completion. PM approval is terminal: the daemon shuts down every live bridge when the session is marked complete, so approving while a peer is mid-work discards their partial output and emits a `completion_approved_with_busy_agents` warning. If you are genuinely done, the roster should be quiet.
 
+If a peer's roster status carries a destructive-action flag (e.g., `complete⚠`), do not trust the completion state. Inspect the peer's last actions before proceeding to review/QA — the agent may have corrupted its workspace before exiting.
+
 ## When a peer exits without finishing the task
 
 If a specialist you spawned transitions terminal (status=blocked, status=incomplete, or unexpectedly exits) before the task it was given is done, the daemon will send you an urgent broker message — don't ignore it.

--- a/internal/cli/nightshift.go
+++ b/internal/cli/nightshift.go
@@ -64,6 +64,7 @@ func newSpawnCmd() *cobra.Command {
 
 func newRosterCmd() *cobra.Command {
 	var session, socket string
+	var verbose bool
 	cmd := &cobra.Command{
 		Use:   "roster",
 		Short: "List active agents in the current session",
@@ -78,9 +79,24 @@ func newRosterCmd() *cobra.Command {
 				return fmt.Errorf("roster: %w", err)
 			}
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
-			fmt.Fprintln(w, "NAME\tROLE\tPROFILE\tSTATUS\tTRANSPORT")
-			for _, run := range runs {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", run.Name, run.Role, run.Profile, run.Status, run.Transport)
+			if verbose {
+				fmt.Fprintln(w, "NAME\tROLE\tPROFILE\tSTATUS\tTRANSPORT\tDESTRUCTIVE\tLAST_CMD")
+				for _, run := range runs {
+					status := rosterStatus(run)
+					lastCmd := run.LastDestructiveCmd
+					if lastCmd == "" {
+						lastCmd = "-"
+					}
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%s\n",
+						run.Name, run.Role, run.Profile, status, run.Transport,
+						run.DestructiveActions, lastCmd)
+				}
+			} else {
+				fmt.Fprintln(w, "NAME\tROLE\tPROFILE\tSTATUS\tTRANSPORT")
+				for _, run := range runs {
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+						run.Name, run.Role, run.Profile, rosterStatus(run), run.Transport)
+				}
 			}
 			w.Flush()
 			return nil
@@ -88,7 +104,19 @@ func newRosterCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&session, "session", "", "Session ID (required if BELAYER_SESSION_ID not set)")
 	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show destructive action count and last command snippet")
 	return cmd
+}
+
+// rosterStatus returns the display status string for a roster row.
+// When an agent has recorded destructive actions, a warning suffix (⚠) is
+// appended so supervisors and PM agents can distinguish a clean completion
+// from one that nuked its own workspace first. See Gap 16 in VARIANCE_REPORT.md.
+func rosterStatus(run store.AgentRun) string {
+	if run.DestructiveActions > 0 {
+		return run.Status + "⚠"
+	}
+	return run.Status
 }
 
 func newFinishCmd() *cobra.Command {

--- a/internal/cli/nightshift.go
+++ b/internal/cli/nightshift.go
@@ -4,11 +4,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/donovan-yohan/belayer/internal/store"
 	"github.com/spf13/cobra"
 )
+
+// ansiEscapeRe matches ANSI terminal escape sequences.
+var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// sanitizeCmdForDisplay strips control characters and ANSI escapes from s so it
+// is safe to pass to tabwriter without corrupting column alignment.
+func sanitizeCmdForDisplay(s string) string {
+	s = ansiEscapeRe.ReplaceAllString(s, "")
+	s = strings.NewReplacer("\t", " ", "\n", " ", "\r", " ").Replace(s)
+	return s
+}
 
 func resolveAgentID(flagVal string) (string, error) {
 	if flagVal != "" {
@@ -83,7 +96,7 @@ func newRosterCmd() *cobra.Command {
 				fmt.Fprintln(w, "NAME\tROLE\tPROFILE\tSTATUS\tTRANSPORT\tDESTRUCTIVE\tLAST_CMD")
 				for _, run := range runs {
 					status := rosterStatus(run)
-					lastCmd := run.LastDestructiveCmd
+					lastCmd := sanitizeCmdForDisplay(run.LastDestructiveCmd)
 					if lastCmd == "" {
 						lastCmd = "-"
 					}

--- a/internal/daemon/bridge_events.go
+++ b/internal/daemon/bridge_events.go
@@ -102,16 +102,20 @@ func (d *Daemon) handleBridgeToolStarted(sessionID, agentName string, data map[s
 		return
 	}
 
+	previewSnippet := preview
+	if len(previewSnippet) > 200 {
+		previewSnippet = previewSnippet[:200]
+	}
 	_ = d.store.LogEvent(store.SessionEvent{
 		SessionID: sessionID,
 		Type:      "warning:destructive_tool_call",
 		Data: mustJSON(map[string]string{
 			"agent":   agentName,
 			"kind":    kind,
-			"preview": preview,
+			"preview": previewSnippet,
 		}),
 	})
-	log.Printf("WARNING: session %s agent %s executed destructive command (kind=%s): %s", sessionID, agentName, kind, preview)
+	log.Printf("WARNING: session %s agent %s executed destructive command (kind=%s): %s", sessionID, agentName, kind, previewSnippet)
 }
 
 func (d *Daemon) handleBridgeFinished(sessionID, agentName string, data map[string]any) {

--- a/internal/daemon/bridge_events.go
+++ b/internal/daemon/bridge_events.go
@@ -53,9 +53,11 @@ func (d *Daemon) processBridgeEvent(sessionID, eventType, data string) {
 		d.handleBridgeCompletionApproved(sessionID, agentName, eventData)
 	case "bridge:completion_rejected":
 		d.handleBridgeCompletionRejected(sessionID, agentName, eventData)
+	case "bridge:tool_started":
+		d.handleBridgeToolStarted(sessionID, agentName, eventData)
 	}
-	// bridge:step_completed, bridge:heartbeat, bridge:tool_started,
-	// bridge:tool_completed, bridge:status_change, bridge:turn_usage,
+	// bridge:step_completed, bridge:heartbeat, bridge:tool_completed,
+	// bridge:status_change, bridge:turn_usage,
 	// bridge:session_usage — log-only, no side effects needed.
 }
 
@@ -64,6 +66,52 @@ func (d *Daemon) handleBridgeStarted(sessionID, agentName string, data map[strin
 	if hermesSessionID != "" {
 		_ = d.store.UpdateAgentRunHermesSessionID(sessionID, agentName, hermesSessionID)
 	}
+}
+
+// handleBridgeToolStarted inspects terminal tool calls for destructive shell
+// patterns. When detected, it increments the agent run's destructive_actions
+// counter and records the command snippet for later surfacing in roster output.
+func (d *Daemon) handleBridgeToolStarted(sessionID, agentName string, data map[string]any) {
+	// Only inspect terminal / bash tool invocations.
+	toolName, _ := data["tool"].(string)
+	if toolName == "" {
+		toolName, _ = data["name"].(string)
+	}
+	// Hermes terminal tool names can vary by profile; we check common names.
+	// input_preview is always present for standard+ log levels.
+	switch toolName {
+	case "terminal", "bash", "shell", "run_command", "execute_command", "computer":
+		// These are the tools that execute shell commands.
+	default:
+		// Not a terminal tool; skip destructive check.
+		return
+	}
+
+	preview, _ := data["input_preview"].(string)
+	if preview == "" {
+		return
+	}
+
+	kind, ok := DetectDestructive(preview)
+	if !ok {
+		return
+	}
+
+	if err := d.store.UpdateAgentRunDestructive(sessionID, agentName, kind, preview); err != nil {
+		log.Printf("WARNING: handleBridgeToolStarted: failed to record destructive action for %s in session %s: %v", agentName, sessionID, err)
+		return
+	}
+
+	_ = d.store.LogEvent(store.SessionEvent{
+		SessionID: sessionID,
+		Type:      "warning:destructive_tool_call",
+		Data: mustJSON(map[string]string{
+			"agent":   agentName,
+			"kind":    kind,
+			"preview": preview,
+		}),
+	})
+	log.Printf("WARNING: session %s agent %s executed destructive command (kind=%s): %s", sessionID, agentName, kind, preview)
 }
 
 func (d *Daemon) handleBridgeFinished(sessionID, agentName string, data map[string]any) {

--- a/internal/daemon/bridge_events_test.go
+++ b/internal/daemon/bridge_events_test.go
@@ -221,6 +221,85 @@ func TestUnknownBridgeEventDoesNotError(t *testing.T) {
 	}
 }
 
+// TestBridgeToolStartedDestructiveDetection verifies that a bridge:tool_started
+// event with a destructive terminal command increments the destructive_actions
+// counter on the agent run and records the command snippet.
+func TestBridgeToolStartedDestructiveDetection(t *testing.T) {
+	d := testDaemon(t)
+	sessionID := setupSessionWithAgents(t, d, "backend-dev")
+
+	// Non-destructive terminal call — should not increment counter.
+	rr := postBridgeEvent(t, d, sessionID, "bridge:tool_started", map[string]any{
+		"agent":         "backend-dev",
+		"tool":          "terminal",
+		"input_preview": "ls /workspace",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("non-destructive: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	run, err := d.store.GetAgentRun(sessionID, "backend-dev")
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if run.DestructiveActions != 0 {
+		t.Fatalf("expected 0 destructive actions after non-destructive cmd, got %d", run.DestructiveActions)
+	}
+
+	// Destructive terminal call — rm -rf
+	rr = postBridgeEvent(t, d, sessionID, "bridge:tool_started", map[string]any{
+		"agent":         "backend-dev",
+		"tool":          "terminal",
+		"input_preview": "rm -rf /workspace/.belayer",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("destructive rm -rf: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	run, err = d.store.GetAgentRun(sessionID, "backend-dev")
+	if err != nil {
+		t.Fatalf("GetAgentRun after destructive: %v", err)
+	}
+	if run.DestructiveActions != 1 {
+		t.Fatalf("expected 1 destructive action after rm -rf, got %d", run.DestructiveActions)
+	}
+	if run.LastDestructiveCmd == "" {
+		t.Fatal("expected LastDestructiveCmd to be set")
+	}
+
+	// Second destructive call — counter should increment to 2.
+	rr = postBridgeEvent(t, d, sessionID, "bridge:tool_started", map[string]any{
+		"agent":         "backend-dev",
+		"tool":          "bash",
+		"input_preview": "git reset --hard HEAD",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("destructive git reset: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	run, err = d.store.GetAgentRun(sessionID, "backend-dev")
+	if err != nil {
+		t.Fatalf("GetAgentRun after second destructive: %v", err)
+	}
+	if run.DestructiveActions != 2 {
+		t.Fatalf("expected 2 destructive actions, got %d", run.DestructiveActions)
+	}
+
+	// Non-terminal tool (Write) — destructive pattern in input_preview should be ignored.
+	rr = postBridgeEvent(t, d, sessionID, "bridge:tool_started", map[string]any{
+		"agent":         "backend-dev",
+		"tool":          "write_file",
+		"input_preview": "rm -rf /would-be-bad-if-executed",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("non-terminal tool: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	run, err = d.store.GetAgentRun(sessionID, "backend-dev")
+	if err != nil {
+		t.Fatalf("GetAgentRun after non-terminal: %v", err)
+	}
+	if run.DestructiveActions != 2 {
+		t.Fatalf("expected counter still 2 for non-terminal tool, got %d", run.DestructiveActions)
+	}
+}
+
 // TestBridgeEventWithoutAgentFieldDoesNotPanic verifies that bridge events
 // missing the agent field are silently ignored without panicking.
 func TestBridgeEventWithoutAgentFieldDoesNotPanic(t *testing.T) {

--- a/internal/daemon/destructive.go
+++ b/internal/daemon/destructive.go
@@ -1,0 +1,64 @@
+package daemon
+
+import "regexp"
+
+// DetectDestructive reports whether cmd matches a known destructive shell
+// pattern. It returns the matched kind (e.g. "rm-rf") and ok=true on a match.
+//
+// Detection is whole-line regex applied to the raw command string. This is
+// intentionally simple: we do NOT attempt to parse shell quoting, so a command
+// like `echo 'rm -rf /'` will be flagged as "rm-rf". That is an accepted
+// false-positive trade-off; the flag surfaces a warning, not a hard block.
+// Document the limitation here so future readers understand the boundary.
+//
+// Patterns are case-insensitive where the commands themselves are
+// case-insensitive (SQL keywords, git sub-commands). rm/dd are lowercase-only
+// on Unix.
+var destructivePatterns = []struct {
+	kind string
+	re   *regexp.Regexp
+}{
+	// rm -rf / rm -Rf / rm -fr / rm -fR — any two-char flag combo with r (or R) and f.
+	// Requires the flags to be in a single token starting with '-'.
+	// Anchored to a word boundary so "form" doesn't match.
+	{
+		kind: "rm-rf",
+		re:   regexp.MustCompile(`(?i)\brm\s+-[rRfF]*[rR][rRfF]*\b`),
+	},
+	// git reset --hard
+	{
+		kind: "git-reset-hard",
+		re:   regexp.MustCompile(`(?i)\bgit\s+reset\s+--hard\b`),
+	},
+	// git push --force / git push -f / git push --force-with-lease
+	{
+		kind: "git-force-push",
+		re:   regexp.MustCompile(`(?i)\bgit\s+push\b.*\s(--force|--force-with-lease|-f)\b`),
+	},
+	// git clean -f / -fd / -fx / -fX (any combo starting with -f containing d/x/X)
+	{
+		kind: "git-clean",
+		re:   regexp.MustCompile(`(?i)\bgit\s+clean\s+-[a-zA-Z]*f[a-zA-Z]*\b`),
+	},
+	// SQL: DROP TABLE / DROP DATABASE / TRUNCATE TABLE (case-insensitive)
+	{
+		kind: "sql-drop",
+		re:   regexp.MustCompile(`(?i)\b(DROP\s+(TABLE|DATABASE)|TRUNCATE\s+TABLE)\b`),
+	},
+	// dd with of=/dev/ — writing directly to a device node
+	{
+		kind: "dd-to-device",
+		re:   regexp.MustCompile(`\bdd\b.*\bof=/dev/`),
+	},
+}
+
+// DetectDestructive checks cmd against all destructive patterns and returns
+// the first matched kind and ok=true. Returns ("", false) if no pattern matches.
+func DetectDestructive(cmd string) (kind string, ok bool) {
+	for _, p := range destructivePatterns {
+		if p.re.MatchString(cmd) {
+			return p.kind, true
+		}
+	}
+	return "", false
+}

--- a/internal/daemon/destructive.go
+++ b/internal/daemon/destructive.go
@@ -18,27 +18,29 @@ var destructivePatterns = []struct {
 	kind string
 	re   *regexp.Regexp
 }{
-	// rm -rf / rm -Rf / rm -fr / rm -fR — any two-char flag combo with r (or R) and f.
-	// Requires the flags to be in a single token starting with '-'.
+	// rm -rf / rm -Rf / rm -fr / rm -fR — requires BOTH r and f in the same flag token.
+	// Accepts any ordering (rf, fr, -rfv, etc.) but rejects -r or -f alone.
 	// Anchored to a word boundary so "form" doesn't match.
 	{
 		kind: "rm-rf",
-		re:   regexp.MustCompile(`(?i)\brm\s+-[rRfF]*[rR][rRfF]*\b`),
+		re:   regexp.MustCompile(`(?i)\brm\s+-(?:[a-zA-Z]*r[a-zA-Z]*f|[a-zA-Z]*f[a-zA-Z]*r)[a-zA-Z]*\b`),
 	},
-	// git reset --hard
+	// git reset --hard — also matches git -C <repo> reset --hard
 	{
 		kind: "git-reset-hard",
-		re:   regexp.MustCompile(`(?i)\bgit\s+reset\s+--hard\b`),
+		re:   regexp.MustCompile(`(?i)\bgit\s+(?:-C\s+\S+\s+)?reset\s+--hard\b`),
 	},
 	// git push --force / git push -f / git push --force-with-lease
+	// Also matches git -C <repo> push ...
 	{
 		kind: "git-force-push",
-		re:   regexp.MustCompile(`(?i)\bgit\s+push\b.*\s(--force|--force-with-lease|-f)\b`),
+		re:   regexp.MustCompile(`(?i)\bgit\s+(?:-C\s+\S+\s+)?push\b.*\s(--force|--force-with-lease|-f)\b`),
 	},
-	// git clean -f / -fd / -fx / -fX (any combo starting with -f containing d/x/X)
+	// git clean -f / -fd / -fx / -fX (any combo containing f)
+	// Also matches git -C <repo> clean ...
 	{
 		kind: "git-clean",
-		re:   regexp.MustCompile(`(?i)\bgit\s+clean\s+-[a-zA-Z]*f[a-zA-Z]*\b`),
+		re:   regexp.MustCompile(`(?i)\bgit\s+(?:-C\s+\S+\s+)?clean\s+-[a-zA-Z]*f[a-zA-Z]*\b`),
 	},
 	// SQL: DROP TABLE / DROP DATABASE / TRUNCATE TABLE (case-insensitive)
 	{

--- a/internal/daemon/destructive_test.go
+++ b/internal/daemon/destructive_test.go
@@ -1,0 +1,80 @@
+package daemon
+
+import "testing"
+
+func TestDetectDestructive(t *testing.T) {
+	positives := []struct {
+		cmd  string
+		kind string
+	}{
+		// rm-rf variants
+		{"rm -rf /tmp/foo", "rm-rf"},
+		{"rm -Rf /tmp/foo", "rm-rf"},
+		{"rm -fr /tmp/foo", "rm-rf"},
+		{"rm -fR /workspace/.belayer", "rm-rf"},
+		{"sudo rm -rf /", "rm-rf"},
+		// git reset --hard
+		{"git reset --hard", "git-reset-hard"},
+		{"git reset --hard HEAD~1", "git-reset-hard"},
+		{"GIT reset --hard", "git-reset-hard"}, // case-insensitive
+		// git force-push
+		{"git push --force", "git-force-push"},
+		{"git push -f", "git-force-push"},
+		{"git push origin main --force", "git-force-push"},
+		{"git push --force-with-lease", "git-force-push"},
+		// git clean
+		{"git clean -f", "git-clean"},
+		{"git clean -fd", "git-clean"},
+		{"git clean -fx", "git-clean"},
+		{"git clean -fdx", "git-clean"},
+		// sql-drop
+		{"DROP TABLE users", "sql-drop"},
+		{"DROP DATABASE mydb", "sql-drop"},
+		{"TRUNCATE TABLE sessions", "sql-drop"},
+		{"drop table foo", "sql-drop"}, // lower case
+		// dd to device
+		{"dd if=/dev/zero of=/dev/sda", "dd-to-device"},
+		{"dd if=disk.img of=/dev/sdb bs=4M", "dd-to-device"},
+	}
+
+	for _, tc := range positives {
+		kind, ok := DetectDestructive(tc.cmd)
+		if !ok {
+			t.Errorf("expected match for %q, got no match", tc.cmd)
+			continue
+		}
+		if kind != tc.kind {
+			t.Errorf("cmd=%q: expected kind %q, got %q", tc.cmd, tc.kind, kind)
+		}
+	}
+
+	negatives := []string{
+		// rm without -r flag
+		"rm file.txt",
+		"rm -f file.txt",
+		// git reset without --hard
+		"git reset",
+		"git reset HEAD",
+		"git reset --soft HEAD~1",
+		// git push without force
+		"git push origin main",
+		"git push",
+		// git clean without -f
+		"git clean -n",
+		// dd writing to a file, not a device
+		"dd if=/dev/zero of=disk.img bs=4M count=1",
+		// SQL that is not DROP/TRUNCATE
+		"SELECT * FROM users",
+		"CREATE TABLE foo (id int)",
+		// Quoted strings (known false-negative; accepted trade-off)
+		// The following would be a false-positive — document that here.
+		// "echo 'rm -rf /'" would match; that is the accepted limitation.
+	}
+
+	for _, cmd := range negatives {
+		_, ok := DetectDestructive(cmd)
+		if ok {
+			t.Errorf("unexpected match for negative case %q", cmd)
+		}
+	}
+}

--- a/internal/daemon/destructive_test.go
+++ b/internal/daemon/destructive_test.go
@@ -13,20 +13,22 @@ func TestDetectDestructive(t *testing.T) {
 		{"rm -fr /tmp/foo", "rm-rf"},
 		{"rm -fR /workspace/.belayer", "rm-rf"},
 		{"sudo rm -rf /", "rm-rf"},
-		// git reset --hard
+		// git reset --hard (with and without -C prefix)
 		{"git reset --hard", "git-reset-hard"},
 		{"git reset --hard HEAD~1", "git-reset-hard"},
-		{"GIT reset --hard", "git-reset-hard"}, // case-insensitive
+		{"GIT reset --hard", "git-reset-hard"},              // case-insensitive
+		{"git -C /tmp/repo reset --hard", "git-reset-hard"}, // -C <repo> prefix
 		// git force-push
 		{"git push --force", "git-force-push"},
 		{"git push -f", "git-force-push"},
 		{"git push origin main --force", "git-force-push"},
 		{"git push --force-with-lease", "git-force-push"},
-		// git clean
+		// git clean (with and without -C prefix)
 		{"git clean -f", "git-clean"},
 		{"git clean -fd", "git-clean"},
 		{"git clean -fx", "git-clean"},
 		{"git clean -fdx", "git-clean"},
+		{"git -C /foo clean -fdx", "git-clean"}, // -C <repo> prefix
 		// sql-drop
 		{"DROP TABLE users", "sql-drop"},
 		{"DROP DATABASE mydb", "sql-drop"},
@@ -49,9 +51,11 @@ func TestDetectDestructive(t *testing.T) {
 	}
 
 	negatives := []string{
-		// rm without -r flag
+		// rm without both r and f in the same flag token
 		"rm file.txt",
 		"rm -f file.txt",
+		"rm -r /tmp/foo",          // -r alone should NOT match
+		"rm -r -f /tmp/foo",       // space-separated -r and -f should NOT match
 		// git reset without --hard
 		"git reset",
 		"git reset HEAD",
@@ -66,9 +70,9 @@ func TestDetectDestructive(t *testing.T) {
 		// SQL that is not DROP/TRUNCATE
 		"SELECT * FROM users",
 		"CREATE TABLE foo (id int)",
-		// Quoted strings (known false-negative; accepted trade-off)
-		// The following would be a false-positive — document that here.
-		// "echo 'rm -rf /'" would match; that is the accepted limitation.
+		// Quoted strings: known false-positive; accepted trade-off.
+		// "echo 'rm -rf /'" matches the regex even though the command is non-destructive.
+		// Detection is whole-line and does not parse shell quoting.
 	}
 
 	for _, cmd := range negatives {

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -135,6 +135,12 @@ func Migrate(db *sql.DB) error {
 	if err := addColumnIfNotExists(db, "events", "trace_length", "INTEGER"); err != nil {
 		return err
 	}
+	if err := addColumnIfNotExists(db, "agent_runs", "destructive_actions", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+	if err := addColumnIfNotExists(db, "agent_runs", "last_destructive_cmd", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -62,6 +62,15 @@ type AgentRun struct {
 	Status          string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
+
+	// DestructiveActions is the count of destructive shell commands observed
+	// for this agent run (e.g. rm -rf, git reset --hard). Non-zero means the
+	// agent mutated the environment in a potentially irreversible way; a
+	// complete status with this set should be treated with suspicion.
+	DestructiveActions int `json:"destructive_actions,omitempty"`
+	// LastDestructiveCmd is the most recent destructive command string,
+	// truncated to 200 chars.
+	LastDestructiveCmd string `json:"last_destructive_cmd,omitempty"`
 }
 
 // Message represents a persistent message stored for pull-based delivery.
@@ -277,12 +286,12 @@ func (s *Store) CreateAgentRun(run AgentRun) (string, error) {
 // GetAgentRun retrieves a single agent run by session + name.
 func (s *Store) GetAgentRun(sessionID, name string) (AgentRun, error) {
 	row := s.db.QueryRow(
-		`SELECT id, session_id, name, role, profile, repo_scope, workdir, branch, worktree_path, transport, tmux_session, hermes_session_id, status, created_at, updated_at
+		`SELECT id, session_id, name, role, profile, repo_scope, workdir, branch, worktree_path, transport, tmux_session, hermes_session_id, status, created_at, updated_at, COALESCE(destructive_actions,0), COALESCE(last_destructive_cmd,'')
 		 FROM agent_runs WHERE session_id = ? AND name = ?`, sessionID, name,
 	)
 	var run AgentRun
 	var createdAt, updatedAt string
-	err := row.Scan(&run.ID, &run.SessionID, &run.Name, &run.Role, &run.Profile, &run.RepoScope, &run.Workdir, &run.Branch, &run.WorktreePath, &run.Transport, &run.TmuxSession, &run.HermesSessionID, &run.Status, &createdAt, &updatedAt)
+	err := row.Scan(&run.ID, &run.SessionID, &run.Name, &run.Role, &run.Profile, &run.RepoScope, &run.Workdir, &run.Branch, &run.WorktreePath, &run.Transport, &run.TmuxSession, &run.HermesSessionID, &run.Status, &createdAt, &updatedAt, &run.DestructiveActions, &run.LastDestructiveCmd)
 	if err != nil {
 		return AgentRun{}, fmt.Errorf("store: get agent run: %w", err)
 	}
@@ -294,7 +303,7 @@ func (s *Store) GetAgentRun(sessionID, name string) (AgentRun, error) {
 // ListAgentRuns returns all agent runs for a session ordered by created_at.
 func (s *Store) ListAgentRuns(sessionID string) ([]AgentRun, error) {
 	rows, err := s.db.Query(
-		`SELECT id, session_id, name, role, profile, repo_scope, workdir, branch, worktree_path, transport, tmux_session, hermes_session_id, status, created_at, updated_at
+		`SELECT id, session_id, name, role, profile, repo_scope, workdir, branch, worktree_path, transport, tmux_session, hermes_session_id, status, created_at, updated_at, COALESCE(destructive_actions,0), COALESCE(last_destructive_cmd,'')
 		 FROM agent_runs WHERE session_id = ? ORDER BY created_at ASC`, sessionID,
 	)
 	if err != nil {
@@ -306,7 +315,7 @@ func (s *Store) ListAgentRuns(sessionID string) ([]AgentRun, error) {
 	for rows.Next() {
 		var run AgentRun
 		var createdAt, updatedAt string
-		if err := rows.Scan(&run.ID, &run.SessionID, &run.Name, &run.Role, &run.Profile, &run.RepoScope, &run.Workdir, &run.Branch, &run.WorktreePath, &run.Transport, &run.TmuxSession, &run.HermesSessionID, &run.Status, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&run.ID, &run.SessionID, &run.Name, &run.Role, &run.Profile, &run.RepoScope, &run.Workdir, &run.Branch, &run.WorktreePath, &run.Transport, &run.TmuxSession, &run.HermesSessionID, &run.Status, &createdAt, &updatedAt, &run.DestructiveActions, &run.LastDestructiveCmd); err != nil {
 			return nil, fmt.Errorf("store: list agent runs scan: %w", err)
 		}
 		run.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdAt)
@@ -372,6 +381,27 @@ func (s *Store) UpdateAgentRunHermesSessionID(sessionID, name, hermesSessionID s
 	)
 	if err != nil {
 		return fmt.Errorf("store: update agent run hermes session id: %w", err)
+	}
+	return nil
+}
+
+// UpdateAgentRunDestructive atomically increments destructive_actions and
+// records the most recent destructive command (truncated to 200 chars).
+// kind is the pattern kind (e.g. "rm-rf"); cmd is the raw command string.
+func (s *Store) UpdateAgentRunDestructive(sessionID, name, kind, cmd string) error {
+	if len(cmd) > 200 {
+		cmd = cmd[:200]
+	}
+	_, err := s.db.Exec(
+		`UPDATE agent_runs
+		 SET destructive_actions = COALESCE(destructive_actions, 0) + 1,
+		     last_destructive_cmd = ?,
+		     updated_at = ?
+		 WHERE session_id = ? AND name = ?`,
+		cmd, time.Now().UTC(), sessionID, name,
+	)
+	if err != nil {
+		return fmt.Errorf("store: update agent run destructive (%s): %w", kind, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Addresses Gap 16 from VARIANCE_REPORT.md (run 8 — backend-dev-mvp exited `status=complete` right after `rm -rf /workspace/.belayer`; roster label was indistinguishable from healthy completion)
- Adds `DetectDestructive(cmd string) (kind string, ok bool)` in `internal/daemon/destructive.go` with whole-line regex patterns for 6 destructive categories
- Extends `store.AgentRun` with `DestructiveActions` counter and `LastDestructiveCmd` (200-char cap); schema migration via `addColumnIfNotExists`
- Hooks `bridge:tool_started` events: when `tool` is a terminal-type and `input_preview` matches a destructive pattern, increments counter and emits `warning:destructive_tool_call` event
- `belayer roster` now appends `⚠` to status when `DestructiveActions > 0`; `--verbose` flag shows count + command snippet
- Supervisor and PM system prompts updated with handling instructions for `complete⚠`

## Test plan

- [ ] `go test ./internal/daemon/... ./internal/store/...` — all pass
- [ ] `TestDetectDestructive` covers all 6 pattern kinds + false-positive cases
- [ ] `TestBridgeToolStartedDestructiveDetection` verifies counter increments for `rm -rf` and `git reset --hard`, non-terminal tools ignored, non-destructive commands ignored
- [ ] Migration: `addColumnIfNotExists` is idempotent — safe on existing databases
- [ ] `go build ./cmd/belayer` green

## Detection regexes

| Kind | Pattern |
|------|---------|
| `rm-rf` | `(?i)\brm\s+-[rRfF]*[rR][rRfF]*\b` |
| `git-reset-hard` | `(?i)\bgit\s+reset\s+--hard\b` |
| `git-force-push` | `(?i)\bgit\s+push\b.*\s(--force\|--force-with-lease\|-f)\b` |
| `git-clean` | `(?i)\bgit\s+clean\s+-[a-zA-Z]*f[a-zA-Z]*\b` |
| `sql-drop` | `(?i)\b(DROP\s+(TABLE\|DATABASE)\|TRUNCATE\s+TABLE)\b` |
| `dd-to-device` | `\bdd\b.*\bof=/dev/` |

**Known false-positive**: `echo 'rm -rf /'` will trigger `rm-rf` (whole-line, no shell quoting parse). Accepted trade-off — documented in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Roster command now supports `--verbose` flag, displaying additional columns for destructive action counts and last executed destructive command in tabular output.
  * Introduced destructive-action flag (⚠) for agents; flagged agents require direct workspace state verification rather than relying on completion summaries.

* **Documentation**
  * Updated system prompts with new verification procedures for handling agents marked with destructive-action flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->