### PR TITLE
feat(bridge): suppress OpenRouter metadata probe on sandboxed bridges

### DIFF
--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -421,6 +421,31 @@ flowchart TB
 
 The stdin pipe is push (daemon writes when it needs to interrupt). The HTTP channel is pull (bridge calls when it has something to send or needs to check for messages).
 
+### Bridge environment toggles
+
+The daemon injects environment variables into every bridge subprocess at spawn time (see `internal/bridge/bridge.go:BuildEnv`). Some are config-driven:
+
+#### `HERMES_SKIP_OPENROUTER_PROBE`
+
+Set to `1` by default. Suppresses the `openrouter.ai/api/v1/models` metadata fetch that hermes-agent performs at startup, which causes 20+ proxy-denied `CONNECT` requests per run on clamshell sandboxes where the egress policy does not whitelist `openrouter.ai`.
+
+**When to disable:** Only if your LLM vendor requires OpenRouter metadata at startup (e.g. a routing layer that resolves model IDs via the OpenRouter catalog). To opt out, add the following to `.belayer/config.yaml`:
+
+```yaml
+bridge:
+  skip_openrouter_probe: false
+```
+
+**Upstream dependency:** This env var is a no-op until hermes-agent honours it. The complementary hermes-agent change must add (in `auth.py` or wherever `_fetch_openrouter_models` is called):
+
+```python
+import os
+if os.getenv("HERMES_SKIP_OPENROUTER_PROBE") == "1":
+    return {}
+```
+
+Until that hermes-agent change lands, setting or clearing this env var has no effect. Once it lands, the config default (`skip_openrouter_probe: true`) suppresses the probe for all spawned bridges.
+
 ---
 
 ## Worktree isolation

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -69,8 +69,9 @@ type Config struct {
 	BelayerRoot     string   // directory containing hermes_bridge/ package (for PYTHONPATH)
 	Ephemeral       bool     // true = exit on task completion, false = stay alive for more work
 	BelayerTools    []string // role-specific belayer tools from agent.yaml
-	TranscriptPath  string   // absolute path to per-agent JSONL; empty = capture disabled (standard log level)
-	LogLevel        string   // "standard", "verbose", or "trace"; empty treated as "standard"
+	TranscriptPath      string   // absolute path to per-agent JSONL; empty = capture disabled (standard log level)
+	LogLevel            string   // "standard", "verbose", or "trace"; empty treated as "standard"
+	SkipOpenRouterProbe bool     // when true, injects HERMES_SKIP_OPENROUTER_PROBE=1 to suppress the openrouter metadata fetch at bridge startup
 
 	// WriteRoots is the set of absolute paths the agent is allowed to write to.
 	// When ConfineWrites is true and this slice is non-empty, the bridge
@@ -213,6 +214,9 @@ func BuildEnv(cfg Config) []string {
 		level = "standard"
 	}
 	env = appendEnv(env, "BELAYER_LOG_LEVEL", level)
+	if cfg.SkipOpenRouterProbe {
+		env = appendEnv(env, "HERMES_SKIP_OPENROUTER_PROBE", "1")
+	}
 	if cfg.ConfineWrites && len(cfg.WriteRoots) > 0 {
 		env = appendEnv(env, "BELAYER_WRITE_ROOTS", strings.Join(cfg.WriteRoots, ":"))
 	}

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -685,6 +685,52 @@ func TestBuildEnvHermesAgentPathTrimmed(t *testing.T) {
 	}
 }
 
+// TestBuildEnvSkipOpenRouterProbeInjected verifies that HERMES_SKIP_OPENROUTER_PROBE=1
+// is set when SkipOpenRouterProbe is true, and absent when false.
+func TestBuildEnvSkipOpenRouterProbeInjected(t *testing.T) {
+	base := Config{
+		SessionID:  "sess-probe",
+		AgentID:    "agent-probe",
+		Role:       "implementer",
+		Profile:    "default",
+		SocketPath: "/tmp/probe.sock",
+		RunDir:     t.TempDir(),
+	}
+
+	t.Run("true injects env var", func(t *testing.T) {
+		cfg := base
+		cfg.SkipOpenRouterProbe = true
+		env := BuildEnv(cfg)
+		envMap := envToMap(env)
+		if got, ok := envMap["HERMES_SKIP_OPENROUTER_PROBE"]; !ok {
+			t.Error("expected HERMES_SKIP_OPENROUTER_PROBE to be set when SkipOpenRouterProbe=true")
+		} else if got != "1" {
+			t.Errorf("HERMES_SKIP_OPENROUTER_PROBE = %q, want \"1\"", got)
+		}
+	})
+
+	t.Run("false omits env var", func(t *testing.T) {
+		cfg := base
+		cfg.SkipOpenRouterProbe = false
+		env := BuildEnv(cfg)
+		envMap := envToMap(env)
+		if _, ok := envMap["HERMES_SKIP_OPENROUTER_PROBE"]; ok {
+			t.Error("expected HERMES_SKIP_OPENROUTER_PROBE to be absent when SkipOpenRouterProbe=false")
+		}
+	})
+}
+
+// envToMap converts a KEY=VALUE slice into a map for convenient test lookups.
+func envToMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, e := range env {
+		if idx := strings.IndexByte(e, '='); idx >= 0 {
+			m[e[:idx]] = e[idx+1:]
+		}
+	}
+	return m
+}
+
 // TestBuildEnvPYTHONPATHInteriorEmptySegmentsPassedThrough documents current
 // behavior: BuildEnv does not normalize interior empty segments supplied in
 // the caller's PYTHONPATH. Callers with cwd-sensitive environments must

