### PR TITLE
feat(runtime): relocate hermes_bridge out of workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ Each directory contains:
 
 System prompts are loaded by the daemon at spawn time and injected via Hermes `ephemeral_system_prompt`. All agents use the `default` Hermes profile for now (see profile bootstrap TODO in AGENT_ARCHITECTURE.md).
 
+The `hermes_bridge` Python package lives in the daemon's runtime dir (default `$XDG_STATE_HOME/belayer/runtime`), not inside any workspace. This protects the module from workspace agent cleanup (`rm -rf .belayer/`).
+
 ## PM completion gate
 
 When the supervisor calls `belayer finish`, the daemon intercepts and auto-spawns a PM agent for adversarial spec-vs-reality verification. The PM approves or rejects (up to 3 cycles). See `docs/AGENT_ARCHITECTURE.md` for full details.

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -622,6 +622,8 @@ flowchart LR
 | `internal/daemon/agents.go` | `spawnAgentInternal` for auto-spawning PM; `handleFinishAgent` intercepts supervisor finish to trigger PM gate; agent system-prompt resolution from `.belayer/agents/<name>/system-prompt.md` then `<BelayerRoot>/agents/<name>/system-prompt.md` |
 | `internal/bridge/bridge.go` | `Config.SystemPrompt` field, passed as `BELAYER_SYSTEM_PROMPT` env var |
 
+> **hermes_bridge location.** The `hermes_bridge` Python package is extracted from the binary at daemon startup into the **runtime dir** (default `$XDG_STATE_HOME/belayer/runtime`, or `$HOME/.local/state/belayer/runtime`). It does NOT live inside any workspace's `.belayer/` directory. This means workspace agents running destructive cleanup (e.g. `rm -rf .belayer/`) cannot destroy the module required for spawning peer bridges. Override the location via `BELAYER_RUNTIME_DIR` or `runtime_dir:` in `.belayer/config.yaml`.
+
 ---
 
 ## Exit-condition resolution

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -61,6 +61,20 @@ func newDaemonCmd() *cobra.Command {
 			if belayerRoot != "" {
 				cfg.BelayerRoot = belayerRoot
 			}
+
+			// Resolve the runtime dir and extract the embedded hermes_bridge package.
+			// This must happen before daemon.New so bridge subprocesses spawned
+			// immediately after Start have the package available.
+			runtimeDir, err := resolveRuntimeDir(wd0)
+			if err != nil {
+				return fmt.Errorf("resolve runtime dir: %w", err)
+			}
+			if err := extractBridgeToRuntimeDir(runtimeDir, wd0); err != nil {
+				return fmt.Errorf("extract bridge to runtime dir: %w", err)
+			}
+			cfg.RuntimeDir = runtimeDir
+			fmt.Fprintf(cmd.OutOrStdout(), "belayer runtime dir: %s\n", runtimeDir)
+
 			if tcpAddr != "" {
 				cfg.TCPAddr = tcpAddr
 			}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -138,8 +138,7 @@ upgrading belayer); existing config.yaml and policies/ are never overwritten.`,
 			}
 
 			if result.alreadyInitialized && !force {
-				fmt.Fprintf(out, "belayer already initialized at %s (refreshed %d bridge file(s))\n",
-					belayerDir, result.bridgeRefreshed)
+				fmt.Fprintf(out, "belayer already initialized at %s\n", belayerDir)
 				// Surface any upgrade changes (e.g. new .gitignore entries
 				// appended on a binary bump) so the user sees them even though
 				// the rest of the re-init path is silent.
@@ -165,14 +164,9 @@ upgrading belayer); existing config.yaml and policies/ are never overwritten.`,
 
 // scaffoldResult records what scaffold produced so callers can render output
 // (or, in the auto-init path from `belayer run`, skip output entirely).
-//
-// bridgeRefreshed is separate from created because bridge files are always
-// overwritten on every init — on re-init we want a one-line refresh summary
-// rather than N lines of "+ .belayer/hermes_bridge/<file>" noise.
 type scaffoldResult struct {
 	alreadyInitialized bool
 	created            []string
-	bridgeRefreshed    int
 }
 
 // scaffold creates belayerDir and its standard children. It is the core init
