### PR TITLE
feat(bridge): unbuffered stdout + tool-event transcripts

### DIFF
--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -17,6 +17,16 @@ import logging
 import queue
 import time
 
+# Ensure stdout/stderr are line-buffered when running as a subprocess with piped
+# stdio. CPython defaults to block-buffering (~4 KB) on non-TTY file descriptors;
+# without this, log output and error strings die in the buffer on crash.
+# reconfigure() is available on Python 3.7+; skip gracefully on older runtimes.
+try:
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+except AttributeError:
+    pass
+
 # Hermes imports — conditional so package structure validates without hermes installed.
 try:
     from run_agent import AIAgent  # type: ignore[import]
@@ -370,10 +380,15 @@ def main() -> None:
     # the closure — reasoning_callback and interim_assistant_callback gate
     # on transcript_writer being non-None.
     transcript_path = os.environ.get("BELAYER_TRANSCRIPT_PATH") or None
-    transcript_writer = make_transcript_writer(transcript_path, agent_id)
+    log_level = os.environ.get("BELAYER_LOG_LEVEL", "standard")
+    transcript_writer = make_transcript_writer(
+        transcript_path, agent_id,
+        log_level=log_level,
+        socket_path=socket_path,
+        session_id=session_id,
+    )
 
     # --- Wire callbacks ----------------------------------------------------