--- a/internal/bridge/config.go
+++ b/internal/bridge/config.go
@@ -1,0 +1,69 @@
+package bridge
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// ProjectConfig holds the bridge section of .belayer/config.yaml.
+type ProjectConfig struct {
+	// SkipOpenRouterProbe suppresses the HERMES_SKIP_OPENROUTER_PROBE env var
+	// injection when false. Default true: most providers do not need OpenRouter
+	// metadata; suppressing the probe eliminates 20+ proxy-denied CONNECTs per
+	// run when the clamshell egress policy does not whitelist openrouter.ai.
+	//
+	// Set to false only when using a vendor that explicitly requires OpenRouter
+	// metadata at startup (e.g. a routing layer that resolves model IDs via
+	// the OpenRouter catalog).
+	SkipOpenRouterProbe bool `yaml:"skip_openrouter_probe"`
+}
+
+// bridgeConfigFile is the top-level shape of .belayer/config.yaml that we
+// care about — unknown sections are silently ignored by yaml.v3.
+type bridgeConfigFile struct {
+	Bridge bridgeConfigSection `yaml:"bridge"`
+}
+
+// bridgeConfigSection mirrors the yaml shape so we can apply the default
+// before unmarshalling (SkipOpenRouterProbe defaults to true when the key is
+// absent; yaml.v3 zero-initialises missing keys to false, so we pre-set it).
+type bridgeConfigSection struct {
+	SkipOpenRouterProbe *bool `yaml:"skip_openrouter_probe"`
+}
+
+// LoadProjectConfig reads the bridge section from <workdir>/.belayer/config.yaml.
+// If the file does not exist, or the bridge section is absent, it returns the
+// default config (SkipOpenRouterProbe = true). A missing key inside an existing
+// bridge section also defaults to true.
+func LoadProjectConfig(workdir string) (ProjectConfig, error) {
+	defaults := ProjectConfig{
+		SkipOpenRouterProbe: true,
+	}
+	if workdir == "" {
+		return defaults, nil
+	}
+
+	path := filepath.Join(workdir, ".belayer", "config.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return defaults, nil
+		}
+		return defaults, fmt.Errorf("bridge: read config: %w", err)
+	}
+
+	var f bridgeConfigFile
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return defaults, fmt.Errorf("bridge: parse config: %w", err)
+	}
+
+	out := defaults
+	if f.Bridge.SkipOpenRouterProbe != nil {
+		out.SkipOpenRouterProbe = *f.Bridge.SkipOpenRouterProbe
+	}
+	return out, nil
+}