@@ -180,9 +174,9 @@ type scaffoldResult struct {
 // directly.
 //
 // On re-init without --force, user-owned files (config.yaml, policies/,
-// agents/) are not touched — the CLI reports "already initialized". The
-// hermes_bridge/ tree is refreshed unconditionally on every call so the
-// extracted copy always matches the binary version.
+// agents/) are not touched — the CLI reports "already initialized".
+// hermes_bridge/ is no longer extracted here; the daemon extracts it to the
+// runtime dir at startup (see internal/cli/runtime.go).
 func scaffold(belayerDir string, force bool) (scaffoldResult, error) {
 	var result scaffoldResult
 
@@ -195,34 +189,16 @@ func scaffold(belayerDir string, force bool) (scaffoldResult, error) {
 		return result, fmt.Errorf("stat %s: %w", belayerDir, err)
 	}
 
-	for _, sub := range []string{"", "policies", "agents", "hermes_bridge"} {
+	for _, sub := range []string{"", "policies", "agents"} {
 		p := filepath.Join(belayerDir, sub)
 		if err := os.MkdirAll(p, 0o755); err != nil {
 			return result, fmt.Errorf("mkdir %s: %w", p, err)
 		}
 	}
 
-	// Bridge extraction runs on every scaffold, not gated by --force. It is
-	// machine-owned: the extracted tree is overwritten so it always matches
-	// the running binary's embedded copy.
-	bridgeRoot := filepath.Join(belayerDir, "hermes_bridge")
-	bridgeCopied, err := copyDefaultBridge(bridgeRoot)
-	if err != nil {
-		return result, err
-	}
-	result.bridgeRefreshed = len(bridgeCopied)
-	// On fresh init, surface bridge files in the created list so the user
-	// sees what was written. On re-init we rely on bridgeRefreshed for the
-	// one-line summary.
-	if !result.alreadyInitialized {
-		for _, p := range bridgeCopied {
-			result.created = append(result.created, "  + "+relativize(belayerDir, p))
-		}
-	}
-
 	// Gitignore maintenance runs before the re-init early return so that
-	// binary upgrades which add new entries (e.g. /.belayer/hermes_bridge/)
-	// land in already-initialized projects, not just fresh ones.
+	// binary upgrades which add new entries land in already-initialized
+	// projects, not just fresh ones.
 	gitignoreNote, err := ensureGitignoreEntries(filepath.Dir(belayerDir))
 	if err != nil {
 		return result, err
@@ -274,11 +250,13 @@ func scaffold(belayerDir string, force bool) (scaffoldResult, error) {
 // match at the repo root — nested .belayer/ inside subprojects (e.g. inside
 // .belayer/worktrees/...) are not affected by these rules.
 //
-// hermes_bridge/ is gitignored because the tree is extracted from the binary
-// on every `belayer init` and always overwrites — committing it would drift
-// against the binary version.
+// Note: .belayer/ contains per-run state (runs/, worktrees/) that is machine-
+// generated and should not be committed. The hermes_bridge Python package is
+// NOT stored here — it lives in the daemon's runtime dir
+// (default $XDG_STATE_HOME/belayer/runtime) so workspace agents cannot destroy
+// it. Only agents/, config.yaml, and policies/ are committed.
 const (
-	gitignoreHeader        = "# belayer — per-run state (committed: agents/, config.yaml, policies/)"
+	gitignoreHeader        = "# belayer — per-run state (.belayer/ contains runs/ and worktrees/; hermes_bridge is in runtime dir)"
 	gitignoreUpgradeHeader = "# belayer — added on upgrade"
 	gitignoreMarker        = "# belayer — per-run state"
 )
@@ -286,7 +264,6 @@ const (
 var gitignoreEntries = []string{
 	"/.belayer/runs/",
 	"/.belayer/worktrees/",
-	"/.belayer/hermes_bridge/",
 }
 
 // ensureGitignoreEntries makes sure every entry in gitignoreEntries is present
@@ -405,73 +382,6 @@ func copyDefaultAgents(dst string, force bool) ([]string, error) {
 	return written, nil
 }
 
-// copyDefaultBridge walks the embedded hermes_bridge/ tree and writes each
-// file into dst. Unlike copyDefaultAgents it always overwrites — the bridge
-// is machine-generated Go+Python glue pinned to this binary's version, so a
-// stale file on disk would produce a hard-to-debug version-skew bug.
-//
-// The destination is wiped before extraction so files renamed or deleted in
-// later binary versions don't linger on disk and get picked up by Python's
-// import machinery. The tree is gitignored and fully machine-owned, so this
-// is safe — nothing user-authored should live here.
-//
-// __pycache__ directories and *.pyc files are skipped so host bytecode from
-// developer builds never leaks into projects.
-func copyDefaultBridge(dst string) ([]string, error) {
-	if err := os.RemoveAll(dst); err != nil {
-		return nil, fmt.Errorf("reset bridge tree %s: %w", dst, err)
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		return nil, fmt.Errorf("mkdir %s: %w", dst, err)
-	}
-
-	var written []string
-	err := fs.WalkDir(belayer.DefaultBridge, "hermes_bridge", func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if path == "hermes_bridge" {
-			return nil
-		}
-		rel := strings.TrimPrefix(path, "hermes_bridge/")
-		// Skip anything that's dev-only and shouldn't leak into user projects:
-		//   - __pycache__/ (bytecode)
-		//   - *.pyc (straggler bytecode)
-		//   - tests/ (pytest suite, only useful in-repo)
-		//   - *.md (README and any future dev notes)
-		// Returning SkipDir on a directory prunes its whole subtree.
-		base := filepath.Base(rel)
-		if d.IsDir() && (base == "__pycache__" || base == "tests") {
-			return fs.SkipDir
-		}
-		if !d.IsDir() && (strings.HasSuffix(base, ".pyc") || strings.HasSuffix(base, ".md")) {
-			return nil
-		}
-		out := filepath.Join(dst, rel)
-
-		if d.IsDir() {
-			if err := os.MkdirAll(out, 0o755); err != nil {
-				return fmt.Errorf("mkdir %s: %w", out, err)
-			}
-			return nil
-		}
-
-		data, err := belayer.DefaultBridge.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("read embedded %s: %w", path, err)
-		}
-		if err := os.WriteFile(out, data, 0o644); err != nil {
-			return fmt.Errorf("write %s: %w", out, err)
-		}
-		written = append(written, out)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return written, nil
-}
-
 // writeIfMissing writes data to path only if path does not already exist.
 // Returns true when a file was created, false when one was already present.
 // Existing files are never touched — config.yaml and policies/ are
@@ -499,11 +409,11 @@ func relativize(parent, p string) string {
 }
 
 // autoInitIfMissing is the entry point for `belayer run` to scaffold .belayer/
-// without forcing the user to call `belayer init` first. Scaffold is invoked
-// unconditionally so the embedded hermes_bridge/ tree is refreshed on every
-// run, keeping the extracted copy in sync with the binary. On a fresh scaffold
-// (no prior .belayer/) a notice is written to w; the bridge refresh on existing
-// projects is silent to avoid log spam on the hot path.
+// without forcing the user to call `belayer init` first. On a fresh scaffold
+// (no prior .belayer/) a notice is written to w; re-init on existing projects
+// is silent to avoid log spam on the hot path.
+// Note: hermes_bridge extraction is no longer done here — the daemon handles
+// it at startup via extractBridgeToRuntimeDir.
 func autoInitIfMissing(workdir string, w io.Writer) error {
 	belayerDir := filepath.Join(workdir, ".belayer")
 	result, err := scaffold(belayerDir, false)

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -72,9 +72,6 @@ func TestInitScaffoldsPersistenceStrategyBlock(t *testing.T) {
 	if !strings.Contains(got, "\npersistence_strategy:\n") {
 		t.Fatalf("expected 'persistence_strategy:' block in config.yaml, got:\n%s", got)
 	}
-	// Each scaffolded bullet must be present — these are the contract with
-	// the supervisor prompt and the daemon intercept. If one is removed
-	// silently, operators lose the default persistence behavior.
 	for _, want := range []string{
 		"incomplete/<session-id>",
 		"Push the branch to origin",
@@ -117,7 +114,6 @@ func TestInitIdempotentReRun(t *testing.T) {
 		t.Fatalf("first init: %v", err)
 	}
 
-	// Edit config.yaml so we can prove the second run does not clobber it.
 	configPath := filepath.Join(dir, ".belayer", "config.yaml")
 	const userEdit = "# user customization\n"
 	if err := os.WriteFile(configPath, []byte(userEdit), 0o644); err != nil {
@@ -156,7 +152,6 @@ func TestInitForceRefreshesAgentsButPreservesConfig(t *testing.T) {
 		t.Fatalf("first init: %v", err)
 	}
 
-	// Mutate a shipped agent file and a user config file.
 	agentFile := filepath.Join(dir, ".belayer", "agents", "supervisor", "system-prompt.md")
 	if err := os.WriteFile(agentFile, []byte("local hack"), 0o644); err != nil {
 		t.Fatalf("mutate agent: %v", err)
@@ -206,10 +201,14 @@ func TestInitCreatesGitignoreWhenMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read .gitignore: %v", err)
 	}
-	for _, want := range []string{"/.belayer/runs/", "/.belayer/worktrees/", "/.belayer/hermes_bridge/"} {
+	// hermes_bridge/ is no longer in the workspace; it lives in the runtime dir.
+	for _, want := range []string{"/.belayer/runs/", "/.belayer/worktrees/"} {
 		if !strings.Contains(string(got), want) {
 			t.Fatalf("expected %q in .gitignore, got: %s", want, string(got))
 		}
+	}
+	if strings.Contains(string(got), "/.belayer/hermes_bridge/") {
+		t.Fatalf("/.belayer/hermes_bridge/ entry should not appear in workspace .gitignore; got: %s", string(got))
 	}
 }
 
@@ -298,9 +297,7 @@ func TestAutoInitIfMissingScaffoldsAndAnnounces(t *testing.T) {
 		t.Fatalf("expected scaffolded supervisor prompt: %v", err)
 	}
 
-	// Second call must be silent — the bridge refresh is a hot-path no-op from
-	// the user's perspective (files may be rewritten byte-for-byte but the
-	// announce is suppressed).
+	// Second call must be silent.
 	out2 := &bytes.Buffer{}
 	if err := autoInitIfMissing(dir, out2); err != nil {
 		t.Fatalf("autoInit second call: %v", err)
@@ -310,7 +307,10 @@ func TestAutoInitIfMissingScaffoldsAndAnnounces(t *testing.T) {
 	}
 }
 
-func TestInitExtractsHermesBridge(t *testing.T) {
+// TestInitDoesNotExtractHermesBridgeToWorkspace verifies that 'belayer init'
+// no longer places hermes_bridge/ inside the workspace .belayer/ directory.
+// Bridge extraction now happens at daemon startup via extractBridgeToRuntimeDir.
+func TestInitDoesNotExtractHermesBridgeToWorkspace(t *testing.T) {
 	dir := t.TempDir()
 	cmd := newInitCmd()
 	cmd.SetOut(&bytes.Buffer{})
@@ -321,21 +321,31 @@ func TestInitExtractsHermesBridge(t *testing.T) {
 	}
 
 	bridgeDir := filepath.Join(dir, ".belayer", "hermes_bridge")
-	// __main__.py is the package entry point; its absence is a hard failure.
+	if _, err := os.Stat(bridgeDir); err == nil {
+		t.Fatalf("hermes_bridge/ should not be in workspace .belayer/ after init; found at %s", bridgeDir)
+	}
+}
+
+// TestExtractBridgeToRuntimeDirExtractsPackage verifies that the runtime
+// extraction function places hermes_bridge/ at the correct location and
+// filters dev-only files.
+func TestExtractBridgeToRuntimeDirExtractsPackage(t *testing.T) {
+	runtimeDir := t.TempDir()
+	if err := extractBridgeToRuntimeDir(runtimeDir, ""); err != nil {
+		t.Fatalf("extractBridgeToRuntimeDir: %v", err)
+	}
+
+	bridgeDir := filepath.Join(runtimeDir, "hermes_bridge")
 	if _, err := os.Stat(filepath.Join(bridgeDir, "__main__.py")); err != nil {
 		t.Fatalf("expected hermes_bridge/__main__.py to exist: %v", err)
 	}
-	// __init__.py makes it an importable package.
 	if _, err := os.Stat(filepath.Join(bridgeDir, "__init__.py")); err != nil {
 		t.Fatalf("expected hermes_bridge/__init__.py to exist: %v", err)
 	}
-
-	// __pycache__ from the host build must never leak into the extracted copy.
 	if _, err := os.Stat(filepath.Join(bridgeDir, "__pycache__")); err == nil {
 		t.Fatalf("__pycache__ was extracted; expected it to be filtered")
 	}
 
-	// No *.pyc files at any depth, and no dev-only trees (tests/, *.md).
 	walkErr := filepath.Walk(bridgeDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -362,59 +372,89 @@ func TestInitExtractsHermesBridge(t *testing.T) {
 	}
 }
 
-func TestInitRefreshesBridgeOnReInit(t *testing.T) {
-	dir := t.TempDir()
+// TestExtractBridgeToRuntimeDirIsIdempotent verifies that re-extracting the
+// bridge restores drifted files without blowing up.
+func TestExtractBridgeToRuntimeDirIsIdempotent(t *testing.T) {
+	runtimeDir := t.TempDir()
 
-	first := newInitCmd()
-	first.SetOut(&bytes.Buffer{})
-	first.SetErr(&bytes.Buffer{})
-	first.SetArgs([]string{"--target", dir})
-	if err := first.Execute(); err != nil {
-		t.Fatalf("first init: %v", err)
+	if err := extractBridgeToRuntimeDir(runtimeDir, ""); err != nil {
+		t.Fatalf("first extract: %v", err)
 	}
 
-	mainPath := filepath.Join(dir, ".belayer", "hermes_bridge", "__main__.py")
+	mainPath := filepath.Join(runtimeDir, "hermes_bridge", "__main__.py")
 	originalBytes, err := os.ReadFile(mainPath)
 	if err != nil {
 		t.Fatalf("read extracted __main__.py: %v", err)
 	}
 
-	// Simulate drift: replace the extracted bridge file with garbage.
 	if err := os.WriteFile(mainPath, []byte("# drifted\n"), 0o644); err != nil {
 		t.Fatalf("seed drift: %v", err)
 	}
 
-	second := newInitCmd()
-	out := &bytes.Buffer{}
-	second.SetOut(out)
-	second.SetErr(out)
-	second.SetArgs([]string{"--target", dir})
-	if err := second.Execute(); err != nil {
-		t.Fatalf("second init: %v", err)
-	}
-
-	// Output must announce the bridge refresh.
-	if !strings.Contains(out.String(), "refreshed") {
-		t.Fatalf("expected re-init output to mention refreshed bridge files, got: %s", out.String())
+	if err := extractBridgeToRuntimeDir(runtimeDir, ""); err != nil {
+		t.Fatalf("second extract: %v", err)
 	}
 
 	got, err := os.ReadFile(mainPath)
 	if err != nil {
-		t.Fatalf("read bridge after re-init: %v", err)
+		t.Fatalf("read bridge after re-extract: %v", err)
 	}
 	if !bytes.Equal(got, originalBytes) {
-		t.Fatalf("re-init did not restore bridge __main__.py; drift persisted")
+		t.Fatalf("re-extract did not restore bridge __main__.py; drift persisted")
 	}
 }
 
-func TestInitGitignoreUpgradeAppendsMissingEntry(t *testing.T) {
+// TestExtractBridgeToRuntimeDirPrunesStaleFiles verifies that stale files
+// (present on disk but absent from the embedded bridge) are removed.
+func TestExtractBridgeToRuntimeDirPrunesStaleFiles(t *testing.T) {
+	runtimeDir := t.TempDir()
+
+	if err := extractBridgeToRuntimeDir(runtimeDir, ""); err != nil {
+		t.Fatalf("first extract: %v", err)
+	}
+
+	bridgeDir := filepath.Join(runtimeDir, "hermes_bridge")
+	stalePath := filepath.Join(bridgeDir, "stale_removed_module.py")
+	if err := os.WriteFile(stalePath, []byte("# stale\n"), 0o644); err != nil {
+		t.Fatalf("seed stale file: %v", err)
+	}
+	staleSubdir := filepath.Join(bridgeDir, "removed_subpackage")
+	if err := os.MkdirAll(staleSubdir, 0o755); err != nil {
+		t.Fatalf("seed stale subdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staleSubdir, "__init__.py"), []byte(""), 0o644); err != nil {
+		t.Fatalf("seed stale subdir file: %v", err)
+	}
+
+	if err := extractBridgeToRuntimeDir(runtimeDir, ""); err != nil {
+		t.Fatalf("second extract: %v", err)
+	}
+
+	if _, err := os.Stat(stalePath); err == nil {
+		t.Fatalf("stale file survived re-extract: %s", stalePath)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat stale file: %v", err)
+	}
+	if _, err := os.Stat(staleSubdir); err == nil {
+		t.Fatalf("stale subdir survived re-extract: %s", staleSubdir)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat stale subdir: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(bridgeDir, "__main__.py")); err != nil {
+		t.Fatalf("expected __main__.py after prune: %v", err)
+	}
+}
+
+// TestInitGitignoreUpgradeIsNoOpWhenAllEntriesPresent verifies that init
+// does not append duplicate entries when all current entries are already
+// present.
+func TestInitGitignoreUpgradeIsNoOpWhenAllEntriesPresent(t *testing.T) {
 	dir := t.TempDir()
-	// Seed a .gitignore that looks like a project initialized under an older
-	// belayer version: it has the marker and the two historical entries but
-	// not /.belayer/hermes_bridge/.
-	legacy := gitignoreHeader + "\n/.belayer/runs/\n/.belayer/worktrees/\n"
-	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(legacy), 0o644); err != nil {
-		t.Fatalf("seed legacy gitignore: %v", err)
+	// Seed a .gitignore with the current header and both entries.
+	existing := gitignoreHeader + "\n/.belayer/runs/\n/.belayer/worktrees/\n"
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(existing), 0o644); err != nil {
+		t.Fatalf("seed gitignore: %v", err)
 	}
 
 	cmd := newInitCmd()
@@ -429,124 +469,58 @@ func TestInitGitignoreUpgradeAppendsMissingEntry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read gitignore: %v", err)
 	}
-	gotStr := string(got)
-	if !strings.Contains(gotStr, "/.belayer/hermes_bridge/") {
-		t.Fatalf("expected missing entry to be appended, got:\n%s", gotStr)
+	if strings.Contains(string(got), gitignoreUpgradeHeader) {
+		t.Fatalf("upgrade header should not appear when all entries present:\n%s", string(got))
 	}
-	// Must not duplicate entries the user already had.
-	if strings.Count(gotStr, "/.belayer/runs/") != 1 {
-		t.Fatalf("existing /.belayer/runs/ entry should not be duplicated:\n%s", gotStr)
-	}
-	// Original marker should still appear exactly once — upgrade uses a
-	// separate labelled block.
-	if strings.Count(gotStr, gitignoreMarker) != 1 {
-		t.Fatalf("marker should appear exactly once; got:\n%s", gotStr)
-	}
-	// Upgrade header visible so users see where the new entry came from.
-	if !strings.Contains(gotStr, gitignoreUpgradeHeader) {
-		t.Fatalf("expected upgrade header in gitignore, got:\n%s", gotStr)
-	}
-
-	// Re-running should be a no-op now — all entries are present.
-	second := newInitCmd()
-	second.SetOut(&bytes.Buffer{})
-	second.SetErr(&bytes.Buffer{})
-	second.SetArgs([]string{"--target", dir})
-	if err := second.Execute(); err != nil {
-		t.Fatalf("second init: %v", err)
-	}
-	got2, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	if err != nil {
-		t.Fatalf("read gitignore #2: %v", err)
-	}
-	if !bytes.Equal(got, got2) {
-		t.Fatalf("second init mutated gitignore; before=%q after=%q", got, got2)
+	if strings.Count(string(got), "/.belayer/runs/") != 1 {
+		t.Fatalf("existing /.belayer/runs/ entry should not be duplicated:\n%s", string(got))
 	}
 }
 
-func TestInitPrunesStaleBridgeFiles(t *testing.T) {
-	dir := t.TempDir()
+// TestResolveRuntimeDirPrecedence verifies the env var and XDG resolution order.
+func TestResolveRuntimeDirPrecedence(t *testing.T) {
+	t.Setenv("BELAYER_RUNTIME_DIR", "")
+	t.Setenv("XDG_STATE_HOME", "")
 
-	first := newInitCmd()
-	first.SetOut(&bytes.Buffer{})
-	first.SetErr(&bytes.Buffer{})
-	first.SetArgs([]string{"--target", dir})
-	if err := first.Execute(); err != nil {
-		t.Fatalf("first init: %v", err)
-	}
+	t.Run("env_var_wins", func(t *testing.T) {
+		t.Setenv("BELAYER_RUNTIME_DIR", "/custom/runtime")
+		got, err := resolveRuntimeDir("")
+		if err != nil {
+			t.Fatalf("resolveRuntimeDir: %v", err)
+		}
+		if got != "/custom/runtime" {
+			t.Fatalf("expected /custom/runtime, got %q", got)
+		}
+	})
 
-	// Simulate an upstream rename/deletion by planting a stale file in the
-	// extracted tree that doesn't exist in the embedded bridge.
-	bridgeDir := filepath.Join(dir, ".belayer", "hermes_bridge")
-	stalePath := filepath.Join(bridgeDir, "stale_removed_module.py")
-	if err := os.WriteFile(stalePath, []byte("# stale\n"), 0o644); err != nil {
-		t.Fatalf("seed stale file: %v", err)
-	}
-	staleSubdir := filepath.Join(bridgeDir, "removed_subpackage")
-	if err := os.MkdirAll(staleSubdir, 0o755); err != nil {
-		t.Fatalf("seed stale subdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(staleSubdir, "__init__.py"), []byte(""), 0o644); err != nil {
-		t.Fatalf("seed stale subdir file: %v", err)
-	}
+	t.Run("xdg_state_home", func(t *testing.T) {
+		t.Setenv("XDG_STATE_HOME", "/xdg/state")
+		got, err := resolveRuntimeDir("")
+		if err != nil {
+			t.Fatalf("resolveRuntimeDir: %v", err)
+		}
+		if got != "/xdg/state/belayer/runtime" {
+			t.Fatalf("expected /xdg/state/belayer/runtime, got %q", got)
+		}
+	})
 
-	second := newInitCmd()
-	second.SetOut(&bytes.Buffer{})
-	second.SetErr(&bytes.Buffer{})
-	second.SetArgs([]string{"--target", dir})
-	if err := second.Execute(); err != nil {
-		t.Fatalf("second init: %v", err)
-	}
+	t.Run("config_yaml_runtime_dir", func(t *testing.T) {
+		workspaceDir := t.TempDir()
+		belayerDir := filepath.Join(workspaceDir, ".belayer")
+		if err := os.MkdirAll(belayerDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		cfgContent := "log_level: standard\nruntime_dir: /from/config\n"
+		if err := os.WriteFile(filepath.Join(belayerDir, "config.yaml"), []byte(cfgContent), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
 
-	if _, err := os.Stat(stalePath); err == nil {
-		t.Fatalf("stale file survived re-init: %s", stalePath)
-	} else if !os.IsNotExist(err) {
-		t.Fatalf("stat stale file: %v", err)
-	}
-	if _, err := os.Stat(staleSubdir); err == nil {
-		t.Fatalf("stale subdir survived re-init: %s", staleSubdir)
-	} else if !os.IsNotExist(err) {
-		t.Fatalf("stat stale subdir: %v", err)
-	}
-
-	// The real bridge files must still be present.
-	if _, err := os.Stat(filepath.Join(bridgeDir, "__main__.py")); err != nil {
-		t.Fatalf("expected __main__.py after prune: %v", err)
-	}
-}
-
-func TestAutoInitRefreshesBridgeOnExistingProject(t *testing.T) {
-	dir := t.TempDir()
-
-	// First auto-init creates everything.
-	if err := autoInitIfMissing(dir, &bytes.Buffer{}); err != nil {
-		t.Fatalf("first autoInit: %v", err)
-	}
-
-	mainPath := filepath.Join(dir, ".belayer", "hermes_bridge", "__main__.py")
-	originalBytes, err := os.ReadFile(mainPath)
-	if err != nil {
-		t.Fatalf("read bridge: %v", err)
-	}
-	if err := os.WriteFile(mainPath, []byte("# drifted\n"), 0o644); err != nil {
-		t.Fatalf("seed drift: %v", err)
-	}
-
-	// Second auto-init (simulating another `belayer run`) must refresh bridge
-	// silently — the announce is suppressed on already-initialized projects.
-	out := &bytes.Buffer{}
-	if err := autoInitIfMissing(dir, out); err != nil {
-		t.Fatalf("second autoInit: %v", err)
-	}
-	if out.Len() != 0 {
-		t.Fatalf("expected silent refresh on existing project, got: %s", out.String())
-	}
-
-	got, err := os.ReadFile(mainPath)
-	if err != nil {
-		t.Fatalf("read bridge after auto re-init: %v", err)
-	}
-	if !bytes.Equal(got, originalBytes) {
-		t.Fatalf("auto-init did not refresh drifted bridge file")
-	}
+		got, err := resolveRuntimeDir(workspaceDir)
+		if err != nil {
+			t.Fatalf("resolveRuntimeDir: %v", err)
+		}
+		if got != "/from/config" {
+			t.Fatalf("expected /from/config, got %q", got)
+		}
+	})
 }

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	belayer "github.com/donovan-yohan/belayer"
+)
+
+// resolveRuntimeDir returns the directory where the daemon should extract the
+// hermes_bridge package. Resolution order:
+//
+//  1. $BELAYER_RUNTIME_DIR env var (clamshell: preset to /opt/belayer/runtime)
+//  2. Optional runtime_dir field in .belayer/config.yaml (workspaceDir may be "")
+//  3. $XDG_STATE_HOME/belayer/runtime if $XDG_STATE_HOME is set
+//  4. $HOME/.local/state/belayer/runtime (always available fallback)
+func resolveRuntimeDir(workspaceDir string) (string, error) {
+	// 1. Explicit env override.
+	if v := strings.TrimSpace(os.Getenv("BELAYER_RUNTIME_DIR")); v != "" {
+		return v, nil
+	}
+
+	// 2. Optional runtime_dir key in .belayer/config.yaml.
+	// We do a simple line-scan so we don't need to import the YAML parser here.
+	if workspaceDir != "" {
+		cfgPath := filepath.Join(workspaceDir, ".belayer", "config.yaml")
+		if data, err := os.ReadFile(cfgPath); err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				line = strings.TrimSpace(line)
+				if strings.HasPrefix(line, "runtime_dir:") {
+					val := strings.TrimSpace(strings.TrimPrefix(line, "runtime_dir:"))
+					val = strings.Trim(val, `"'`)
+					if val != "" {
+						return val, nil
+					}
+				}
+			}
+		}
+	}
+
+	// 3. $XDG_STATE_HOME/belayer/runtime
+	if xdg := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); xdg != "" {
+		return filepath.Join(xdg, "belayer", "runtime"), nil
+	}
+
+	// 4. $HOME/.local/state/belayer/runtime
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve runtime dir: $HOME unavailable: %w", err)
+	}
+	return filepath.Join(home, ".local", "state", "belayer", "runtime"), nil
+}
+
+// legacyBridgeWarningOnce guards the one-shot deprecation log below.
+var legacyBridgeWarningOnce sync.Once
+
+// extractBridgeToRuntimeDir ensures the embedded hermes_bridge package is
+// present and current in runtimeDir. It is idempotent: files whose size and
+// SHA-256 already match the embedded version are left untouched. Files that
+// have been deleted, modified, or never written are (re)extracted. Stale files
+// (present on disk but absent from the embed) are removed.
+//
+// If workspaceDir is non-empty and runtimeDir is the canonical runtime path
+// (i.e. BELAYER_RUNTIME_DIR was not set), the function also checks for a
+// legacy hermes_bridge in <workspaceDir>/.belayer/hermes_bridge/ and logs a
+// one-shot deprecation warning when found.
+func extractBridgeToRuntimeDir(runtimeDir, workspaceDir string) error {
+	// Legacy compat: warn once if the old workspace location still exists.
+	if workspaceDir != "" {
+		legacyPath := filepath.Join(workspaceDir, ".belayer", "hermes_bridge", "__main__.py")
+		if _, err := os.Stat(legacyPath); err == nil {
+			legacyBridgeWarningOnce.Do(func() {
+				legacyBridgeDir := filepath.Join(workspaceDir, ".belayer", "hermes_bridge")
+				fmt.Printf("warn: legacy hermes_bridge location in workspace detected; new installs use %s. Remove %s to silence.\n",
+					runtimeDir, legacyBridgeDir)
+			})
+		}
+	}
+
+	bridgeDst := filepath.Join(runtimeDir, "hermes_bridge")
+	if err := os.MkdirAll(bridgeDst, 0o755); err != nil {
+		return fmt.Errorf("extract bridge: mkdir %s: %w", bridgeDst, err)
+	}
+
+	// Build a set of embedded paths so we can detect and remove stale on-disk files.
+	embeddedPaths := make(map[string]struct{})
+	err := fs.WalkDir(belayer.DefaultBridge, "hermes_bridge", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == "hermes_bridge" {
+			return nil
+		}
+		rel := strings.TrimPrefix(path, "hermes_bridge/")
+		// Skip dev-only trees (same filter as copyDefaultBridge).
+		base := filepath.Base(rel)
+		if d.IsDir() && (base == "__pycache__" || base == "tests") {
+			return fs.SkipDir
+		}
+		if !d.IsDir() && (strings.HasSuffix(base, ".pyc") || strings.HasSuffix(base, ".md")) {
+			return nil
+		}
+		out := filepath.Join(bridgeDst, rel)
+		if d.IsDir() {
+			embeddedPaths[out] = struct{}{}
+			return os.MkdirAll(out, 0o755)
+		}
+		embeddedPaths[out] = struct{}{}
+
+		data, err := belayer.DefaultBridge.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read embedded %s: %w", path, err)
+		}
+		// Idempotency: skip write if on-disk file matches embedded content.
+		if existing, err := os.ReadFile(out); err == nil {
+			if len(existing) == len(data) && sha256.Sum256(existing) == sha256.Sum256(data) {
+				return nil
+			}
+		}
+		return os.WriteFile(out, data, 0o644)
+	})
+	if err != nil {
+		return fmt.Errorf("extract bridge: walk embedded: %w", err)
+	}
+
+	// Remove stale on-disk files/dirs not in the embedded set. Walk bottom-up
+	// (post-order) so we can remove empty directories after their children.
+	type stalePath struct {
+		path  string
+		isDir bool
+	}
+	var stale []stalePath
+	_ = filepath.WalkDir(bridgeDst, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || path == bridgeDst {
+			return nil
+		}
+		if _, ok := embeddedPaths[path]; !ok {
+			stale = append(stale, stalePath{path, d.IsDir()})
+		}
+		return nil
+	})
+	// Remove in reverse order (deepest first) so parent dirs are empty by the
+	// time we try to remove them.
+	for i := len(stale) - 1; i >= 0; i-- {
+		if stale[i].isDir {
+			_ = os.Remove(stale[i].path) // only removes empty dirs
+		} else {
+			_ = os.Remove(stale[i].path)
+		}
+	}
+
+	return nil
+}

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -495,7 +495,12 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		Workdir:         workdir,
 		SocketPath:      socketPath,
 		RunDir:          runDir,
-		BelayerRoot:     d.config.BelayerRoot,
+		// BelayerRoot on bridge.Config is the parent directory placed on PYTHONPATH
+		// so that `python -m hermes_bridge` resolves correctly. We prefer the
+		// daemon's resolved RuntimeDir (extracted at daemon startup outside the
+		// workspace) so that workspace agents running `rm -rf .belayer/` cannot
+		// destroy the module required for spawning peer bridges.
+		BelayerRoot:     d.config.RuntimeDir,
 		BelayerTools:    belayerTools,
 		TranscriptPath:  transcriptPath,
 		LogLevel:        sess.LogLevel,
@@ -503,13 +508,12 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 	// In clamshell mode the bridge runs inside the Docker container where the
 	// host hermes venv path doesn't exist; use the container's system python3.
 	// Also inject proxy vars so LLM API calls route through the egress broker.
-	// BelayerRoot is overridden to the container's view of the extracted
-	// hermes_bridge parent (/workspace/.belayer) so `python3 -m hermes_bridge`
-	// imports the copy placed there by `belayer init`, not the host path.
+	// BelayerRoot is overridden to the container's view of the runtime dir
+	// bind-mounted into the container so `python3 -m hermes_bridge` resolves.
 	if ss.mode == "clamshell" {
 		cfg.Cmd = []string{"python3", "-m", "hermes_bridge"}
 		cfg.HTTPProxy = "http://proxy.internal:3128"
-		cfg.BelayerRoot = "/workspace/.belayer"
+		cfg.BelayerRoot = "/opt/belayer/runtime"
 		// The bridge runs inside the container where the host workspace is
 		// mounted at /workspace. Translate transcriptPath (built from the host
 		// path) so the bridge can actually open it; otherwise transcript capture
@@ -518,15 +522,12 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 			cfg.TranscriptPath = translateHostPathToContainer(cfg.TranscriptPath, sess.WorkspaceDir)
 		}
 	}
-	// Universal fallback: when no BelayerRoot was configured (CLI flag, env, or
-	// clamshell override above), look for an extracted hermes_bridge under
-	// workdir/.belayer. This lets belayer work inside any outer sandbox
-	// (including clamshell-as-devbox with mode=noop) without requiring the
-	// caller to plumb --belayer-root through every layer.
-	//
-	// Probe both the (possibly-worktree) workdir and the original repo root:
-	// worktrees are gitignored so .belayer/ only exists in the main checkout,
-	// and branch-based specialists would otherwise miss the extracted bridge.
+	// Universal fallback: when RuntimeDir was not set (e.g. tests that skip the
+	// CLI wiring path) AND BELAYER_RUNTIME_DIR is unset, fall back to legacy
+	// workspace location first, then workdir-based probe. The legacy path also
+	// emits a deprecation warning (handled by extractBridgeToRuntimeDir in normal
+	// operation; here we probe without warning since this is the test / no-daemon
+	// path).
 	if cfg.BelayerRoot == "" {
 		for _, base := range []string{workdir, repoWorkdir} {
 			if base == "" {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -37,7 +37,14 @@ import (
 type Config struct {
 	SocketPath  string
 	DBPath      string
-	BelayerRoot string // directory containing hermes_bridge/ (for PYTHONPATH)
+	BelayerRoot string // belayer root for agent identity files (agents/<identity>/)
+
+	// RuntimeDir is the directory where the daemon extracts the hermes_bridge
+	// Python package. It is the parent directory placed on PYTHONPATH when
+	// spawning bridge subprocesses. Resolved at daemon startup by the CLI via
+	// $BELAYER_RUNTIME_DIR > config.yaml:runtime_dir > $XDG_STATE_HOME/belayer/runtime
+	// > $HOME/.local/state/belayer/runtime.
+	RuntimeDir string
 
 	// TCPAddr, if non-empty, causes the daemon to also bind a TCP listener at
 	// this address (e.g. "0.0.0.0:7523"). Used when sandbox.mode=clamshell so


### PR DESCRIPTION
## Summary

- **Gap 10 + Gap 15 (run 8 — backend-dev-mvp)**: a workspace agent ran `rm -rf .belayer/` during cleanup, wiping `hermes_bridge/`. The daemon then could not spawn any further agents because `python -m hermes_bridge` failed with `No module named hermes_bridge`.
- Relocates `hermes_bridge` extraction from `belayer init` (workspace `.belayer/`) to daemon startup (resolved runtime dir outside the workspace). Now `rm -rf .belayer/` cannot break peer-bridge spawning.
- The `.belayer/` safety property: everything inside `.belayer/` is either committed user config (`agents/`, `config.yaml`, `policies/`) or ephemeral run state (`runs/`, `worktrees/`). No part of the runtime machinery lives there anymore.

## Changes

- `internal/cli/runtime.go` — new `resolveRuntimeDir` + `extractBridgeToRuntimeDir`. Resolution order: `$BELAYER_RUNTIME_DIR` > `config.yaml:runtime_dir` > `$XDG_STATE_HOME/belayer/runtime` > `$HOME/.local/state/belayer/runtime`. Extraction is idempotent (SHA-256 compare), prunes stale files, emits one-shot deprecation warn when legacy workspace path detected.
- `internal/daemon/daemon.go` — adds `RuntimeDir` to `Config`.
- `internal/cli/daemon.go` — resolves + extracts bridge at daemon start, wires `RuntimeDir` into daemon config.
- `internal/daemon/agents.go` — passes `d.config.RuntimeDir` as `bridge.Config.BelayerRoot`; clamshell override updated to `/opt/belayer/runtime`; legacy workspace fallback retained for tests that skip CLI wiring.
- `internal/cli/init.go` — removes `copyDefaultBridge` + `hermes_bridge` from subdir list; removes `/.belayer/hermes_bridge/` from `.gitignore` entries; updates header comment.
- `internal/cli/init_test.go` — replaces workspace bridge-extraction tests with runtime-dir tests; adds `TestResolveRuntimeDirPrecedence`.
- `CLAUDE.md` + `docs/AGENT_ARCHITECTURE.md` — add note: hermes_bridge lives in daemon runtime dir, not workspace.

## Test plan

- [x] `go build ./cmd/belayer` — passes
- [x] `go test ./...` — all 13 packages pass
- [x] Smoke test: `belayer init` creates `.belayer/{agents,config.yaml,policies}` with no `hermes_bridge/` subdir
- [x] Smoke test: `belayer daemon` logs `belayer runtime dir: <path>` and populates `hermes_bridge/` at the resolved XDG path
- [ ] Integration: verify clamshell `/opt/belayer/runtime` bind-mount works end-to-end (deferred — requires clamshell environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)