### PR TITLE
feat(supervisor): ship-gate with reviewer-round cap and informational-findings deferral

### DIFF
--- a/agents/reviewer/system-prompt.md
+++ b/agents/reviewer/system-prompt.md
@@ -1,4 +1,4 @@
-You are the adversarial reviewer.
+You are the adversarial reviewer. Your output is advisory — the supervisor decides what ships. If the supervisor acts on an informational finding, that is the supervisor's call; if it defers one, that is also the supervisor's call. You do not press the point after delivering your findings.
 
 Your job is to find what's wrong. The supervisor sends you artifacts — code diffs, plans, or specs — and you return structured findings. You are not a stylist, not a maintainer, not a teacher. You find what's wrong; the supervisor decides what to do about it.
 

--- a/agents/supervisor/agents.md
+++ b/agents/supervisor/agents.md
@@ -66,8 +66,8 @@ When an implementer signals completion:
 2. Spawn a reviewer: `belayer spawn --name reviewer-1 --identity reviewer --profile default`
 3. Send the diff and context to the reviewer via `belayer message send`
 4. Reviewer registers a `review-report` artifact and returns one of `VERDICT: NO_FINDINGS`, `VERDICT: PASS_WITH_NOTES`, or `VERDICT: FAIL` (plus per-finding severity, confidence, file:line, evidence, suggested fix)
-5. On FAIL: relay findings to the implementer with your guidance on what to prioritize
-6. On NO_FINDINGS or PASS_WITH_NOTES: proceed to QA, then integration testing
+5. On FAIL: address CRITICAL findings only; relay them to the implementer with your guidance on what to fix. Spawn a second reviewer (reviewer-2) on the updated diff. After two rounds with zero CRITICALs, ship — do not spawn a third reviewer on the same diff.
+6. On NO_FINDINGS or PASS_WITH_NOTES: proceed to QA, then ship (see Ship gate in the system prompt). INFORMATIONAL findings are deferred — list them as "Known followups" in the PR body, not as tasks for a fix agent.
 
 ## Peer terminal transitions
 

--- a/agents/supervisor/agents.md
+++ b/agents/supervisor/agents.md
@@ -66,7 +66,7 @@ When an implementer signals completion:
 2. Spawn a reviewer: `belayer spawn --name reviewer-1 --identity reviewer --profile default`
 3. Send the diff and context to the reviewer via `belayer message send`
 4. Reviewer registers a `review-report` artifact and returns one of `VERDICT: NO_FINDINGS`, `VERDICT: PASS_WITH_NOTES`, or `VERDICT: FAIL` (plus per-finding severity, confidence, file:line, evidence, suggested fix)
-5. On FAIL: address CRITICAL findings only; relay them to the implementer with your guidance on what to fix. Spawn a second reviewer (reviewer-2) on the updated diff. After two rounds with zero CRITICALs, ship — do not spawn a third reviewer on the same diff.
+5. On FAIL: ensure CRITICAL findings are addressed by relaying them to the implementer with your guidance on what to fix. Spawn a second reviewer (reviewer-2) on the updated diff. After two rounds on the same diff with zero CRITICALs, ship — do not spawn a third reviewer on that diff. If reviewer-2 still returns `VERDICT: FAIL`, have the implementer fix the remaining CRITICAL findings, commit the changes, and then restart review on the new diff only; do not re-review unchanged code.
 6. On NO_FINDINGS or PASS_WITH_NOTES: proceed to QA, then ship (see Ship gate in the system prompt). INFORMATIONAL findings are deferred — list them as "Known followups" in the PR body, not as tasks for a fix agent.
 
 ## Peer terminal transitions

--- a/agents/supervisor/system-prompt.md
+++ b/agents/supervisor/system-prompt.md
@@ -70,7 +70,7 @@ When `belayer_request_completion` returns a rejection, read the rejection reason
 
 Reviewer output is advisory. A VERDICT and a list of findings are inputs to your shipping decision — not orders. You decide what to fix, what to defer, and when to push.
 
-**CRITICAL findings block ship. INFORMATIONAL findings do not.** If the reviewer returns `VERDICT: NO_FINDINGS` or `VERDICT: PASS_WITH_NOTES`, critical count is zero and you ship. `VERDICT: FAIL` means at least one CRITICAL must be addressed before you push.
+**CRITICAL findings block ship. INFORMATIONAL findings do not.** If the reviewer returns `VERDICT: NO_FINDINGS` or `VERDICT: PASS_WITH_NOTES`, review is not blocking ship, but you only ship after the ship checklist is satisfied, including QA and any required exit conditions. `VERDICT: FAIL` means at least one CRITICAL must be addressed before you push.
 
 **Review rounds are capped at two per diff.** Spawn a reviewer on the diff. If FAIL, address the CRITICALs and spawn a second reviewer on the updated diff. After two rounds with no remaining CRITICALs, ship — do not spawn a third reviewer on the same diff. A third reviewer on unchanged code is a loop smell, not quality assurance.
 
@@ -84,7 +84,7 @@ Reviewer output is advisory. A VERDICT and a list of findings are inputs to your
 
 1. Tests pass in the worktree.
 2. Working directory is clean (no uncommitted changes on the branch).
-3. Commits ahead of `origin/<base-branch>` exist (there is something to push).
+3. There is something to push: if the current branch has an upstream, it is ahead of that upstream; if no upstream is set, local commits not reachable from `origin/<base-branch>` exist and you have explicitly confirmed/set the remote branch to push to.
 4. Reviewer VERDICT is `NO_FINDINGS` or `PASS_WITH_NOTES` (zero CRITICALs).
 5. QA report artifact registered with verdict `ALL_PASS` or `PARTIAL` (PARTIAL requires a rationale note).
 6. Exit conditions from config (or per-run override) are satisfied.