--- a/internal/bridge/config_test.go
+++ b/internal/bridge/config_test.go
@@ -1,0 +1,104 @@
+package bridge
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeConfig writes content into <dir>/.belayer/config.yaml, creating
+// the directory if needed.
+func writeConfig(t *testing.T, dir, content string) {
+	t.Helper()
+	belayerDir := filepath.Join(dir, ".belayer")
+	if err := os.MkdirAll(belayerDir, 0o755); err != nil {
+		t.Fatalf("mkdir .belayer: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(belayerDir, "config.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+}
+
+// TestLoadProjectConfig_DefaultsWhenMissing verifies that a missing
+// config.yaml returns SkipOpenRouterProbe=true.
+func TestLoadProjectConfig_DefaultsWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig: %v", err)
+	}
+	if !cfg.SkipOpenRouterProbe {
+		t.Error("expected SkipOpenRouterProbe=true when config.yaml is missing")
+	}
+}
+
+// TestLoadProjectConfig_DefaultsWhenBridgeSectionAbsent verifies that a
+// config.yaml without a bridge section returns SkipOpenRouterProbe=true.
+func TestLoadProjectConfig_DefaultsWhenBridgeSectionAbsent(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, "log_level: standard\n")
+
+	cfg, err := LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig: %v", err)
+	}
+	if !cfg.SkipOpenRouterProbe {
+		t.Error("expected SkipOpenRouterProbe=true when bridge section is absent")
+	}
+}
+
+// TestLoadProjectConfig_ExplicitTrue verifies that bridge.skip_openrouter_probe: true
+// is parsed correctly.
+func TestLoadProjectConfig_ExplicitTrue(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, "bridge:\n  skip_openrouter_probe: true\n")
+
+	cfg, err := LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig: %v", err)
+	}
+	if !cfg.SkipOpenRouterProbe {
+		t.Error("expected SkipOpenRouterProbe=true")
+	}
+}
+
+// TestLoadProjectConfig_ExplicitFalse verifies that bridge.skip_openrouter_probe: false
+// overrides the default.
+func TestLoadProjectConfig_ExplicitFalse(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, "bridge:\n  skip_openrouter_probe: false\n")
+
+	cfg, err := LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig: %v", err)
+	}
+	if cfg.SkipOpenRouterProbe {
+		t.Error("expected SkipOpenRouterProbe=false when explicitly set to false")
+	}
+}
+
+// TestLoadProjectConfig_EmptyWorkdir verifies that an empty workdir returns defaults.
+func TestLoadProjectConfig_EmptyWorkdir(t *testing.T) {
+	cfg, err := LoadProjectConfig("")
+	if err != nil {
+		t.Fatalf("LoadProjectConfig: %v", err)
+	}
+	if !cfg.SkipOpenRouterProbe {
+		t.Error("expected SkipOpenRouterProbe=true for empty workdir")
+	}
+}
+
+// TestLoadProjectConfig_BridgeSectionPresentKeyMissing verifies that a bridge
+// section present but with no skip_openrouter_probe key still defaults to true.
+func TestLoadProjectConfig_BridgeSectionPresentKeyMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, "bridge:\n  # no skip_openrouter_probe key\n")
+
+	cfg, err := LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig: %v", err)
+	}
+	if !cfg.SkipOpenRouterProbe {
+		t.Error("expected SkipOpenRouterProbe=true when key is absent from bridge section")
+	}
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/donovan-yohan/belayer/internal/bridge"
 	"github.com/donovan-yohan/belayer/internal/daemon"
 	"github.com/donovan-yohan/belayer/internal/runtime"
 	"github.com/donovan-yohan/belayer/internal/sandbox"
@@ -125,6 +126,15 @@ func newDaemonCmd() *cobra.Command {
 			} else {
 				fmt.Fprintf(cmd.OutOrStdout(), "belayer runtime: command (loaded from %s/.belayer/config.yaml)\n", wd)
 			}
+			// Load bridge config (skip_openrouter_probe etc.) from .belayer/config.yaml.
+			// Default: SkipOpenRouterProbe=true — suppresses the openrouter metadata
+			// probe that causes proxy-denied CONNECTs on clamshell sandboxes.
+			bridgeCfg, err := bridge.LoadProjectConfig(wd)
+			if err != nil {
+				return fmt.Errorf("load bridge config: %w", err)
+			}
+			cfg.SkipOpenRouterProbe = bridgeCfg.SkipOpenRouterProbe
+
 			// If the workdir has a .belayer/ directory, also bind a Unix socket
 			// there so clamshell bridge subprocesses can reach the daemon via the
 			// bind-mounted workspace path (/workspace/.belayer/daemon.sock).

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -47,6 +47,18 @@ log_level: standard
 #     - name: api
 #       url: http://localhost:8080
 
+# Bridge settings. Controls how bridge subprocesses are configured.
+#
+# skip_openrouter_probe: when true (default), hermes-agent skips the
+#   openrouter.ai metadata fetch at startup. This eliminates 20+ proxy-denied
+#   CONNECTs per run on clamshell sandboxes that do not whitelist openrouter.ai.
+#   Set to false only if your LLM vendor requires OpenRouter metadata at startup.
+#   Note: requires a complementary hermes-agent change to take effect — see
+#   docs/AGENT_ARCHITECTURE.md for details.
+#
+# bridge:
+#   skip_openrouter_probe: true
+
 # Exit conditions — natural-language assertions the PM validates before a run
 # is marked complete. These are the project-wide definition-of-done: the PM
 # rejects completion until every condition has evidence. Edit to fit your

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -534,12 +534,13 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		// daemon's resolved RuntimeDir (extracted at daemon startup outside the
 		// workspace) so that workspace agents running `rm -rf .belayer/` cannot
 		// destroy the module required for spawning peer bridges.