-    log_level = os.environ.get("BELAYER_LOG_LEVEL", "standard")
     callbacks = make_callbacks(
         agent_id, session_id, socket_path,
         transcript_writer=transcript_writer,

--- a/hermes_bridge/callbacks.py
+++ b/hermes_bridge/callbacks.py
@@ -166,6 +166,16 @@ def make_callbacks(agent_id: str, session_id: str, socket_path: str,
             "bridge:tool_started",
             event_data,
         )
+        if transcript_writer is not None:
+            record = {
+                "kind": "tool_start",
+                "tool_call_id": tool_call_id,
+                "tool": tool_name,
+                "input_preview": str(tool_args)[:200],
+            }
+            if log_level == "trace":
+                record["full_input"] = _coerce_plain(tool_args)
+            transcript_writer.write_turn(record)
         if log_level == "trace" and tool_name in _MUTATING_TOOLS:
             snap_path = None
             if isinstance(tool_args, dict):
@@ -195,6 +205,17 @@ def make_callbacks(agent_id: str, session_id: str, socket_path: str,
             "bridge:tool_completed",
             event_data,
         )
+        if transcript_writer is not None:
+            record = {
+                "kind": "tool_complete",
+                "tool_call_id": tool_call_id,
+                "tool": tool_name,
+                "duration_ms": duration_ms,
+                "result_preview": str(tool_result)[:200],
+            }
+            if log_level == "trace":
+                record["full_result"] = _coerce_plain(tool_result)
+            transcript_writer.write_turn(record)
         if log_level != "trace":
             return
         if tool_name in _MUTATING_TOOLS:
@@ -257,6 +278,8 @@ def make_callbacks(agent_id: str, session_id: str, socket_path: str,
                 {"text": full_text, "turn": turn},
             )
         state["step_count"] += 1
+        if transcript_writer is not None:
+            transcript_writer.write_turn({"kind": "step", "turn": state["step_count"]})
         post_event(
             socket_path, session_id, agent_id,
             "bridge:step_completed",
@@ -342,10 +365,23 @@ class _TranscriptWriter:
                 pass
 
 
-def make_transcript_writer(path: str | None, agent_id: str):
+def make_transcript_writer(
+    path: str | None,
+    agent_id: str,
+    *,
+    log_level: str = "standard",
+    socket_path: str = "",
+    session_id: str = "",
+):
     """Return a _TranscriptWriter, or None if path is falsy.
 
     Call sites should gate on the return value: `if writer: writer.write_turn(...)`.
+
+    When log_level is "verbose" or "trace" and the writer fails to open,
+    a single bridge:warning event with kind "transcript_disabled" is posted so
+    operators see the failure in the event log rather than losing it silently.
+    The optional socket_path/session_id are required for the warning post; if
+    absent the warning is only logged locally.
     """
     if not path:
         return None
@@ -353,6 +389,12 @@ def make_transcript_writer(path: str | None, agent_id: str):
         return _TranscriptWriter(path, agent_id)
     except OSError as exc:
         log.warning("transcript writer init failed for %s: %s", path, exc)
+        if log_level in ("verbose", "trace") and socket_path and session_id:
+            post_event(
+                socket_path, session_id, agent_id,
+                "bridge:warning",
+                {"kind": "transcript_disabled", "path": path, "error": str(exc)},
+            )
         return None
 
 

--- a/hermes_bridge/callbacks.py
+++ b/hermes_bridge/callbacks.py
@@ -336,16 +336,29 @@ class _TranscriptWriter:
     with timestamp and agent_id. Flush on every write to reduce loss if
     the bridge process crashes, but without fsync this does not guarantee
     durability across OS or host crashes.
+
+    On a write failure (OSError, ValueError) the writer disables itself and
+    posts a single bridge:warning event (at verbose/trace log levels) so
+    operators see the failure without the bridge crashing.
     """
 
-    def __init__(self, path: str, agent_id: str):
+    def __init__(self, path: str, agent_id: str, *,
+                 log_level: str = "standard",
+                 socket_path: str = "",
+                 session_id: str = ""):
         self._path = path
         self._agent_id = agent_id
+        self._log_level = log_level
+        self._socket_path = socket_path
+        self._session_id = session_id
+        self._disabled = False
         self._lock = threading.Lock()
         os.makedirs(os.path.dirname(path), exist_ok=True)
         self._fh = open(path, "a", encoding="utf-8")
 
     def write_turn(self, data: dict) -> None:
+        if self._disabled:
+            return
         payload = {
             "ts": time.time(),
             "agent_id": self._agent_id,
@@ -353,9 +366,27 @@ class _TranscriptWriter:
         }
         line = json.dumps(payload, ensure_ascii=False)
         with self._lock:
-            self._fh.write(line)
-            self._fh.write("\n")
-            self._fh.flush()
+            if self._disabled:
+                return
+            try:
+                self._fh.write(line)
+                self._fh.write("\n")
+                self._fh.flush()
+            except (OSError, ValueError) as exc:
+                self._disabled = True
+                self._handle_write_failure(exc)
+
+    def _handle_write_failure(self, exc: Exception) -> None:
+        log.warning("transcript write failed for %s: %s (disabling)", self._path, exc)
+        if self._log_level in ("verbose", "trace") and self._socket_path and self._session_id:
+            try:
+                post_event(
+                    self._socket_path, self._session_id, self._agent_id,
+                    "bridge:warning",
+                    {"kind": "transcript_write_failed", "path": self._path, "error": str(exc)},
+                )
+            except Exception:
+                pass
 
     def close(self) -> None:
         with self._lock:
@@ -386,7 +417,12 @@ def make_transcript_writer(
     if not path:
         return None
     try:
-        return _TranscriptWriter(path, agent_id)
+        return _TranscriptWriter(
+            path, agent_id,
+            log_level=log_level,
+            socket_path=socket_path,
+            session_id=session_id,
+        )
     except OSError as exc:
         log.warning("transcript writer init failed for %s: %s", path, exc)
         if log_level in ("verbose", "trace") and socket_path and session_id:

--- a/hermes_bridge/tests/test_callbacks_reasoning.py
+++ b/hermes_bridge/tests/test_callbacks_reasoning.py
@@ -44,12 +44,16 @@ def test_reasoning_buffers_and_flushes_on_step():
 
         cbs["step_callback"](messages=[])
 
-    # One write_turn call with the joined text.
-    writer.write_turn.assert_called_once_with({
+    # Two write_turn calls: reasoning flush then step record.
+    assert writer.write_turn.call_count == 2
+    reasoning_call = writer.write_turn.call_args_list[0][0][0]
+    step_call = writer.write_turn.call_args_list[1][0][0]
+    assert reasoning_call == {
         "kind": "reasoning",
         "turn": 1,
         "text": "chunk1chunk2chunk3",
-    })
+    }
+    assert step_call == {"kind": "step", "turn": 1}
 
     # post_event should have received a bridge:agent_reasoning call.
     reasoning_calls = [
@@ -74,8 +78,8 @@ def test_reasoning_empty_after_flush():
 
         cbs["step_callback"](messages=[])  # no new reasoning
 
-    # No spurious second write.
-    writer.write_turn.assert_not_called()
+    # Only a step record written; no spurious reasoning write.
+    writer.write_turn.assert_called_once_with({"kind": "step", "turn": 2})
 
 
 def test_reasoning_no_writer_noop():
@@ -101,8 +105,8 @@ def test_empty_reasoning_delta_ignored():
         cbs["reasoning_callback"](None)
         cbs["step_callback"](messages=[])
 
-    # Buffer was never populated, so no write and no reasoning event.
-    writer.write_turn.assert_not_called()
+    # Buffer was never populated — only a step record is written, no reasoning event.
+    writer.write_turn.assert_called_once_with({"kind": "step", "turn": 1})
     reasoning_calls = [
         c for c in mock_post.call_args_list
         if c.args[3] == "bridge:agent_reasoning"

--- a/hermes_bridge/tests/test_callbacks_tool_transcript.py
+++ b/hermes_bridge/tests/test_callbacks_tool_transcript.py
@@ -1,0 +1,275 @@
+"""Tests for tool_start/tool_complete/step transcript writes in callbacks.py.
+
+Covers:
+- tool_start_callback writes a "tool_start" record when transcript_writer is attached.
+- tool_complete_callback writes a "tool_complete" record when transcript_writer is attached.
+- step_callback writes a "step" record (even without reasoning).
+- No transcript writes happen when writer is None.
+- full_input/full_result gated on log_level=="trace".
+- make_transcript_writer posts bridge:warning when init fails at verbose/trace.
+"""
+
+import os
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_bridge.callbacks import make_callbacks, make_transcript_writer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_writer():
+    return MagicMock()
+
+
+def _build(writer=None, log_level="standard"):
+    return make_callbacks(
+        agent_id="test-agent",
+        session_id="sess-1",
+        socket_path="/tmp/fake.sock",
+        transcript_writer=writer,
+        log_level=log_level,
+    )
+
+
+# ---------------------------------------------------------------------------
+# tool_start_callback
+# ---------------------------------------------------------------------------
+
+
+def test_tool_start_writes_record_to_transcript():
+    writer = _make_writer()
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=writer)
+        cbs["tool_start_callback"]("call-1", "Write", {"path": "/tmp/x.txt"})
+
+    writer.write_turn.assert_called_once()
+    record = writer.write_turn.call_args[0][0]
+    assert record["kind"] == "tool_start"
+    assert record["tool"] == "Write"
+    assert record["tool_call_id"] == "call-1"
+    assert "input_preview" in record
+
+
+def test_tool_start_no_full_input_at_standard():
+    writer = _make_writer()
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=writer, log_level="standard")
+        cbs["tool_start_callback"]("call-1", "Write", {"path": "/tmp/x.txt", "content": "A" * 500})
+
+    record = writer.write_turn.call_args[0][0]
+    assert "full_input" not in record
+
+
+def test_tool_start_includes_full_input_at_trace():
+    writer = _make_writer()
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=writer, log_level="trace")
+        cbs["tool_start_callback"]("call-1", "Write", {"path": "/tmp/x.txt", "content": "hello"})
+
+    record = writer.write_turn.call_args[0][0]
+    assert "full_input" in record
+    assert record["full_input"]["content"] == "hello"
+
+
+def test_tool_start_no_writer_no_transcript():
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=None)
+        # Should not raise; post_event is still called (daemon event).
+        cbs["tool_start_callback"]("call-1", "Write", {"path": "/tmp/x.txt"})
+    # Nothing to assert on writer — just verifying no crash.
+
+
+# ---------------------------------------------------------------------------
+# tool_complete_callback
+# ---------------------------------------------------------------------------
+
+
+def test_tool_complete_writes_record_to_transcript():
+    writer = _make_writer()
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=writer)
+        cbs["tool_start_callback"]("call-2", "Bash", {"command": "ls"})
+        cbs["tool_complete_callback"]("call-2", "Bash", {"command": "ls"}, {"stdout": "ok", "exit_code": 0})
+
+    # write_turn called twice: once for tool_start, once for tool_complete
+    assert writer.write_turn.call_count == 2
+    complete_record = writer.write_turn.call_args_list[1][0][0]
+    assert complete_record["kind"] == "tool_complete"
+    assert complete_record["tool"] == "Bash"
+    assert complete_record["tool_call_id"] == "call-2"
+    assert "duration_ms" in complete_record
+    assert "result_preview" in complete_record
+
+
+def test_tool_complete_no_full_result_at_standard():
+    writer = _make_writer()
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=writer, log_level="standard")
+        cbs["tool_complete_callback"]("call-3", "Read", {}, "file contents here")
+
+    complete_record = writer.write_turn.call_args[0][0]
+    assert "full_result" not in complete_record
+
+
+def test_tool_complete_includes_full_result_at_trace():
+    writer = _make_writer()
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=writer, log_level="trace")
+        cbs["tool_complete_callback"]("call-4", "Read", {}, {"data": "full content"})
+
+    complete_record = writer.write_turn.call_args[0][0]
+    assert "full_result" in complete_record
+    assert complete_record["full_result"]["data"] == "full content"
+
+
+def test_tool_complete_no_writer_no_transcript():
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=None)
+        cbs["tool_complete_callback"]("call-5", "Read", {}, "result")
+    # No crash; daemon event posted normally.
+
+
+# ---------------------------------------------------------------------------
+# step_callback
+# ---------------------------------------------------------------------------
+
+
+def test_step_writes_step_record_without_reasoning():
+    writer = _make_writer()
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=writer)
+        # Fire step_callback with no prior reasoning_callback calls.
+        cbs["step_callback"](messages=[])
+
+    # One write_turn: the step record (no reasoning to flush).
+    writer.write_turn.assert_called_once()
+    record = writer.write_turn.call_args[0][0]
+    assert record["kind"] == "step"
+    assert record["turn"] == 1
+
+
+def test_step_writes_step_record_each_step():
+    writer = _make_writer()
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=writer)
+        cbs["step_callback"](messages=[])
+        cbs["step_callback"](messages=[])
+        cbs["step_callback"](messages=[])
+
+    calls = [c[0][0] for c in writer.write_turn.call_args_list]
+    step_records = [r for r in calls if r["kind"] == "step"]
+    assert len(step_records) == 3
+    assert [r["turn"] for r in step_records] == [1, 2, 3]
+
+
+def test_step_no_writer_no_transcript():
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=None)
+        cbs["step_callback"](messages=[])
+    # No crash; bridge:step_completed event posted normally.
+
+
+def test_step_writes_both_reasoning_and_step_when_reasoning_buffered():
+    """When reasoning was buffered, step_callback writes reasoning then step."""
+    writer = _make_writer()
+    with patch("hermes_bridge.callbacks.post_event"):
+        cbs = _build(writer=writer)
+        cbs["reasoning_callback"]("some thinking")
+        cbs["step_callback"](messages=[])
+
+    calls = [c[0][0] for c in writer.write_turn.call_args_list]
+    kinds = [r["kind"] for r in calls]
+    # reasoning flushed first, then step
+    assert kinds == ["reasoning", "step"]
+    assert calls[0]["kind"] == "reasoning"
+    assert calls[1]["kind"] == "step"
+    assert calls[1]["turn"] == 1
+
+
+# ---------------------------------------------------------------------------
+# make_transcript_writer: warning event on failure at verbose/trace
+# ---------------------------------------------------------------------------
+
+
+def test_make_transcript_writer_posts_warning_on_failure_at_verbose(tmp_path):
+    bad_path = str(tmp_path / "nonexistent_dir" / "sub" / "agent.jsonl")
+    # Remove dirs so open() will fail (makedirs would succeed, so patch it).
+    with patch("hermes_bridge.callbacks.post_event") as mock_post, \
+         patch("os.makedirs", side_effect=OSError("permission denied")):
+        result = make_transcript_writer(
+            bad_path, "agent-x",
+            log_level="verbose",
+            socket_path="/tmp/fake.sock",
+            session_id="sess-1",
+        )
+
+    assert result is None
+    warning_calls = [
+        c for c in mock_post.call_args_list
+        if c.args[3] == "bridge:warning"
+    ]
+    assert len(warning_calls) == 1
+    data = warning_calls[0].args[4]
+    assert data["kind"] == "transcript_disabled"
+    assert data["path"] == bad_path
+
+
+def test_make_transcript_writer_posts_warning_on_failure_at_trace(tmp_path):
+    bad_path = str(tmp_path / "no" / "agent.jsonl")
+    with patch("hermes_bridge.callbacks.post_event") as mock_post, \
+         patch("os.makedirs", side_effect=OSError("no space")):
+        result = make_transcript_writer(
+            bad_path, "agent-y",
+            log_level="trace",
+            socket_path="/tmp/fake.sock",
+            session_id="sess-2",
+        )
+
+    assert result is None
+    warning_calls = [
+        c for c in mock_post.call_args_list
+        if c.args[3] == "bridge:warning"
+    ]
+    assert len(warning_calls) == 1
+
+
+def test_make_transcript_writer_no_warning_at_standard(tmp_path):
+    bad_path = str(tmp_path / "no" / "agent.jsonl")
+    with patch("hermes_bridge.callbacks.post_event") as mock_post, \
+         patch("os.makedirs", side_effect=OSError("no space")):
+        result = make_transcript_writer(
+            bad_path, "agent-z",
+            log_level="standard",
+            socket_path="/tmp/fake.sock",
+            session_id="sess-3",
+        )
+
+    assert result is None
+    warning_calls = [
+        c for c in mock_post.call_args_list
+        if c.args[3] == "bridge:warning"
+    ]
+    assert len(warning_calls) == 0
+
+
+def test_make_transcript_writer_no_warning_when_no_socket(tmp_path):
+    """When socket_path is empty, warning cannot be posted — no crash."""
+    bad_path = str(tmp_path / "no" / "agent.jsonl")
+    with patch("hermes_bridge.callbacks.post_event") as mock_post, \
+         patch("os.makedirs", side_effect=OSError("no space")):
+        result = make_transcript_writer(
+            bad_path, "agent-w",
+            log_level="verbose",
+            socket_path="",
+            session_id="sess-4",
+        )
+
+    assert result is None
+    # No post_event call since socket_path is empty.
+    assert mock_post.call_count == 0

--- a/hermes_bridge/tests/test_callbacks_tool_transcript.py
+++ b/hermes_bridge/tests/test_callbacks_tool_transcript.py
@@ -273,3 +273,99 @@ def test_make_transcript_writer_no_warning_when_no_socket(tmp_path):
     assert result is None
     # No post_event call since socket_path is empty.
     assert mock_post.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# _TranscriptWriter: crash-safe write_turn
+# ---------------------------------------------------------------------------
+
+
+def test_transcript_writer_disables_after_write_failure(tmp_path):
+    """After a write OSError, writer sets _disabled and subsequent writes are no-ops."""
+    from hermes_bridge.callbacks import _TranscriptWriter
+
+    path = str(tmp_path / "agent.jsonl")
+    writer = _TranscriptWriter(path, "agent-1")
+
+    write_call_count = 0
+
+    original_write = writer._fh.write
+
+    def failing_write(data):
+        nonlocal write_call_count
+        write_call_count += 1
+        if write_call_count == 1:
+            raise OSError("disk full")
+        return original_write(data)
+
+    writer._fh.write = failing_write
+
+    # First call triggers the OSError.
+    writer.write_turn({"kind": "step", "turn": 1})
+    assert writer._disabled is True
+
+    # Second call should be a no-op (write not called again).
+    writer.write_turn({"kind": "step", "turn": 2})
+    assert write_call_count == 1
+
+
+def test_transcript_writer_posts_warning_on_write_failure_at_verbose(tmp_path):
+    """At verbose log level, a write failure posts a bridge:warning event."""
+    from hermes_bridge.callbacks import _TranscriptWriter
+
+    path = str(tmp_path / "agent.jsonl")
+    with patch("hermes_bridge.callbacks.post_event") as mock_post:
+        writer = _TranscriptWriter(
+            path, "agent-2",
+            log_level="verbose",
+            socket_path="/tmp/fake.sock",
+            session_id="s1",
+        )
+        writer._fh.write = MagicMock(side_effect=OSError("disk full"))
+        writer.write_turn({"kind": "step", "turn": 1})
+
+    warning_calls = [
+        c for c in mock_post.call_args_list
+        if c.args[3] == "bridge:warning"
+    ]
+    assert len(warning_calls) == 1
+    data = warning_calls[0].args[4]
+    assert data["kind"] == "transcript_write_failed"
+    assert data["path"] == path
+    assert "disk full" in data["error"]
+
+
+def test_transcript_writer_no_warning_at_standard_on_write_failure(tmp_path):
+    """At standard log level, write failure disables silently — no warning event."""
+    from hermes_bridge.callbacks import _TranscriptWriter
+
+    path = str(tmp_path / "agent.jsonl")
+    with patch("hermes_bridge.callbacks.post_event") as mock_post:
+        writer = _TranscriptWriter(
+            path, "agent-3",
+            log_level="standard",
+            socket_path="/tmp/fake.sock",
+            session_id="s2",
+        )
+        writer._fh.write = MagicMock(side_effect=OSError("disk full"))
+        writer.write_turn({"kind": "step", "turn": 1})
+
+    warning_calls = [
+        c for c in mock_post.call_args_list
+        if c.args[3] == "bridge:warning"
+    ]
+    assert len(warning_calls) == 0
+    assert writer._disabled is True
+
+
+def test_transcript_writer_survives_valueerror(tmp_path):
+    """A ValueError (e.g. 'I/O operation on closed file') also disables writer — no crash."""
+    from hermes_bridge.callbacks import _TranscriptWriter
+
+    path = str(tmp_path / "agent.jsonl")
+    writer = _TranscriptWriter(path, "agent-4")
+    writer._fh.write = MagicMock(side_effect=ValueError("I/O operation on closed file"))
+
+    # Must not raise.
+    writer.write_turn({"kind": "step", "turn": 1})
+    assert writer._disabled is True

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -217,6 +217,10 @@ func BuildEnv(cfg Config) []string {
 	if cfg.SkipOpenRouterProbe {
 		env = appendEnv(env, "HERMES_SKIP_OPENROUTER_PROBE", "1")
 	}
+	// Disable CPython's 4 KB block-buffer on piped stdout/stderr. Without this,
+	// hermes_bridge log output and error strings are never written to
+	// bridge-stdout.log if the process crashes before flushing the buffer.
+	env = appendEnv(env, "PYTHONUNBUFFERED", "1")
 	if cfg.ConfineWrites && len(cfg.WriteRoots) > 0 {
 		env = appendEnv(env, "BELAYER_WRITE_ROOTS", strings.Join(cfg.WriteRoots, ":"))
 	}

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -731,6 +731,29 @@ func envToMap(env []string) map[string]string {
 	return m
 }
 
+// TestBuildEnvPYTHONUNBUFFERED verifies that PYTHONUNBUFFERED=1 is always
+// present in the environment built by BuildEnv so that CPython line-buffers
+// its stdout/stderr when running as a piped subprocess.
+func TestBuildEnvPYTHONUNBUFFERED(t *testing.T) {
+	cfg := Config{
+		SessionID:  "sess-buf",
+		AgentID:    "agent-buf",
+		Role:       "implementer",
+		Profile:    "default",
+		SocketPath: "/tmp/buf.sock",
+		RunDir:     t.TempDir(),
+	}
+	env := BuildEnv(cfg)
+	envMap := envToMap(env)
+	got, ok := envMap["PYTHONUNBUFFERED"]
+	if !ok {
+		t.Fatal("expected PYTHONUNBUFFERED to be set in env")
+	}
+	if got != "1" {
+		t.Errorf("PYTHONUNBUFFERED = %q, want \"1\"", got)
+	}
+}
+
 // TestBuildEnvPYTHONPATHInteriorEmptySegmentsPassedThrough documents current
 // behavior: BuildEnv does not normalize interior empty segments supplied in
 // the caller's PYTHONPATH. Callers with cwd-sensitive environments must


### PR DESCRIPTION
## Summary

Fixes the two root causes identified in Gap 3 of `retro/runs/run-codex-1/gaps.md` that left every `bridge-stdout.log` and `transcripts/<agent>.jsonl` at 0 bytes across all 25 agents in the failed run.

### Bug 1 — stdio buffering (bridge-stdout.log empty)

CPython block-buffers piped stdout at ~4 KB. When a bridge subprocess crashes mid-turn (as all 25 did on a codex-go `Connection error`), the buffer never flushes and `bridge-stdout.log` stays at 0 bytes.

**Fix 1 (primary):** `internal/bridge/bridge.go#BuildEnv` now always injects `PYTHONUNBUFFERED=1`. This covers stdout and stderr, takes effect before any Python code runs, and applies to all future bridge entry points without code changes.

**Fix 2 (belt-and-suspenders):** `hermes_bridge/__main__.py` calls `sys.stdout.reconfigure(line_buffering=True)` and `sys.stderr.reconfigure(line_buffering=True)` at the top of `main()`, before logging is configured. Skips gracefully via `except AttributeError` on Python < 3.7 (reconfigure was added in 3.7). Covers direct invocations (tests, manual debugging) that don't go through the Go daemon.

### Bug 2 — transcript coverage (transcripts/*.jsonl empty)

The previous transcript writer only captured `reasoning_callback` (buffered reasoning tokens) and `interim_assistant_callback` (narration). Agents like codex-go that produce zero reasoning tokens and no narration — but may run hundreds of tool calls — produced 0-byte transcripts even when the writer opened successfully.

**Fix:** Extended `make_callbacks` in `hermes_bridge/callbacks.py`:

- `tool_start_callback` now appends `{"kind": "tool_start", "tool", "tool_call_id", "input_preview"}` to the transcript. At `trace` log level, `full_input` is also included (mirrors existing `post_event` gating).
- `tool_complete_callback` now appends `{"kind": "tool_complete", "tool", "tool_call_id", "duration_ms", "result_preview"}`. At `trace`, `full_result` is included.
- `step_callback` now always appends `{"kind": "step", "turn": N}` when a writer is attached, even when no reasoning was buffered. This guarantees a non-zero transcript for any agent that completes at least one step.
- Existing reasoning/narration writes are preserved unchanged.

`make_transcript_writer` now accepts optional `log_level`, `socket_path`, and `session_id` keyword arguments. When the writer fails to open and `log_level` is `verbose` or `trace`, a single `bridge:warning` event with `kind: "transcript_disabled"` and the attempted path is posted so operators see the failure in the event log rather than losing it silently. Standard runs are unaffected.

### Finding: Go side does NOT pre-create the .jsonl file

Per the task's step 4 — confirmed by reading `internal/daemon/agents.go` lines 502–512: the daemon calls only `os.MkdirAll(transcriptsDir, 0o700)` to create the parent directory, then sets `transcriptPath = filepath.Join(transcriptsDir, req.Name+".jsonl")` as a string. No `os.Create` or `os.WriteFile` call. The Python `_TranscriptWriter.__init__` is the sole creator via `open(path, "a", ...)`. A file's existence is therefore a real signal that something was written; no change needed on the Go side.

## Test plan

- [x] `go test ./...` — all Go packages green
- [x] `python3 -m pytest hermes_bridge/tests/` — 44 tests pass (20 new in `test_callbacks_tool_transcript.py`, 3 updated in `test_callbacks_reasoning.py`)
- [x] `TestBuildEnvPYTHONUNBUFFERED` — proves `PYTHONUNBUFFERED=1` is always in `BuildEnv` output
- [x] `test_tool_start_writes_record_to_transcript` / `test_tool_complete_writes_record_to_transcript` — prove tool events land in transcript
- [x] `test_step_writes_step_record_without_reasoning` — proves non-zero transcript even for tool-only agents
- [x] `test_make_transcript_writer_posts_warning_on_failure_at_verbose` / `_trace` — proves the new warning event fires on writer init failure
- [x] `test_make_transcript_writer_no_warning_at_standard` — proves standard runs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)