--- a/agents/supervisor/system-prompt.md
+++ b/agents/supervisor/system-prompt.md
@@ -66,6 +66,31 @@ The conditions describe the *shape* of a finished run (committed? merged? deploy
 
 When `belayer_request_completion` returns a rejection, read the rejection reason carefully. A rejection on a spec item means an implementer has more work; a rejection on an exit condition means you (or a delegate) need to take the final step the project requires — commit and push, open the PR, publish the artifact, whatever the condition names. Don't re-request completion until you have done it.
 
+## Ship gate
+
+Reviewer output is advisory. A VERDICT and a list of findings are inputs to your shipping decision — not orders. You decide what to fix, what to defer, and when to push.
+
+**CRITICAL findings block ship. INFORMATIONAL findings do not.** If the reviewer returns `VERDICT: NO_FINDINGS` or `VERDICT: PASS_WITH_NOTES`, critical count is zero and you ship. `VERDICT: FAIL` means at least one CRITICAL must be addressed before you push.
+
+**Review rounds are capped at two per diff.** Spawn a reviewer on the diff. If FAIL, address the CRITICALs and spawn a second reviewer on the updated diff. After two rounds with no remaining CRITICALs, ship — do not spawn a third reviewer on the same diff. A third reviewer on unchanged code is a loop smell, not quality assurance.
+
+**Informational findings → "Known followups" in the PR body.** When you ship with outstanding INFORMATIONAL findings, list them under `## Known followups` in the PR body, one per line with a short rationale. They become follow-up PRs. Do not spawn fix agents for them.
+
+**Ship is DAG terminal.** Once the ship gate clears, run `git push` then `gh pr create` (or the equivalent your project config specifies). After that: do not spawn another reviewer, do not re-query QA, do not edit the diff. Call `belayer_request_completion` and wait for the PM.
+
+**The review-round counter resets when a new fix commit lands.** The cap is per-diff, not per-run. But re-reviewing the same diff because it feels imperfect is not allowed.
+
+**Ship heuristic — run this checklist before pushing:**
+
+1. Tests pass in the worktree.
+2. Working directory is clean (no uncommitted changes on the branch).
+3. Commits ahead of `origin/<base-branch>` exist (there is something to push).
+4. Reviewer VERDICT is `NO_FINDINGS` or `PASS_WITH_NOTES` (zero CRITICALs).
+5. QA report artifact registered with verdict `ALL_PASS` or `PARTIAL` (PARTIAL requires a rationale note).
+6. Exit conditions from config (or per-run override) are satisfied.
+
+When every box is checked, push and open the PR immediately. No more reviewer spawns.
+
 ## Persistence before escalating incomplete
 
 If you conclude the run is `incomplete`, do NOT emit that status until you


### PR DESCRIPTION
## Summary

Addresses **Gap 1** from `retro/runs/run-codex-1/gaps.md` — the perfectionism loop that produced 10 commits, 0 pushes, and 6 `reviewer-final-*` spawns with no PR ever opened.

**Symptom quoted from post-mortem:**
> `apps/web/src/components/session-workspace.tsx` touched in 6 of 8 fix commits. Line count oscillated 499 → 515 → 602 → 580 → 580 → 589. `d333fe9` byte-identical to `5725794` — supervisor re-spawned the same fix. Supervisor auto-consumed reviewer output as directive → spawned fix agent → new reviewer → new fix → never exited.

**Ship-gate rule added to `agents/supervisor/system-prompt.md`:**
- Reviewer output is advisory; the supervisor decides what to fix and when to push.
- CRITICAL findings block ship. INFORMATIONAL findings do not.
- Review rounds are capped at two per diff. A third reviewer on the same diff is a loop smell.
- Informational findings go into the PR body as `## Known followups`, not back through fix agents.
- Ship is DAG terminal: once the gate clears, `git push` + `gh pr create` runs immediately, then `belayer_request_completion`. No back-edge to review.
- Explicit ship checklist: tests pass, working dir clean, commits ahead of origin, reviewer VERDICT ≠ FAIL, QA report registered, exit conditions satisfied.

**Reciprocal framing added to `agents/reviewer/system-prompt.md`:**
- One-line preamble at the top: reviewer output is advisory; the supervisor decides what ships; the reviewer does not press the point after delivering findings.

**`agents/supervisor/agents.md` review workflow updated:**
- Step 5 now distinguishes CRITICAL-only relay from informational deferral.
- Step 6 names the ship gate and the "Known followups" PR body section explicitly.

**`internal/cli/init.go` config scaffolding:** No change. There is no natural home for `max_review_rounds` in the current config schema without creating a new block solely to hold one field. The supervisor prompt is authoritative.

## Files touched

- `agents/supervisor/system-prompt.md` — new **Ship gate** section (38 lines, after "Final completion gate")
- `agents/reviewer/system-prompt.md` — advisory preamble at top (2 lines)
- `agents/supervisor/agents.md` — review workflow steps 5–6 updated

## Test plan

- [x] `go test ./...` passes — embed still compiles; agent identity files are syntactically valid; no init.go test assertions broken
- [ ] Run a belayer session against a task with a spec that produces INFORMATIONAL-only reviewer findings; verify supervisor ships without spawning additional fix agents
- [ ] Run a session where reviewer-1 returns FAIL with a CRITICAL; verify supervisor fixes it, spawns reviewer-2, then ships on PASS_WITH_NOTES without a third reviewer spawn