-		BelayerRoot:     d.config.RuntimeDir,
-		BelayerTools:    belayerTools,
-		TranscriptPath:  transcriptPath,
-		LogLevel:        sess.LogLevel,
-		WriteRoots:      writeRoots,
-		ConfineWrites:   d.config.ConfineAgentWrites,
+		BelayerRoot:         d.config.RuntimeDir,
+		BelayerTools:        belayerTools,
+		TranscriptPath:      transcriptPath,
+		LogLevel:            sess.LogLevel,
+		SkipOpenRouterProbe: d.config.SkipOpenRouterProbe,
+		WriteRoots:          writeRoots,
+		ConfineWrites:       d.config.ConfineAgentWrites,
 	}
 	// In clamshell mode the bridge runs inside the Docker container where the
 	// host hermes venv path doesn't exist; use the container's system python3.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -78,6 +78,13 @@ type Config struct {
 	BridgeBaseURL string
 	BridgeProvider string
 
+	// SkipOpenRouterProbe, when true (the default when loaded from
+	// .belayer/config.yaml), injects HERMES_SKIP_OPENROUTER_PROBE=1 into every
+	// bridge subprocess so hermes-agent skips the openrouter metadata fetch at
+	// startup. Set false only when using a vendor that requires OpenRouter
+	// metadata. See bridge.Config.SkipOpenRouterProbe and docs/AGENT_ARCHITECTURE.md.
+	SkipOpenRouterProbe bool
+
 	// AuthToken, if non-empty, is the bearer token required on all TCP requests
 	// except GET /health. If TCPAddr is set and AuthToken is empty, New()
 	// auto-generates a 32-byte random token and logs it.


### PR DESCRIPTION
## Summary

- Injects `HERMES_SKIP_OPENROUTER_PROBE=1` into every bridge subprocess by default, eliminating 20+ proxy-denied `CONNECT` requests per run to `openrouter.ai/api/v1/models` on clamshell sandboxes (Gap 17 from retro/VARIANCE_REPORT.md, run 8).
- Adds `bridge.skip_openrouter_probe` field to `.belayer/config.yaml` schema (default `true`); set `false` only if your LLM vendor requires OpenRouter metadata at startup.
- Plumbs the toggle through `bridge.Config` → `bridge.BuildEnv` → `daemon.Config` → `agents.go` → CLI config load.

## Files touched

- `internal/bridge/bridge.go` — `SkipOpenRouterProbe bool` field on `Config`; injection in `BuildEnv`
- `internal/bridge/config.go` (new) — `LoadProjectConfig` reads `bridge:` section from `.belayer/config.yaml`
- `internal/bridge/bridge_test.go` — `TestBuildEnvSkipOpenRouterProbeInjected` (true/false subtests)
- `internal/bridge/config_test.go` (new) — 6 config-parse tests covering defaults, explicit true/false, missing section, empty workdir
- `internal/daemon/daemon.go` — `SkipOpenRouterProbe bool` on daemon `Config`
- `internal/daemon/agents.go` — plumbs `d.config.SkipOpenRouterProbe` into `bridge.Config`
- `internal/cli/daemon.go` — loads bridge config and sets `cfg.SkipOpenRouterProbe`
- `internal/cli/init.go` — adds commented `bridge:` block to default `config.yaml` template
- `docs/AGENT_ARCHITECTURE.md` — documents `HERMES_SKIP_OPENROUTER_PROBE` toggle and when to set false

## Upstream dependency (hermes-agent — separate PR required)

This env var is a **no-op until hermes-agent honours it**. The complementary hermes-agent change must be made in `auth.py` (or wherever `_fetch_openrouter_models` is called) — before making the HTTP request:

```python
import os
if os.getenv("HERMES_SKIP_OPENROUTER_PROBE") == "1":
    return {}
```

Until that hermes-agent PR lands, setting or clearing `HERMES_SKIP_OPENROUTER_PROBE` has no effect on bridge behaviour. Once it lands, the belayer-side default (`skip_openrouter_probe: true`) suppresses the probe for all spawned bridges with zero operator action required.

## Test plan

- [x] `go build ./cmd/belayer` passes
- [x] `go test ./internal/bridge/...` passes (all new tests green)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)