### PR TITLE
feat: embedded web UI, multi-daemon dashboard, workspace-scoped defaults

### DIFF
--- a/docs/dashboard-spec.md
+++ b/docs/dashboard-spec.md
@@ -1,0 +1,182 @@
+# Belayer Dashboard — Multi-Daemon Unified Web UI
+
+## Goal
+A single `belayer dashboard` command serves one Web UI that aggregates sessions, events, messages, and agents from multiple Belayer daemons running on the same machine.
+
+## Architecture
+
+```
+┌─────────────┐     ┌─────────────────────────────┐     ┌─────────────┐
+│   Browser   │────▶│  belayer dashboard :7525   │────▶│  Daemon A   │
+│  (UI /ui/)  │     │  - static files             │     │  :7523      │
+└─────────────┘     │  - /api/daemons list        │────▶│  Daemon B   │
+                    │  - /api/daemons/{n}/...     │     │  :7524      │
+                    │    reverse proxy            │     └─────────────┘
+                    └─────────────────────────────┘
+```
+
+The dashboard is a thin reverse-proxy + static-file server. It does NOT hold state. All session data lives in the individual daemons.
+
+## Backend — New Package `internal/dashboard/`
+
+### Types
+
+```go
+package dashboard
+
+type DaemonConfig struct {
+    Name  string `yaml:"name"`
+    URL   string `yaml:"url"`   // e.g. http://localhost:7523
+    Token string `yaml:"token"` // bearer token for that daemon
+}
+
+type Server struct {
+    daemons []DaemonConfig
+    // reverse proxies cached per daemon
+    proxies map[string]*httputil.ReverseProxy
+}
+```
+
+### Routes
+
+| Route | Handler | Description |
+|-------|---------|-------------|
+| `GET /ui/{$}` | `handleWebUI` | Serve `index.html` from embedded `belayer.WebUI` |
+| `GET /ui/{path...}` | `handleWebUI` | Serve CSS/JS/static assets |
+| `GET /api/daemons` | `handleListDaemons` | JSON array of `{name, url, healthy}` |
+| `GET /api/daemons/{name}/health` | `handleProxy` | Proxy to daemon `/health` |
+| `GET /api/daemons/{name}/sessions` | `handleProxy` | Proxy to daemon `/sessions` |
+| `GET /api/daemons/{name}/sessions/{id}` | `handleProxy` | Proxy to daemon `/sessions/{id}` |
+| `GET /api/daemons/{name}/sessions/{id}/events` | `handleProxy` | Proxy to daemon `/sessions/{id}/events` |
+| `GET /api/daemons/{name}/events/stream` | `handleProxySSE` | Proxy SSE stream (no buffering) |
+| `GET /api/daemons/{name}/sessions/{id}/tool-calls` | `handleProxy` | Proxy to daemon `/sessions/{id}/tool-calls` |
+| `GET /api/daemons/{name}/sessions/{id}/outline` | `handleProxy` | Proxy to daemon `/sessions/{id}/outline` |
+| `GET /api/daemons/{name}/sessions/{id}/artifacts` | `handleProxy` | Proxy to daemon `/sessions/{id}/artifacts` |
+| `GET /api/daemons/{name}/sessions/{id}/transcripts` | `handleProxy` | Proxy to daemon `/sessions/{id}/transcripts` |
+| `GET /api/daemons/{name}/sessions/{id}/transcripts/{agent}` | `handleProxy` | Proxy to daemon `/sessions/{id}/transcripts/{agent}` |
+| `GET /api/daemons/{name}/sessions/{id}/conversation` | `handleProxy` | Proxy to daemon `/sessions/{id}/conversation` |
+| `GET /api/daemons/{name}/sessions/{id}/phase` | `handleProxy` | Proxy to daemon `/sessions/{id}/phase` |
+
+### Proxy behavior
+
+- For each daemon, create an `httputil.ReverseProxy` with a custom `Director` that:
+  1. Rewrites the request URL from `/api/daemons/{name}/...` to `/{...}`
+  2. Sets `Authorization: Bearer <token>` header
+  3. Sets `X-Forwarded-For` (optional but nice)
+- For SSE (`/events/stream`), ensure `FlushInterval` is set on the proxy transport so events stream immediately
+- The proxy should NOT buffer the response body
+
+### Static file serving
+
+Reuse the exact same pattern as `internal/daemon/webui.go`:
+```go
+func handleWebUI(w http.ResponseWriter, r *http.Request) {
+    path := strings.TrimPrefix(r.URL.Path, "/ui")
+    if path == "" || path == "/" { path = "/index.html" }
+    content, err := belayer.WebUI.ReadFile("web" + path)
+    // ... set Content-Type, write
+}
+```
+
+### Health check
+
+`GET /api/daemons` should do a lightweight `GET /health` on each daemon (with 2s timeout) and report `healthy: true/false`.
+
+## CLI — `internal/cli/dashboard.go`
+
+New command:
+```bash
+belayer dashboard --port 7525 \
+  --daemon "extend-api=http://localhost:7523:tokenA" \
+  --daemon "relay-ide=http://localhost:7524:tokenB"
+```
+
+Flags:
+- `--port` / `-p` (default `7525`)
+- `--daemon` (repeatable) — format `name=url:token`
+- `--config` — path to YAML config file with the same daemon list
+
+If `--config` is provided, parse it. Otherwise parse `--daemon` flags. At least one daemon must be configured.
+
+## Frontend — `web/app.js` Multi-Daemon Mode
+
+### Detection
+On startup, attempt `GET /api/daemons`:
+- **200 with array** → dashboard/multi-daemon mode
+- **404** → single-daemon mode (backward compatible)
+
+### Multi-daemon state additions
+```js
+let daemons = [];        // [{name, url, healthy}]
+let activeDaemon = null; // name of daemon owning active session
+```
+
+### UI changes
+
+**Sidebar — Sessions section**
+Replace the flat session list with grouped list:
+```
+Sessions
+├── extend-api ●
+│   ├── session-abc (running)
+│   └── session-def (complete)
+├── relay-ide ●
+│   └── session-xyz (running)
+```
+
+Each daemon name has a health dot (green/yellow/red). Sessions are indented under their daemon.
+
+**Top bar**
+Show `Dashboard` instead of `Belayer` in brand. Show active daemon name next to session name.
+
+**API helper changes**
+```js
+function apiUrl(daemonName, path) {
+    if (dashboardMode) {
+        return `/api/daemons/${encodeURIComponent(daemonName)}${path}`;
+    }
+    return path; // single-daemon mode
+}
+```
+
+All `apiGet`, `apiGetText`, and SSE `openSSE` calls must include the daemon name.
+
+**SSE in multi-daemon mode**
+```js
+function openSSE(daemonName, sessionId) {
+    const url = apiUrl(daemonName, `/events/stream?sessions=${encodeURIComponent(sessionId)}&tier=verbose&after=${lastEventId}`);
+    // ... rest same as current SSE logic
+}
+```
+
+**Session selection**
+When a session is clicked, we now know both the session ID and its daemon name. Set `activeDaemon` and proceed as before.
+
+**Polling**
+`loadSessions` in multi-daemon mode fetches `/api/daemons`, then for each daemon fetches `/api/daemons/{name}/sessions`, and combines results.
+
+### Backward compatibility
+Single-daemon mode must work exactly as before. All changes should be additive — the UI detects dashboard mode at runtime.
+
+## Files to create / modify
+
+### New files
+- `internal/dashboard/server.go` — dashboard HTTP server + proxy
+- `internal/cli/dashboard.go` — CLI command wiring
+- `internal/dashboard/server_test.go` — proxy + static file tests
+
+### Modified files
+- `cmd/belayer/main.go` — register `dashboard` subcommand
+- `web/app.js` — multi-daemon detection + UI
+- `web/index.html` — minor: add daemon list container, dashboard brand
+- `web/style.css` — minor: daemon group styles, indentation
+
+## CORS considerations
+
+Since the dashboard proxies all requests, the browser only talks to the dashboard origin. No CORS configuration is needed on the individual daemons. The dashboard → daemon requests are server-to-server.
+
+## Security
+
+- The dashboard does not enforce auth itself (it serves static files publicly)
+- Auth is delegated to each daemon via the `Authorization: Bearer <token>` header injected by the proxy
+- Tokens are configured explicitly by the operator; there is no auto-discovery that could leak tokens

--- a/docs/hermes-proxmox-lxc-deployment.md
+++ b/docs/hermes-proxmox-lxc-deployment.md
@@ -1,0 +1,286 @@
+# Hermes Agent on Proxmox LXC
+
+Deploy Hermes Agent to a privileged Proxmox LXC container with persistent data via bind mounts, Tailscale SSH for keyless access, and network containment to prevent lateral movement.
+
+## Prerequisites
+
+- Proxmox host accessible via SSH
+- Tailscale account with admin access
+- Debian 12 LXC template cached in Proxmox (`local:vztmpl/debian-12-standard_*`)
+
+## Architecture
+
+The LXC is a **citadel** — it receives connections, it does not initiate them to other machines.
+
+- Discord gateway: outbound HTTPS only (safe)
+- Tailscale SSH: inbound from your devices only
+- No OpenSSH daemon
+- No outbound SSH keys
+- Persistent data on host storage via bind mount
+
+## Step 1: SSH Key Setup (one-time)
+
+Generate an ed25519 key pair for Proxmox host access:
+
+```bash
+ssh-keygen -t ed25519 -C "hermes-proxmox-$(date +%Y%m%d)" -f ~/.ssh/hermes_proxmox_ed25519 -N ""
+cat ~/.ssh/hermes_proxmox_ed25519.pub
+```
+
+Add the public key to Proxmox root's authorized_keys:
+```bash
+ssh root@proxmox-host "mkdir -p /root/.ssh && echo 'YOUR_PUBKEY' >> /root/.ssh/authorized_keys"
+```
+
+Configure SSH client:
+```bash
+cat >> ~/.ssh/config << 'EOF'
+Host beanworld-pve
+    HostName beanworld
+    User root
+    IdentityFile ~/.ssh/hermes_proxmox_ed25519
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+EOF
+```
+
+## Step 2: Check Resources
+
+```bash
+ssh beanworld-pve "pveversion; pvesm status; ls /etc/pve/lxc/; ls /etc/pve/qemu-server/"
+```
+
+Note existing IDs to avoid collision. Check storage pools.
+
+## Step 3: Create Persistent Data Directory
+
+```bash
+ssh beanworld-pve "mkdir -p /storage/hermes-data && chmod 700 /storage/hermes-data"
+```
+
+## Step 4: Create the LXC
+
+```bash
+ssh beanworld-pve "pct create 102 local:vztmpl/debian-12-standard_12.12-1_amd64.tar.zst \
+  --hostname hermes-devbox \
+  --rootfs local-lvm:32 \
+  --cores 8 \
+  --memory 6144 \
+  --swap 2048 \
+  --features nesting=1,keyctl=1 \
+  --net0 name=eth0,bridge=vmbr0,ip=dhcp,type=veth \
+  --mp0 /storage/hermes-data,mp=/root/.hermes,backup=1 \
+  --start 1 --unprivileged 0"
+```
+
+**Why privileged + nesting?** Hermes spawns Docker containers. Unprivileged LXC + Docker is a cgroup nightmare.
+
+## Step 5: Install Base Packages and Docker
+
+```bash
+ssh beanworld-pve "pct exec 102 -- bash -c '
+export DEBIAN_FRONTEND=noninteractive
+export LANG=C.UTF-8
+apt-get update -qq
+apt-get install -y -qq curl git ca-certificates build-essential libssl-dev pkg-config htop nano
+curl -fsSL https://get.docker.com | sh
+systemctl enable --now docker
+'"
+```
+
+## Step 6: Install Hermes
+
+```bash
+ssh beanworld-pve "pct exec 102 -- bash -c '
+cd /opt
+git clone --recursive https://github.com/donovan-yohan/hermes-agent.git
+cd hermes-agent
+git checkout dy-main
+bash setup-hermes.sh <<< \"n\"
+'"
+```
+
+**Note:** The install script is `setup-hermes.sh`, not `install.sh`. It uses `uv` for Python environment management.
+
+## Step 7: Add SSH Access Key
+
+```bash
+ssh beanworld-pve "pct exec 102 -- bash -c '
+mkdir -p /root/.ssh && chmod 700 /root/.ssh
+echo \"YOUR_PUBKEY\" > /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys
+'"
+```
+
+## Step 8: Tailscale Setup (CRITICAL — requires TUN device)
+
+**The gotcha:** Tailscale needs `/dev/net/tun` which LXC does not provide by default. Add these to the container config:
+
+```bash
+ssh beanworld-pve "cat >> /etc/pve/lxc/102.conf << 'EOF'
+lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file 0 0
+lxc.cgroup2.devices.allow: c 10:200 rwm
+EOF"
+```
+
+Restart the LXC to pick up the TUN mount:
+```bash
+ssh beanworld-pve "pct stop 102 && sleep 2 && pct start 102"
+```
+
+Install and auth Tailscale using an **auth key** (headless, survives reboots):
+```bash
+ssh beanworld-pve "pct exec 102 -- curl -fsSL https://tailscale.com/install.sh | sh"
+ssh beanworld-pve "pct exec 102 -- tailscale up --ssh --accept-routes=false --advertise-routes= --authkey=tskey-auth-..."
+```
+
+Generate the auth key at https://login.tailscale.com/admin/settings/keys with:
+- Reusable: Yes
+- Ephemeral: No
+- Tags: `tag:hermes-lxc`
+
+## Step 9: Disable OpenSSH (security hardening)
+
+Once Tailscale SSH is confirmed working, remove OpenSSH:
+```bash
+ssh beanworld-pve "pct exec 102 -- systemctl disable --now ssh ssh.socket"
+```
+
+Verify no port 22 listeners:
+```bash
+ssh beanworld-pve "pct exec 102 -- ss -tlnp | grep ':22' || echo 'Port 22 closed'"
+```
+
+## Step 10: Remove Outbound SSH Keys
+
+The LXC should never have private keys to other machines:
+```bash
+ssh beanworld-pve "pct exec 102 -- rm -f /root/.ssh/id_* /root/.ssh/hermes_*"
+ssh beanworld-pve "pct exec 102 -- find /root/.ssh -type f -name 'id_*' | wc -l"  # should be 0
+```
+
+## Step 11: Tailscale ACL Lockdown
+
+Paste this into your Tailscale ACL (https://login.tailscale.com/admin/acls):
+
+```json
+{
+  "grants": [
+    {"src": ["autogroup:owner", "group:household"], "dst": ["*"], "ip": ["*"]},
+    {"src": ["tag:hermes-lxc"], "dst": ["tag:hermes-lxc"], "ip": ["*"]}
+  ],
+  "ssh": [
+    {"action": "check", "src": ["autogroup:member"], "dst": ["autogroup:self"], "users": ["autogroup:nonroot", "root"]},
+    {"action": "check", "src": ["autogroup:owner", "group:household"], "dst": ["tag:hermes-lxc"], "users": ["root"]}
+  ],
+  "tagOwners": {
+    "tag:hermes-lxc": ["autogroup:admin"]
+  },
+  "nodeAttrs": [
+    {"target": ["tag:hermes-lxc"], "attr": ["funnel"]}
+  ]
+}
+```
+
+**What this does:**
+- LXC can only reach itself on the tailnet (required for Tailscale internals)
+- LXC **cannot** SSH to or reach any other tailnet node
+- Only household members + admins can SSH **to** the LXC
+
+## Step 12: Disaster Recovery Rebuild Script
+
+Save this to `/storage/hermes-rebuild.sh` on the Proxmox host:
+
+```bash
+#!/bin/bash
+set -e
+LXC_ID=102
+LXC_HOSTNAME=hermes-devbox
+TEMPLATE="local:vztmpl/debian-12-standard_12.12-1_amd64.tar.zst"
+
+echo "=== Hermes Devbox Rebuild ==="
+read -p "Continue? [y/N] " -n 1 -r
+echo
+[[ ! $REPLY =~ ^[Yy]$ ]] && exit 1
+
+if [ ! -d "/storage/hermes-data" ]; then
+    echo "ERROR: /storage/hermes-data not found"
+    exit 1
+fi
+
+if pct status $LXC_ID &>/dev/null; then
+    pct stop $LXC_ID 2>/dev/null || true
+    pct destroy $LXC_ID
+fi
+
+pct create $LXC_ID $TEMPLATE \
+    --hostname $LXC_HOSTNAME --rootfs local-lvm:32 --cores 8 --memory 6144 --swap 2048 \
+    --features nesting=1,keyctl=1 \
+    --net0 name=eth0,bridge=vmbr0,ip=dhcp,type=veth \
+    --mp0 /storage/hermes-data,mp=/root/.hermes,backup=1 \
+    --unprivileged 0 --start 1
+
+sleep 5
+
+cat >> /etc/pve/lxc/${LXC_ID}.conf << 'EOF'
+lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file 0 0
+lxc.cgroup2.devices.allow: c 10:200 rwm
+EOF
+
+pct stop $LXC_ID && sleep 2 && pct start $LXC_ID && sleep 5
+
+pct exec $LXC_ID -- bash -c '
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y -qq curl git ca-certificates build-essential libssl-dev pkg-config
+    curl -fsSL https://get.docker.com | sh
+    systemctl enable --now docker
+    curl -fsSL https://tailscale.com/install.sh | sh
+    systemctl enable tailscaled
+'
+
+pct exec $LXC_ID -- bash -c '
+    cd /opt && git clone --recursive https://github.com/donovan-yohan/hermes-agent.git
+    cd /opt/hermes-agent && git checkout dy-main
+    bash setup-hermes.sh <<< "n"
+'
+
+pct exec $LXC_ID -- bash -c '
+    mkdir -p /root/.ssh && chmod 700 /root/.ssh
+    echo "YOUR_PUBKEY_HERE" > /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+'
+
+echo "=== Rebuild Complete ==="
+echo "IP: $(pct exec $LXC_ID -- hostname -I | awk '{print $1}')"
+echo "Auth Tailscale, then run: hermes setup && hermes gateway install"
+```
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **Privileged LXC** | Docker requires it. Unprivileged + Docker is a cgroup nightmare. |
+| **Bind mount `/storage/hermes-data` → `/root/.hermes`** | Persistent state survives container destruction. |
+| **Tailscale SSH instead of OpenSSH** | Keyless, ACL-enforced, audit-logged, no port forwarding. |
+| **Auth key (not interactive)** | Headless server needs unattended auth. |
+| **No outbound SSH keys on LXC** | Prevents lateral movement if the agent is compromised. |
+| **Disable OpenSSH daemon** | Reduces attack surface once Tailscale SSH is confirmed working. |
+
+## Troubleshooting
+
+### TUN device not available
+**Symptom:** `tailscaled` fails with `tstun.New("tailscale0"): operation not permitted`
+**Fix:** Ensure both `lxc.mount.entry` and `lxc.cgroup2.devices.allow` are in the LXC config, then restart.
+
+### Docker repo fails during install
+**Symptom:** `E: The repository '...' does not have a Release file`
+**Fix:** A broken `/etc/apt/sources.list.d/docker.list` was created by an earlier failed command. Remove it and use `curl -fsSL https://get.docker.com | sh` instead.
+
+### Hermes install script 404
+**Symptom:** `curl: (22) The requested URL returned error: 404`
+**Fix:** The upstream `install.sh` doesn't exist in the fork. Use `setup-hermes.sh` instead.
+
+### Tailscale auth times out
+**Symptom:** `tailscale up` hangs waiting for browser auth
+**Fix:** Use `--authkey` with a pre-generated key. Interactive auth requires a TTY/browser which headless LXCs don't have.

--- a/docs/webui-spec.md
+++ b/docs/webui-spec.md
@@ -1,0 +1,209 @@
+# Belayer Web UI Spec
+
+## Goal
+A self-hosted, dark-themed, zero-build-step web dashboard for live monitoring of Belayer agent sessions. Ships inside the Go binary via `go:embed`. Accessible at `/ui/` when the daemon is running.
+
+## Design Principles
+- **No build step**: vanilla HTML/CSS/JS, no npm, no bundler.
+- **Dark IDE aesthetic**: GitHub-dark palette (`#0d1117`, `#161b22`, `#21262d`), compact density.
+- **Three-panel layout**:
+  - Left (240px): sessions list + connection status
+  - Center (flex): event timeline / message stream (main focus)
+  - Right (260px): agent roster + session metadata
+- **Color-coded agents**: every agent bubble/badge uses a deterministic color derived from its role/identity.
+- **Live streaming**: SSE `GET /events/stream` with auto-reconnect.
+
+## Agent Color Palette
+Colors are assigned by agent identity name prefix (first component before `.` or `-`):
+
+| Identity | Color (hex) | Tailwind approx |
+|----------|-------------|-----------------|
+| supervisor | `#8b5cf6` | violet-500 |
+| backend-dev | `#22c55e` | green-500 |
+| web-dev | `#f59e0b` | amber-500 |
+| qa | `#ef4444` | red-500 |
+| pm | `#06b6d4` | cyan-500 |
+| reviewer | `#94a3b8` | slate-400 |
+| system / daemon | `#64748b` | slate-500 |
+| unknown | `#a855f7` | purple-500 |
+
+Render agent name pills with `background-color` at 15% opacity and `border-left: 3px solid <color>`.
+
+## Layout Detail
+
+### Top Bar (48px)
+- Left: Belayer logo/wordmark + daemon instance ID (truncated)
+- Center: active session name + status badge
+- Right: SSE connection status (green dot = connected, red = disconnected, amber = reconnecting)
+
+### Left Sidebar (240px)
+- Section: "Sessions"
+  - List of sessions from `GET /sessions`
+  - Each row: name, status badge, created_at relative time
+  - Click to select / load
+  - Auto-refresh every 5s
+- Section: "Filters" (collapsible)
+  - Toggle event type filters: `session_*`, `agent_*`, `bridge:*`, `message_*`, `artifact_*`, `tool_*`
+  - Agent checkboxes (populated from roster)
+
+### Center Pane (flex)
+- Tab bar: "Events" | "Messages" | "Tool Calls"
+- **Events tab**: chronological feed of all `SessionEvent` objects
+  - Each row: timestamp | agent pill | event type | collapsed payload
+  - Click to expand payload (pretty-printed JSON)
+  - Auto-scroll to bottom when near bottom
+  - Pause auto-scroll when user scrolls up
+- **Messages tab**: dedicated inter-agent messaging view
+  - Chat-bubble style: left = inbound to selected agent, right = outbound
+  - Or: clean table showing `from → to` with content
+  - Highlight @mentions
+- **Tool Calls tab**: paired tool invocations from `GET /sessions/{id}/tool-calls`
+  - Collapsible rows showing input preview + result preview + duration
+
+### Right Sidebar (260px)
+- Section: "Agent Roster"
+  - List from `GET /sessions/{id}` agent roster + live status
+  - Each agent: colored dot + name + role + status badge
+  - Status: `running`, `complete`, `blocked`, `pending_verification`
+- Section: "Session Metadata"
+  - ID, log_level, created_at, phase
+- Section: "Artifacts"
+  - List from `GET /sessions/{id}/artifacts`
+  - Links to download
+
+## Data Flow
+1. On load: `GET /health` → verify capabilities (look for `web_ui: true`)
+2. `GET /sessions` → populate left sidebar
+3. On session select: `GET /sessions/{id}` → populate metadata + roster
+4. `GET /sessions/{id}/events?after=0&limit=1000` → backfill recent events
+5. Open SSE: `GET /events/stream?sessions={id}&tier=verbose`
+6. Merge backfill + live events into chronological feed
+7. `GET /sessions/{id}/tool-calls` → populate tool calls tab
+8. Poll `GET /sessions/{id}/outline` every 10s for roster updates
+
+## SSE Reconnect Strategy
+- Use `fetch()` + `ReadableStream` parser (NOT native `EventSource`) so we can:
+  - Set `Authorization: Bearer <token>` header
+  - Control reconnect backoff (500ms → 30s cap)
+  - Access `Last-Event-ID` equivalent manually
+- On reconnect: resume from last seen event `id` using `?after=<id>`
+- On `daemon_draining`: show warning banner, stop reconnecting after 3 attempts
+- On `daemon_hello` with new `daemon_instance_id`: clear event buffer and reload from `?after=0`
+
+## Auth & TCP
+- The UI is served at `/ui/` and `/ui/*` from embedded static files.
+- `authMiddleware` must exempt `/ui/` and `/ui/*` so the HTML/JS/CSS loads without a token.
+- `authMiddleware` must also accept `?token=<bearer>` on **GET requests** (including SSE) because browsers cannot set headers on EventSource/fetch without CORS preflight complications, and because the UI needs to pass the token via URL for SSE.
+- The UI reads `?token=...` from `window.location.search` on startup and stores it in memory. All `fetch()` calls include `Authorization: Bearer <token>`. The SSE URL also includes `?token=...`.
+
+## Go Implementation Plan
+
+### New: `web/index.html`
+Single HTML file that loads `style.css` and `app.js`. All CSS and JS are in separate files for readability, but no build step.
+
+### New: `web/style.css`
+Dark theme CSS. ~400 lines. No external dependencies.
+
+### New: `web/app.js`
+Vanilla JS. ~800-1000 lines. Modules via IIFE or simple script tags.
+
+### New: `internal/daemon/webui.go`
+```go
+package daemon
+
+import (
+    "embed"
+    "io/fs"
+    "net/http"
+    "strings"
+)
+
+//go:embed all:web
+var webFS embed.FS
+
+func (d *Daemon) handleWebUI(w http.ResponseWriter, r *http.Request) {
+    // Strip /ui prefix
+    path := strings.TrimPrefix(r.URL.Path, "/ui")
+    if path == "" || path == "/" {
+        path = "/index.html"
+    }
+    // Serve from embedded FS
+    content, err := webFS.ReadFile("web" + path)
+    if err != nil {
+        http.NotFound(w, r)
+        return
+    }
+    // Set content type based on extension
+    switch {
+    case strings.HasSuffix(path, ".css"):
+        w.Header().Set("Content-Type", "text/css")
+    case strings.HasSuffix(path, ".js"):
+        w.Header().Set("Content-Type", "application/javascript")
+    default:
+        w.Header().Set("Content-Type", "text/html; charset=utf-8")
+    }
+    w.Write(content)
+}
+```
+
+**IMPORTANT**: `embed.FS` is relative to the package directory. Since `internal/daemon/webui.go` cannot embed files from the repo root (`web/`), we have two options:
+1. Put `web/` under `internal/daemon/web/` and embed from there
+2. Keep `web/` at repo root and have `embed.go` in package `belayer` embed it, then `internal/daemon` imports `github.com/donovan-yohan/belayer` to access the FS
+
+Option 2 follows the existing pattern (`embed.go` already exists at repo root in package `belayer`). We'll add `//go:embed all:web` to `embed.go` and expose a `var WebUI embed.FS`. Then `internal/daemon/webui.go` imports the root package.
+
+### Modified: `embed.go`
+```go
+//go:embed all:web
+var WebUI embed.FS
+```
+
+### Modified: `internal/daemon/daemon.go`
+Add route:
+```go
+mux.HandleFunc("GET /ui/{$}", d.handleWebUI)
+mux.HandleFunc("GET /ui/{path...}", d.handleWebUI)
+```
+Also add redirect from `/` to `/ui/` for convenience (optional but nice).
+
+### Modified: `internal/daemon/auth.go`
+In `authMiddleware`, exempt `/ui/` and `/ui/*`:
+```go
+if strings.HasPrefix(r.URL.Path, "/ui/") {
+    next.ServeHTTP(w, r)
+    return
+}
+```
+
+Also add query-param token fallback for GET requests:
+```go
+auth := r.Header.Get("Authorization")
+if auth == "" && r.Method == http.MethodGet {
+    auth = "Bearer " + r.URL.Query().Get("token")
+}
+```
+
+### Modified: `internal/daemon/health_test.go`
+Add `WebUI bool json:"web_ui"` to capabilities struct and assert it is `true`.
+
+## Capabilities
+Add `web_ui: true` to the `/health` capabilities manifest.
+
+## Testing
+- `TestWebUI_ServesIndex` — `GET /ui/` returns 200 and HTML containing "Belayer"
+- `TestWebUI_ServesCSS` — `GET /ui/style.css` returns 200 with correct Content-Type
+- `TestWebUI_ServesJS` — `GET /ui/app.js` returns 200 with correct Content-Type
+- `TestAuth_ExemptsWebUI` — `GET /ui/index.html` on TCP without token returns 200
+- `TestAuth_QueryParamToken` — `GET /sessions?token=<valid>` on TCP returns 200
+- `TestHealth_AdvertisesWebUI` — `/health` contains `web_ui: true`
+
+## Reference UI Projects
+- https://github.com/nesquena/hermes-webui — three-panel layout, dark theme, composer footer, context ring
+- https://github.com/outsourc-e/hermes-workspace — chat with tool rendering, inspector panel, terminal
+
+## Scope Exclusions (future work)
+- Transcript viewer (verbose+ reasoning text)
+- Trace fragment viewer (trace tier file snapshots)
+- Real-time terminal/PTY
+- PWA / offline mode
+- Multi-session side-by-side view

--- a/embed.go
+++ b/embed.go
@@ -21,3 +21,9 @@ var DefaultAgents embed.FS
 //
 //go:embed all:hermes_bridge
 var DefaultBridge embed.FS
+
+// WebUI is the zero-build web dashboard shipped inside the belayer binary.
+// Served at /ui/ when the daemon is running.
+//
+//go:embed all:web
+var WebUI embed.FS

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -403,13 +403,6 @@ def main() -> None:
         agent_kwargs["max_iterations"] = max_turns
     if hermes_session_id:
         agent_kwargs["session_id"] = hermes_session_id
-    # Only pass ephemeral if AIAgent supports it (newer Hermes versions)
-    import inspect
-    aiagent_sig = inspect.signature(AIAgent.__init__)
-    if "ephemeral" in aiagent_sig.parameters:
-        agent_kwargs["ephemeral"] = ephemeral
-    else:
-        log.debug("AIAgent does not support ephemeral parameter, skipping")
 
     try:
         agent = AIAgent(**agent_kwargs)

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -403,7 +403,13 @@ def main() -> None:
         agent_kwargs["max_iterations"] = max_turns
     if hermes_session_id:
         agent_kwargs["session_id"] = hermes_session_id
-    agent_kwargs["ephemeral"] = ephemeral
+    # Only pass ephemeral if AIAgent supports it (newer Hermes versions)
+    import inspect
+    aiagent_sig = inspect.signature(AIAgent.__init__)
+    if "ephemeral" in aiagent_sig.parameters:
+        agent_kwargs["ephemeral"] = ephemeral
+    else:
+        log.debug("AIAgent does not support ephemeral parameter, skipping")
 
     try:
         agent = AIAgent(**agent_kwargs)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -38,27 +38,33 @@ func newDaemonCmd() *cobra.Command {
 		Short: "Start the belayer daemon",
 		Long:  "Starts the long-running belayer supervisor on a Unix socket." + ChannelsFooter,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Resolve working directory first — drives all defaults.
+			wd := workdir
+			if wd == "" {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return fmt.Errorf("resolve working directory: %w", err)
+				}
+				wd = cwd
+			}
+
 			// Load .belayer.env files into the daemon process environment so
 			// bridge subprocesses inherit provider credentials (e.g. OPENCODE_GO_API_KEY).
 			// Workspace-scoped file is loaded first so it takes precedence over home.
-			wd0 := workdir
-			if wd0 == "" {
-				if cwd, err := os.Getwd(); err == nil {
-					wd0 = cwd
-				}
-			}
-			if wd0 != "" {
-				loadEnvFile(filepath.Join(wd0, ".belayer", ".belayer.env"))
-			}
+			loadEnvFile(filepath.Join(wd, ".belayer", ".belayer.env"))
 			home, _ := os.UserHomeDir()
 			loadEnvFile(filepath.Join(home, ".belayer.env"))
 
 			cfg := daemon.DefaultConfig()
 			if socketPath != "" {
 				cfg.SocketPath = socketPath
+			} else {
+				cfg.SocketPath = filepath.Join(wd, ".belayer", "daemon.sock")
 			}
 			if dbPath != "" {
 				cfg.DBPath = dbPath
+			} else {
+				cfg.DBPath = filepath.Join(wd, ".belayer", "belayer.db")
 			}
 			if belayerRoot != "" {
 				cfg.BelayerRoot = belayerRoot
@@ -67,11 +73,11 @@ func newDaemonCmd() *cobra.Command {
 			// Resolve the runtime dir and extract the embedded hermes_bridge package.
 			// This must happen before daemon.New so bridge subprocesses spawned
 			// immediately after Start have the package available.
-			runtimeDir, err := resolveRuntimeDir(wd0)
+			runtimeDir, err := resolveRuntimeDir(wd)
 			if err != nil {
 				return fmt.Errorf("resolve runtime dir: %w", err)
 			}
-			if err := extractBridgeToRuntimeDir(runtimeDir, wd0); err != nil {
+			if err := extractBridgeToRuntimeDir(runtimeDir, wd); err != nil {
 				return fmt.Errorf("extract bridge to runtime dir: %w", err)
 			}
 			cfg.RuntimeDir = runtimeDir
@@ -102,14 +108,6 @@ func newDaemonCmd() *cobra.Command {
 				cfg.ConfineAgentWrites = true
 			}
 
-			wd := workdir
-			if wd == "" {
-				cwd, err := os.Getwd()
-				if err != nil {
-					return fmt.Errorf("resolve working directory: %w", err)
-				}
-				wd = cwd
-			}
 			rtCfg, err := runtime.LoadConfig(wd)
 			if err != nil {
 				return err
@@ -140,12 +138,14 @@ func newDaemonCmd() *cobra.Command {
 				cfg.MaxSideSummonsPerSession = caps.MaxSideSummonsPerSession
 			}
 
-			// If the workdir has a .belayer/ directory, also bind a Unix socket
-			// there so sandboxed bridge subprocesses can reach the daemon via the
-			// bind-mounted workspace path (/workspace/.belayer/daemon.sock).
+			// If the primary socket is not already inside the workspace, also bind
+			// a workspace-local Unix socket so sandboxed bridge subprocesses can
+			// reach the daemon via the bind-mounted path.
 			wsSock := filepath.Join(wd, ".belayer", "daemon.sock")
-			if _, err := os.Stat(filepath.Dir(wsSock)); err == nil {
-				cfg.WorkspaceSockPath = wsSock
+			if cfg.SocketPath != wsSock {
+				if _, err := os.Stat(filepath.Dir(wsSock)); err == nil {
+					cfg.WorkspaceSockPath = wsSock
+				}
 			}
 
 			d, err := daemon.New(cfg)
@@ -161,8 +161,8 @@ func newDaemonCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&socketPath, "socket", "", "Unix socket path (default ~/.belayer/daemon.sock)")
-	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database path (default ~/.belayer/belayer.db)")
+	cmd.Flags().StringVar(&socketPath, "socket", "", "Unix socket path (default <workdir>/.belayer/daemon.sock)")
+	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database path (default <workdir>/.belayer/belayer.db)")
 	cmd.Flags().StringVar(&belayerRoot, "belayer-root", "", "Path to belayer repo root (for hermes_bridge PYTHONPATH)")
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Workspace directory (for .belayer/config.yaml lookup; default cwd)")
 	cmd.Flags().StringVar(&tcpAddr, "tcp-addr", "", "Also bind a TCP listener (e.g. 0.0.0.0:7523) for sandboxed container access")

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/donovan-yohan/belayer/internal/dashboard"
+	"github.com/spf13/cobra"
+)
+
+func newDashboardCmd() *cobra.Command {
+	var port, configPath string
+
+	cmd := &cobra.Command{
+		Use:   "dashboard",
+		Short: "Start the unified Belayer dashboard",
+		Long: `Starts a web dashboard that aggregates multiple Belayer daemons into a single UI.
+
+The dashboard serves the embedded web assets at /ui/ and reverse-proxies API calls
+to configured daemon backends via /api/daemons/{name}/...
+
+Configuration is loaded from a YAML file:
+
+  daemons:
+    - name: extend-api
+      url: http://localhost:7523
+      token: ***
+    - name: relay-ide
+      url: http://localhost:7524
+      token: ***
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if configPath == "" {
+				return fmt.Errorf("--config is required (path to dashboard YAML config)")
+			}
+			daemons, err := dashboard.LoadConfig(configPath)
+			if err != nil {
+				return err
+			}
+			if len(daemons) == 0 {
+				return fmt.Errorf("config file %q contains no daemons", configPath)
+			}
+
+			srv, err := dashboard.NewServer(daemons)
+			if err != nil {
+				return err
+			}
+
+			addr := ":" + port
+			if port == "" {
+				addr = ":7525"
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "belayer dashboard listening on %s\n", addr)
+			fmt.Fprintf(cmd.OutOrStdout(), "configured daemons:\n")
+			for _, d := range daemons {
+				fmt.Fprintf(cmd.OutOrStdout(), "  - %s -> %s\n", d.Name, d.URL)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "open http://localhost%s/ui/ in your browser\n", addr)
+
+			return http.ListenAndServe(addr, srv.Handler())
+		},
+	}
+
+	cmd.Flags().StringVarP(&port, "port", "p", "7525", "TCP port to listen on")
+	cmd.Flags().StringVar(&configPath, "config", "", "Path to dashboard YAML config file (required)")
+	return cmd
+}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -522,7 +522,7 @@ func TestInitGitignoreUpgradeIsNoOpWhenAllEntriesPresent(t *testing.T) {
 	}
 }
 
-// TestResolveRuntimeDirPrecedence verifies the env var and XDG resolution order.
+// TestResolveRuntimeDirPrecedence verifies the env var, config, workspace, and XDG resolution order.
 func TestResolveRuntimeDirPrecedence(t *testing.T) {
 	t.Setenv("BELAYER_RUNTIME_DIR", "")
 	t.Setenv("XDG_STATE_HOME", "")
@@ -546,6 +546,18 @@ func TestResolveRuntimeDirPrecedence(t *testing.T) {
 		}
 		if got != "/xdg/state/belayer/runtime" {
 			t.Fatalf("expected /xdg/state/belayer/runtime, got %q", got)
+		}
+	})
+
+	t.Run("workspace_default", func(t *testing.T) {
+		workspaceDir := t.TempDir()
+		got, err := resolveRuntimeDir(workspaceDir)
+		if err != nil {
+			t.Fatalf("resolveRuntimeDir: %v", err)
+		}
+		want := filepath.Join(workspaceDir, ".belayer", "runtime")
+		if got != want {
+			t.Fatalf("expected %q, got %q", want, got)
 		}
 	})
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -41,6 +41,7 @@ over SQLite.`,
 	cmd.AddCommand(
 		newVersionCmd(),
 		newDaemonCmd(),
+		newDashboardCmd(),
 		newSessionCmd(),
 		newLogsCmd(),
 		newStatusCmd(),

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -17,8 +17,9 @@ import (
 //
 //  1. $BELAYER_RUNTIME_DIR env var (clamshell: preset to /opt/belayer/runtime)
 //  2. Optional runtime_dir field in .belayer/config.yaml (workspaceDir may be "")
-//  3. $XDG_STATE_HOME/belayer/runtime if $XDG_STATE_HOME is set
-//  4. $HOME/.local/state/belayer/runtime (always available fallback)
+//  3. <workspaceDir>/.belayer/runtime when workspaceDir is non-empty
+//  4. $XDG_STATE_HOME/belayer/runtime if $XDG_STATE_HOME is set
+//  5. $HOME/.local/state/belayer/runtime (always available fallback)
 func resolveRuntimeDir(workspaceDir string) (string, error) {
 	// 1. Explicit env override.
 	if v := strings.TrimSpace(os.Getenv("BELAYER_RUNTIME_DIR")); v != "" {
@@ -43,12 +44,17 @@ func resolveRuntimeDir(workspaceDir string) (string, error) {
 		}
 	}
 
-	// 3. $XDG_STATE_HOME/belayer/runtime
+	// 3. Workspace-local default.
+	if workspaceDir != "" {
+		return filepath.Join(workspaceDir, ".belayer", "runtime"), nil
+	}
+
+	// 4. $XDG_STATE_HOME/belayer/runtime
 	if xdg := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); xdg != "" {
 		return filepath.Join(xdg, "belayer", "runtime"), nil
 	}
 
-	// 4. $HOME/.local/state/belayer/runtime
+	// 5. $HOME/.local/state/belayer/runtime
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve runtime dir: $HOME unavailable: %w", err)

--- a/internal/daemon/auth.go
+++ b/internal/daemon/auth.go
@@ -94,7 +94,15 @@ func (d *Daemon) authMiddleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+		// /ui/ and /ui/* are exempt — static assets must load without a token.
+		if strings.HasPrefix(r.URL.Path, "/ui/") {
+			next.ServeHTTP(w, r)
+			return
+		}
 		auth := r.Header.Get("Authorization")
+		if auth == "" && r.Method == http.MethodGet {
+			auth = "Bearer " + r.URL.Query().Get("token")
+		}
 		if !strings.HasPrefix(auth, "Bearer ") {
 			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing bearer token"})
 			return

--- a/internal/daemon/auth_test.go
+++ b/internal/daemon/auth_test.go
@@ -308,3 +308,39 @@ func TestAuth_WrongLengthTokenTakesSameTimeAsCorrectLength(t *testing.T) {
 	}
 }
 
+// TestAuth_ExemptsWebUI verifies that GET /ui/index.html on the TCP listener
+// succeeds without an Authorization header.
+func TestAuth_ExemptsWebUI(t *testing.T) {
+	_, port := startDaemonWithTCP(t, Config{
+		TCPAddr:   "127.0.0.1:0",
+		AuthToken: "test123",
+	})
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/ui/index.html", port))
+	if err != nil {
+		t.Fatalf("GET /ui/index.html: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// TestAuth_QueryParamToken verifies that a GET request with ?token=<valid>
+// is accepted even when the Authorization header is absent.
+func TestAuth_QueryParamToken(t *testing.T) {
+	_, port := startDaemonWithTCP(t, Config{
+		TCPAddr:   "127.0.0.1:0",
+		AuthToken: "test123",
+	})
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/sessions?token=test123", port))
+	if err != nil {
+		t.Fatalf("GET /sessions?token=...: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -366,6 +366,8 @@ func New(cfg Config) (*Daemon, error) {
 	mux.HandleFunc("GET /sessions/{id}/transcripts", d.handleListTranscripts)
 	mux.HandleFunc("GET /sessions/{id}/transcripts/{agent}", d.handleTranscriptContent)
 	mux.HandleFunc("GET /sessions/{id}/traces", d.handleListTraces)
+	mux.HandleFunc("GET /ui/{$}", d.handleWebUI)
+	mux.HandleFunc("GET /ui/{path...}", d.handleWebUI)
 
 	// Set up auth token for TCP listener. Use the configured token, or
 	// auto-generate one when TCPAddr is set without an explicit token.
@@ -824,6 +826,7 @@ var healthCapabilities = struct {
 	ArtifactsBytes   bool     `json:"artifacts_bytes"`
 	LinkNext         bool     `json:"link_next"`
 	LogLevels        []string `json:"log_levels"`
+	WebUI            bool     `json:"web_ui"`
 }{
 	SearchPredicates: []string{"q", "session", "type_prefix", "agent", "after", "before"},
 	ArchiveHTTP:      true,
@@ -837,6 +840,7 @@ var healthCapabilities = struct {
 	ArtifactsBytes:   true,
 	LinkNext:         true,
 	LogLevels:        []string{"standard", "verbose", "trace"},
+	WebUI:            true,
 }
 
 type healthResponse struct {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -84,6 +84,8 @@ func testDaemon(t *testing.T) *Daemon {
 	mux.HandleFunc("POST /sessions/{id}/tools", d.handleRegisterTool)
 	mux.HandleFunc("GET /sessions/{id}/tools", d.handleListTools)
 	mux.HandleFunc("POST /sessions/{id}/tools/{name}", d.handleExecuteTool)
+	mux.HandleFunc("GET /ui/{$}", d.handleWebUI)
+	mux.HandleFunc("GET /ui/{path...}", d.handleWebUI)
 	d.server = &http.Server{Handler: mux}
 	// Wait for in-flight archiver goroutines before closing the store so that
 	// async terminal-archive workers don't race store.Close / t.TempDir cleanup.

--- a/internal/daemon/health_test.go
+++ b/internal/daemon/health_test.go
@@ -83,6 +83,7 @@ func TestHealth_AdvertisesFullCapabilityManifest(t *testing.T) {
 			ArtifactsBytes   bool     `json:"artifacts_bytes"`
 			LinkNext         bool     `json:"link_next"`
 			LogLevels        []string `json:"log_levels"`
+			WebUI            bool     `json:"web_ui"`
 		} `json:"capabilities"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
@@ -103,6 +104,7 @@ func TestHealth_AdvertisesFullCapabilityManifest(t *testing.T) {
 		{"traces", c.Traces},
 		{"artifacts_bytes", c.ArtifactsBytes},
 		{"link_next", c.LinkNext},
+		{"web_ui", c.WebUI},
 	} {
 		if !tc.got {
 			t.Errorf("capability %q: expected true, got false", tc.name)

--- a/internal/daemon/webui.go
+++ b/internal/daemon/webui.go
@@ -1,0 +1,31 @@
+package daemon
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/donovan-yohan/belayer"
+)
+
+func (d *Daemon) handleWebUI(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/ui")
+	if path == "" || path == "/" {
+		path = "/index.html"
+	}
+
+	content, err := belayer.WebUI.ReadFile("web" + path)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch {
+	case strings.HasSuffix(path, ".css"):
+		w.Header().Set("Content-Type", "text/css")
+	case strings.HasSuffix(path, ".js"):
+		w.Header().Set("Content-Type", "application/javascript")
+	default:
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	}
+	w.Write(content)
+}

--- a/internal/daemon/webui_test.go
+++ b/internal/daemon/webui_test.go
@@ -1,0 +1,59 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestWebUI_ServesIndex verifies that GET /ui/ returns 200 and HTML containing
+// "Belayer".
+func TestWebUI_ServesIndex(t *testing.T) {
+	d := testDaemon(t)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/ui/", nil)
+	d.server.Handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "Belayer") {
+		t.Fatalf("expected body to contain 'Belayer', got %q", rr.Body.String())
+	}
+}
+
+// TestWebUI_ServesCSS verifies that GET /ui/style.css returns 200 with
+// text/css Content-Type.
+func TestWebUI_ServesCSS(t *testing.T) {
+	d := testDaemon(t)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/ui/style.css", nil)
+	d.server.Handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "text/css" {
+		t.Fatalf("expected Content-Type text/css, got %q", ct)
+	}
+}
+
+// TestWebUI_ServesJS verifies that GET /ui/app.js returns 200 with
+// application/javascript Content-Type.
+func TestWebUI_ServesJS(t *testing.T) {
+	d := testDaemon(t)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/ui/app.js", nil)
+	d.server.Handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/javascript" {
+		t.Fatalf("expected Content-Type application/javascript, got %q", ct)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -1,0 +1,163 @@
+// Package dashboard provides a unified Web UI that aggregates multiple Belayer
+// daemons. It serves the embedded static assets and reverse-proxies API calls
+// to configured daemon backends.
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/donovan-yohan/belayer"
+	"go.yaml.in/yaml/v3"
+)
+
+// DaemonConfig describes one daemon backend the dashboard proxies to.
+type DaemonConfig struct {
+	Name  string `yaml:"name"`
+	URL   string `yaml:"url"`
+	Token string `yaml:"token"`
+}
+
+// ConfigFile is the YAML shape read from --config.
+type ConfigFile struct {
+	Daemons []DaemonConfig `yaml:"daemons"`
+}
+
+// Server is the dashboard HTTP server.
+type Server struct {
+	daemons []DaemonConfig
+	proxies map[string]*httputil.ReverseProxy
+}
+
+// NewServer creates a dashboard server for the given daemon backends.
+func NewServer(daemons []DaemonConfig) (*Server, error) {
+	if len(daemons) == 0 {
+		return nil, fmt.Errorf("dashboard: at least one daemon must be configured")
+	}
+	s := &Server{
+		daemons: daemons,
+		proxies: make(map[string]*httputil.ReverseProxy, len(daemons)),
+	}
+	for _, d := range daemons {
+		target, err := url.Parse(d.URL)
+		if err != nil {
+			return nil, fmt.Errorf("dashboard: invalid URL for daemon %q: %w", d.Name, err)
+		}
+		proxy := httputil.NewSingleHostReverseProxy(target)
+		proxy.FlushInterval = 100 * time.Millisecond
+		originalDirector := proxy.Director
+		prefix := "/api/daemons/" + d.Name
+		proxy.Director = func(req *http.Request) {
+			originalDirector(req)
+			req.URL.Path = strings.TrimPrefix(req.URL.Path, prefix)
+			req.Header.Set("Authorization", "Bearer "+d.Token)
+		}
+		s.proxies[d.Name] = proxy
+	}
+	return s, nil
+}
+
+// Handler returns the http.Handler for the dashboard.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /ui/{$}", s.handleWebUI)
+	mux.HandleFunc("GET /ui/{path...}", s.handleWebUI)
+	mux.HandleFunc("GET /api/daemons", s.handleListDaemons)
+	// Catch-all proxy for any method under /api/daemons/{name}/
+	mux.HandleFunc("/api/daemons/{name}/", s.handleProxy)
+	return mux
+}
+
+func (s *Server) handleWebUI(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/ui")
+	if path == "" || path == "/" {
+		path = "/index.html"
+	}
+
+	content, err := belayer.WebUI.ReadFile("web" + path)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch {
+	case strings.HasSuffix(path, ".css"):
+		w.Header().Set("Content-Type", "text/css")
+	case strings.HasSuffix(path, ".js"):
+		w.Header().Set("Content-Type", "application/javascript")
+	default:
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	}
+	w.Write(content)
+}
+
+type daemonInfo struct {
+	Name    string `json:"name"`
+	URL     string `json:"url"`
+	Healthy bool   `json:"healthy"`
+}
+
+func (s *Server) handleListDaemons(w http.ResponseWriter, r *http.Request) {
+	infos := make([]daemonInfo, len(s.daemons))
+	var wg sync.WaitGroup
+	for i, d := range s.daemons {
+		wg.Add(1)
+		go func(idx int, cfg DaemonConfig) {
+			defer wg.Done()
+			infos[idx] = daemonInfo{
+				Name:    cfg.Name,
+				URL:     cfg.URL,
+				Healthy: s.checkHealth(cfg),
+			}
+		}(i, d)
+	}
+	wg.Wait()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(infos)
+}
+
+func (s *Server) checkHealth(d DaemonConfig) bool {
+	client := &http.Client{Timeout: 2 * time.Second}
+	req, err := http.NewRequest("GET", d.URL+"/health", nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Authorization", "Bearer "+d.Token)
+	res, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer res.Body.Close()
+	return res.StatusCode == http.StatusOK
+}
+
+func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	proxy, ok := s.proxies[name]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+// LoadConfig reads a dashboard YAML config file.
+func LoadConfig(path string) ([]DaemonConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard: read config: %w", err)
+	}
+	var cfg ConfigFile
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("dashboard: parse config: %w", err)
+	}
+	return cfg.Daemons, nil
+}

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -1,0 +1,260 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestServer_ServesWebUI(t *testing.T) {
+	srv, err := NewServer([]DaemonConfig{{Name: "test", URL: "http://localhost:1", Token: "t"}})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	// index.html
+	res, err := http.Get(ts.URL + "/ui/")
+	if err != nil {
+		t.Fatalf("GET /ui/: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+	body, _ := io.ReadAll(res.Body)
+	if !strings.Contains(string(body), "Belayer") {
+		t.Fatalf("index.html should contain 'Belayer', got:\n%s", string(body))
+	}
+
+	// CSS
+	res2, err := http.Get(ts.URL + "/ui/style.css")
+	if err != nil {
+		t.Fatalf("GET /ui/style.css: %v", err)
+	}
+	defer res2.Body.Close()
+	if res2.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for css, got %d", res2.StatusCode)
+	}
+	ct := res2.Header.Get("Content-Type")
+	if ct != "text/css" {
+		t.Fatalf("expected text/css, got %s", ct)
+	}
+
+	// JS
+	res3, err := http.Get(ts.URL + "/ui/app.js")
+	if err != nil {
+		t.Fatalf("GET /ui/app.js: %v", err)
+	}
+	defer res3.Body.Close()
+	if res3.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for js, got %d", res3.StatusCode)
+	}
+	if res3.Header.Get("Content-Type") != "application/javascript" {
+		t.Fatalf("expected application/javascript, got %s", res3.Header.Get("Content-Type"))
+	}
+}
+
+func TestServer_ListDaemons(t *testing.T) {
+	// Start a mock daemon
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			auth := r.Header.Get("Authorization")
+			if auth != "Bearer good-token" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		if r.URL.Path == "/sessions" {
+			w.Write([]byte(`[]`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+
+	srv, err := NewServer([]DaemonConfig{
+		{Name: "mock", URL: mock.URL, Token: "good-token"},
+		{Name: "down", URL: "http://localhost:1", Token: "t"},
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/api/daemons")
+	if err != nil {
+		t.Fatalf("GET /api/daemons: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+
+	var infos []daemonInfo
+	if err := json.NewDecoder(res.Body).Decode(&infos); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 daemons, got %d", len(infos))
+	}
+
+	m := make(map[string]bool)
+	for _, info := range infos {
+		m[info.Name] = info.Healthy
+	}
+	if !m["mock"] {
+		t.Fatalf("mock daemon should be healthy")
+	}
+	if m["down"] {
+		t.Fatalf("down daemon should be unhealthy")
+	}
+}
+
+func TestServer_Proxy(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer tok" {
+			http.Error(w, "bad auth", http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path == "/sessions" {
+			w.Write([]byte(`{"proxied":true}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+
+	srv, _ := NewServer([]DaemonConfig{{Name: "a", URL: mock.URL, Token: "tok"}})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/api/daemons/a/sessions")
+	if err != nil {
+		t.Fatalf("GET proxy: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200, got %d: %s", res.StatusCode, string(body))
+	}
+	body, _ := io.ReadAll(res.Body)
+	if !strings.Contains(string(body), `"proxied":true`) {
+		t.Fatalf("expected proxied response, got: %s", string(body))
+	}
+}
+
+func TestServer_ProxyUnknownDaemon(t *testing.T) {
+	srv, _ := NewServer([]DaemonConfig{{Name: "a", URL: "http://localhost:1", Token: "t"}})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/api/daemons/unknown/sessions")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", res.StatusCode)
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dashboard.yaml")
+	content := `
+daemons:
+  - name: extend-api
+    url: http://localhost:7523
+    token: abc
+  - name: relay-ide
+    url: http://localhost:7524
+    token: def
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfgs, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfgs) != 2 {
+		t.Fatalf("expected 2 daemons, got %d", len(cfgs))
+	}
+	if cfgs[0].Name != "extend-api" || cfgs[0].Token != "abc" {
+		t.Fatalf("unexpected first daemon: %+v", cfgs[0])
+	}
+	if cfgs[1].Name != "relay-ide" || cfgs[1].Token != "def" {
+		t.Fatalf("unexpected second daemon: %+v", cfgs[1])
+	}
+}
+
+func TestLoadConfig_MissingFile(t *testing.T) {
+	_, err := LoadConfig("/nonexistent/dashboard.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestNewServer_EmptyDaemons(t *testing.T) {
+	_, err := NewServer([]DaemonConfig{})
+	if err == nil {
+		t.Fatal("expected error for empty daemon list")
+	}
+}
+
+func TestNewServer_InvalidURL(t *testing.T) {
+	_, err := NewServer([]DaemonConfig{{Name: "bad", URL: "://invalid", Token: "t"}})
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestServer_ProxySSE(t *testing.T) {
+	// SSE endpoint that sends two events then hangs until client disconnects
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		w.Write([]byte("data: hello\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Wait a bit so the client can read
+		time.Sleep(50 * time.Millisecond)
+	}))
+	defer mock.Close()
+
+	srv, _ := NewServer([]DaemonConfig{{Name: "sse", URL: mock.URL, Token: ""}})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/api/daemons/sse/events/stream")
+	if err != nil {
+		t.Fatalf("GET SSE: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+	body, _ := io.ReadAll(res.Body)
+	if !strings.Contains(string(body), "data: hello") {
+		t.Fatalf("expected SSE data, got: %s", string(body))
+	}
+}

--- a/web/app.js
+++ b/web/app.js
@@ -662,15 +662,13 @@ ${escapeHtml(JSON.stringify(t, null, 2))}
 
   // --- UI helpers ---
   function setSSEStatus(status) {
-    const el = document.getElementById('sse-status');
-    if (!el) return;
-    el.className = 'sse-dot ' + status;
-    el.textContent = status === 'connected' ? 'Live' : status === 'reconnecting' ? 'Reconnecting…' : 'Offline';
+    const dot = document.getElementById('sse-dot');
+    const text = document.getElementById('sse-status');
+    if (dot) dot.className = 'sse-dot ' + status;
+    if (text) text.textContent = status === 'connected' ? 'Live' : status === 'reconnecting' ? 'Reconnecting…' : 'Offline';
 
-    const dot = document.getElementById('conn-status');
-    if (dot) {
-      dot.className = 'sse-dot ' + status;
-    }
+    const conn = document.getElementById('conn-status');
+    if (conn) conn.className = 'sse-dot ' + status;
   }
 
   function showBanner(text, severity) {

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,686 @@
+// Belayer Web UI — Live Agent Dashboard
+// Vanilla JS, no build step. Consumes the Belayer daemon REST API + SSE.
+// Supports both single-daemon mode and multi-daemon dashboard mode.
+
+(function () {
+  'use strict';
+
+  // --- Config ---
+  const API_BASE = '';
+  const POLL_INTERVAL_MS = 5000;
+  const OUTLINE_POLL_MS = 10000;
+  const MAX_BACKOFF_MS = 30000;
+
+  // --- State ---
+  let token = '';
+  let dashboardMode = false;
+  let daemons = [];              // in dashboard mode: [{name, url, healthy, sessions}]
+  let sessions = [];
+  let activeSessionId = null;
+  let activeDaemon = null;       // name of daemon owning active session
+  let events = [];
+  let messages = [];
+  let toolCalls = [];
+  let agents = new Map();
+  let artifacts = [];
+  let sessionMeta = null;
+  let sseController = null;
+  let reconnectTimer = null;
+  let backoffMs = 500;
+  let lastEventId = 0;
+  let daemonInstanceId = null;
+  let sessionPollTimer = null;
+  let outlinePollTimer = null;
+  let autoScroll = true;
+  let activeTab = 'events';
+  let typeFilters = new Set(['session_', 'agent_', 'bridge:', 'message_', 'artifact_', 'tool_', 'completion_', 'pm_', 'warning:', 'node_', 'trace:', 'custom_event']);
+  let agentFilters = new Set();
+
+  // --- Agent Colors ---
+  const AGENT_COLORS = {
+    supervisor: '#8b5cf6',
+    'backend-dev': '#22c55e',
+    'web-dev': '#f59e0b',
+    qa: '#ef4444',
+    pm: '#06b6d4',
+    reviewer: '#94a3b8',
+    system: '#64748b',
+    unknown: '#a855f7',
+  };
+
+  function agentColor(name) {
+    if (!name) return AGENT_COLORS.system;
+    const base = name.split(/[.-]/)[0].toLowerCase();
+    return AGENT_COLORS[base] || AGENT_COLORS.unknown;
+  }
+
+  function agentPill(name) {
+    const color = agentColor(name);
+    const display = name || 'system';
+    return `<span class="agent-pill" style="border-left-color:${color};background:${color}26"><span class="agent-dot" style="background:${color}"></span>${escapeHtml(display)}</span>`;
+  }
+
+  // --- Utils ---
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+  }
+
+  function fmtTime(iso) {
+    const d = new Date(iso);
+    return d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  }
+
+  function fmtRelTime(iso) {
+    const diff = (Date.now() - new Date(iso).getTime()) / 1000;
+    if (diff < 60) return 'now';
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+    return `${Math.floor(diff / 86400)}d ago`;
+  }
+
+  function syntaxHighlight(json) {
+    if (!json) return '';
+    const s = typeof json === 'string' ? json : JSON.stringify(json, null, 2);
+    return escapeHtml(s)
+      .replace(/"(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)/g, '<span class="json-key">$1</span>$2')
+      .replace(/"(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"/g, '<span class="json-string">$&</span>')
+      .replace(/\b(true|false)\b/g, '<span class="json-boolean">$1</span>')
+      .replace(/\b(null)\b/g, '<span class="json-null">$1</span>')
+      .replace(/\b(\d+\.?\d*)\b/g, '<span class="json-number">$1</span>');
+  }
+
+  // --- API ---
+  function apiUrl(path, daemonName) {
+    let base = '';
+    if (dashboardMode && daemonName) {
+      base = `/api/daemons/${encodeURIComponent(daemonName)}`;
+    }
+    const sep = path.includes('?') ? '&' : '?';
+    return `${API_BASE}${base}${path}${token ? sep + 'token=' + encodeURIComponent(token) : ''}`;
+  }
+
+  async function apiGet(path, daemonName) {
+    let url = API_BASE + path;
+    if (dashboardMode && daemonName) {
+      url = `${API_BASE}/api/daemons/${encodeURIComponent(daemonName)}${path}`;
+    }
+    const headers = {};
+    if (token) headers['Authorization'] = 'Bearer ' + token;
+    const res = await fetch(url, { headers });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    return res.json();
+  }
+
+  async function apiGetText(path, daemonName) {
+    let url = API_BASE + path;
+    if (dashboardMode && daemonName) {
+      url = `${API_BASE}/api/daemons/${encodeURIComponent(daemonName)}${path}`;
+    }
+    const headers = {};
+    if (token) headers['Authorization'] = 'Bearer ' + token;
+    const res = await fetch(url, { headers });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    return res.text();
+  }
+
+  // --- Init ---
+  async function init() {
+    const params = new URLSearchParams(window.location.search);
+    token = params.get('token') || '';
+
+    // Detect dashboard mode
+    try {
+      const dlist = await apiGet('/api/daemons');
+      if (Array.isArray(dlist)) {
+        dashboardMode = true;
+        daemons = dlist.map(d => ({ ...d, sessions: [] }));
+        document.querySelector('.brand').textContent = 'Dashboard';
+      }
+    } catch (e) {
+      // 404 or error -> single-daemon mode
+      dashboardMode = false;
+    }
+
+    if (!dashboardMode) {
+      checkHealth();
+    }
+    loadSessions();
+    bindTabs();
+    bindFilters();
+    bindScroll();
+
+    sessionPollTimer = setInterval(loadSessions, POLL_INTERVAL_MS);
+
+    // Collapsible filters
+    const filtersToggle = document.getElementById('filters-toggle');
+    if (filtersToggle) {
+      filtersToggle.addEventListener('click', () => {
+        const body = document.getElementById('filters-body');
+        body.classList.toggle('collapsed');
+        document.querySelector('#filters-toggle .chevron').textContent = body.classList.contains('collapsed') ? '▶' : '▼';
+      });
+    }
+  }
+
+  async function checkHealth() {
+    try {
+      const data = await apiGet('/health');
+      document.getElementById('daemon-id').textContent = data.daemon_instance_id?.slice(0, 8) || '—';
+      if (!data.capabilities?.web_ui) {
+        showBanner('Daemon does not advertise web_ui capability — UI may not work.', 'warn');
+      }
+    } catch (e) {
+      showBanner('Daemon health check failed: ' + e.message, 'danger');
+    }
+  }
+
+  // --- Sessions ---
+  async function loadSessions() {
+    if (dashboardMode) {
+      try {
+        const dlist = await apiGet('/api/daemons');
+        if (!Array.isArray(dlist)) return;
+        daemons = dlist.map(d => ({ ...d, sessions: [] }));
+
+        await Promise.all(daemons.map(async (d) => {
+          try {
+            const data = await apiGet('/sessions', d.name);
+            d.sessions = (data || []).map(s => ({ ...s, _daemon: d.name }));
+          } catch (e) {
+            d.sessions = [];
+          }
+        }));
+
+        // Flatten for backward-compatible session list
+        sessions = daemons.flatMap(d => d.sessions);
+        renderSessions();
+      } catch (e) {
+        console.error('loadSessions dashboard', e);
+      }
+      return;
+    }
+
+    try {
+      const data = await apiGet('/sessions');
+      sessions = data || [];
+      renderSessions();
+    } catch (e) {
+      console.error('loadSessions', e);
+    }
+  }
+
+  function renderSessions() {
+    const list = document.getElementById('sessions-list');
+    if (!list) return;
+
+    if (dashboardMode) {
+      list.innerHTML = daemons.map(d => `
+        <li class="daemon-group">
+          <div class="daemon-header">
+            <span class="daemon-dot ${d.healthy ? 'healthy' : 'unhealthy'}"></span>
+            <span class="daemon-name">${escapeHtml(d.name)}</span>
+          </div>
+          <ul class="daemon-sessions">
+            ${d.sessions.map(s => `
+              <li class="session-item ${s.id === activeSessionId ? 'active' : ''}" data-id="${escapeHtml(s.id)}" data-daemon="${escapeHtml(d.name)}">
+                <div class="session-name">${escapeHtml(s.name || s.id.slice(0, 8))}</div>
+                <div class="session-meta">
+                  <span class="status-badge ${s.status}">${escapeHtml(s.status)}</span>
+                  ${fmtRelTime(s.created_at)}
+                </div>
+              </li>
+            `).join('')}
+          </ul>
+        </li>
+      `).join('');
+
+      list.querySelectorAll('.session-item').forEach(el => {
+        el.addEventListener('click', () => selectSession(el.dataset.id, el.dataset.daemon));
+      });
+      return;
+    }
+
+    list.innerHTML = sessions.map(s => `
+      <li class="session-item ${s.id === activeSessionId ? 'active' : ''}" data-id="${escapeHtml(s.id)}">
+        <div class="session-name">${escapeHtml(s.name || s.id.slice(0, 8))}</div>
+        <div class="session-meta">
+          <span class="status-badge ${s.status}">${escapeHtml(s.status)}</span>
+          ${fmtRelTime(s.created_at)}
+        </div>
+      </li>
+    `).join('');
+    list.querySelectorAll('.session-item').forEach(el => {
+      el.addEventListener('click', () => selectSession(el.dataset.id));
+    });
+  }
+
+  async function selectSession(id, daemonName) {
+    if (activeSessionId === id && (!dashboardMode || activeDaemon === daemonName)) return;
+    activeSessionId = id;
+    if (dashboardMode && daemonName) {
+      activeDaemon = daemonName;
+    }
+    events = [];
+    messages = [];
+    toolCalls = [];
+    lastEventId = 0;
+    agents.clear();
+    artifacts = [];
+    renderSessions();
+    closeSSE();
+
+    const currentDaemon = dashboardMode ? activeDaemon : null;
+
+    try {
+      const session = await apiGet(`/sessions/${id}`, currentDaemon);
+      sessionMeta = session;
+      const displayName = session.name || id.slice(0, 8);
+      const daemonLabel = dashboardMode && currentDaemon ? `[${currentDaemon}] ` : '';
+      document.getElementById('active-session-name').textContent = daemonLabel + displayName;
+      document.getElementById('active-session-status').textContent = session.status;
+      document.getElementById('active-session-status').className = 'status-badge ' + session.status;
+      document.getElementById('active-session-status').classList.remove('hidden');
+
+      if (session.agents) {
+        session.agents.forEach(a => agents.set(a.name, a));
+      }
+      renderRoster();
+      renderMeta();
+      renderAgentFilters();
+
+      const arts = await apiGet(`/sessions/${id}/artifacts`, currentDaemon);
+      artifacts = arts || [];
+      renderArtifacts();
+
+      const hist = await apiGet(`/sessions/${id}/events?after=0&limit=1000`, currentDaemon);
+      if (hist && hist.length) {
+        events = hist;
+        lastEventId = hist[hist.length - 1].id;
+        processEvents(hist);
+      }
+      renderEvents();
+      renderMessages();
+
+      const tools = await apiGet(`/sessions/${id}/tool-calls`, currentDaemon);
+      toolCalls = tools || [];
+      renderToolCalls();
+
+      openSSE(id, currentDaemon);
+      startOutlinePoll(currentDaemon);
+    } catch (e) {
+      showBanner('Failed to load session: ' + e.message, 'danger');
+    }
+  }
+
+  // --- SSE ---
+  function openSSE(sessionId, daemonName) {
+    closeSSE();
+    setSSEStatus('reconnecting');
+
+    const url = apiUrl(`/events/stream?sessions=${encodeURIComponent(sessionId)}&tier=verbose&after=${lastEventId}`, daemonName);
+    const headers = {};
+    if (token) headers['Authorization'] = 'Bearer ' + token;
+
+    fetch(url, { headers })
+      .then(res => {
+        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+        setSSEStatus('connected');
+        backoffMs = 500;
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        sseController = { abort: () => reader.cancel() };
+
+        function pump() {
+          return reader.read().then(({ done, value }) => {
+            if (done) {
+              scheduleReconnect(sessionId, daemonName);
+              return;
+            }
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop();
+            parseSSELines(lines);
+            return pump();
+          }).catch(err => {
+            console.error('SSE read error', err);
+            scheduleReconnect(sessionId, daemonName);
+          });
+        }
+        return pump();
+      })
+      .catch(err => {
+        console.error('SSE fetch error', err);
+        setSSEStatus('disconnected');
+        scheduleReconnect(sessionId, daemonName);
+      });
+  }
+
+  function closeSSE() {
+    if (sseController) {
+      try { sseController.abort(); } catch (e) {}
+      sseController = null;
+    }
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    stopOutlinePoll();
+  }
+
+  function scheduleReconnect(sessionId, daemonName) {
+    setSSEStatus('reconnecting');
+    reconnectTimer = setTimeout(() => {
+      backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+      openSSE(sessionId, daemonName);
+    }, backoffMs);
+  }
+
+  function parseSSELines(lines) {
+    let current = {};
+    for (const line of lines) {
+      if (line.startsWith('id:')) {
+        current.id = parseInt(line.slice(3).trim(), 10);
+      } else if (line.startsWith('event:')) {
+        current.event = line.slice(6).trim();
+      } else if (line.startsWith('data:')) {
+        current.data = (current.data || '') + line.slice(5).trim();
+      } else if (line === '' && current.event) {
+        handleSSEEvent(current);
+        current = {};
+      }
+    }
+  }
+
+  function handleSSEEvent(frame) {
+    if (frame.event === 'daemon_hello') {
+      try {
+        const data = JSON.parse(frame.data);
+        if (daemonInstanceId && daemonInstanceId !== data.daemon_instance_id) {
+          events = [];
+          lastEventId = 0;
+          daemonInstanceId = data.daemon_instance_id;
+          if (activeSessionId) openSSE(activeSessionId, activeDaemon);
+          return;
+        }
+        daemonInstanceId = data.daemon_instance_id;
+      } catch (e) {}
+      return;
+    }
+    if (frame.event === 'daemon_draining') {
+      showBanner('Daemon is draining — sessions will archive soon', 'warn');
+      return;
+    }
+    if (frame.event === 'session_digest') {
+      return;
+    }
+    if (!frame.event || frame.id == null) return;
+
+    const evt = { type: frame.event, id: frame.id, data: {} };
+    try { evt.data = JSON.parse(frame.data); } catch (e) {}
+    if (evt.id > lastEventId) lastEventId = evt.id;
+    events.push(evt);
+    processEvent(evt);
+    renderEvents();
+    renderMessages();
+  }
+
+  function processEvents(list) {
+    for (const e of list) processEvent(e);
+  }
+
+  function processEvent(e) {
+    if (e.type === 'message_sent' || e.type === 'message_broadcast') {
+      messages.push(e);
+    }
+    const agentName = e.data?.agent || e.data?.from || e.data?.agent_name;
+    if (agentName && !agents.has(agentName)) {
+      agents.set(agentName, { name: agentName, role: 'unknown', status: 'running' });
+    }
+  }
+
+  // --- Outline Polling ---
+  function startOutlinePoll(daemonName) {
+    stopOutlinePoll();
+    if (!activeSessionId) return;
+    outlinePollTimer = setInterval(async () => {
+      try {
+        const data = await apiGet(`/sessions/${activeSessionId}/outline`, daemonName);
+        if (data.agents) {
+          data.agents.forEach(a => agents.set(a.name, a));
+          renderRoster();
+        }
+        if (data.artifacts) {
+          artifacts = data.artifacts;
+          renderArtifacts();
+        }
+        if (data.session) {
+          sessionMeta = { ...sessionMeta, ...data.session };
+          renderMeta();
+        }
+      } catch (e) {
+        console.error('outline poll', e);
+      }
+    }, OUTLINE_POLL_MS);
+  }
+
+  function stopOutlinePoll() {
+    if (outlinePollTimer) { clearInterval(outlinePollTimer); outlinePollTimer = null; }
+  }
+
+  // --- Rendering ---
+  function renderEvents() {
+    const feed = document.getElementById('events-feed');
+    if (!feed) return;
+    const filtered = events.filter(e => {
+      const typeOk = Array.from(typeFilters).some(p => e.type.startsWith(p));
+      const agent = e.data?.agent || e.data?.from || e.data?.agent_name || 'system';
+      const agentOk = agentFilters.size === 0 || agentFilters.has(agent);
+      return typeOk && agentOk;
+    });
+
+    feed.innerHTML = filtered.map(e => `
+      <div class="event-row" data-id="${e.id}">
+        <div class="event-header">
+          <span class="event-ts">${fmtTime(e.timestamp || e.data?.sent_at)}</span>
+          ${agentPill(e.data?.agent || e.data?.from || e.data?.agent_name)}
+          <span class="event-type">${escapeHtml(e.type)}</span>
+        </div>
+        <div class="event-payload">${syntaxHighlight(e.data)}</div>
+      </div>
+    `).join('');
+
+    feed.querySelectorAll('.event-row').forEach(row => {
+      row.addEventListener('click', () => row.classList.toggle('expanded'));
+    });
+
+    if (autoScroll && activeTab === 'events') {
+      const container = document.getElementById('tab-events');
+      container.scrollTop = container.scrollHeight;
+    }
+  }
+
+  function renderMessages() {
+    const feed = document.getElementById('messages-feed');
+    if (!feed) return;
+    const list = messages.filter(m => {
+      const agent = m.data?.from || m.data?.agent || 'system';
+      return agentFilters.size === 0 || agentFilters.has(agent);
+    });
+
+    if (!list.length) {
+      feed.innerHTML = '<div class="empty-state">No messages yet</div>';
+      return;
+    }
+
+    feed.innerHTML = list.map(m => `
+      <div class="message-row">
+        <div class="message-header">
+          ${agentPill(m.data?.from)}
+          <span class="message-arrow">→</span>
+          <span class="message-to">${escapeHtml(m.data?.to || 'broadcast')}</span>
+          <span class="event-ts">${fmtTime(m.data?.sent_at || m.timestamp)}</span>
+        </div>
+        <div class="message-body">${escapeHtml(m.data?.content || '')}</div>
+      </div>
+    `).join('');
+  }
+
+  function renderToolCalls() {
+    const feed = document.getElementById('toolcalls-feed');
+    if (!feed) return;
+    if (!toolCalls.length) {
+      feed.innerHTML = '<div class="empty-state">No tool calls yet</div>';
+      return;
+    }
+    feed.innerHTML = toolCalls.map(t => `
+      <div class="tool-row">
+        <div class="tool-header">
+          <span class="tool-name">${escapeHtml(t.tool)}</span>
+          ${agentPill(t.agent)}
+          <span class="tool-duration">${t.duration_ms}ms</span>
+          <span class="tool-status ${t.status}">${escapeHtml(t.status)}</span>
+        </div>
+        <div class="tool-body">
+${escapeHtml(JSON.stringify(t, null, 2))}
+        </div>
+      </div>
+    `).join('');
+
+    feed.querySelectorAll('.tool-header').forEach(h => {
+      h.addEventListener('click', () => h.closest('.tool-row').classList.toggle('expanded'));
+    });
+  }
+
+  function renderRoster() {
+    const list = document.getElementById('agent-roster');
+    if (!list) return;
+    const items = Array.from(agents.values());
+    if (!items.length) {
+      list.innerHTML = '<li class="empty-state">No agents</li>';
+      return;
+    }
+    list.innerHTML = items.map(a => `
+      <li class="roster-item">
+        <span class="agent-dot" style="background:${agentColor(a.name)}"></span>
+        <div>
+          <div class="roster-name">${escapeHtml(a.name)}</div>
+          <div class="roster-role">${escapeHtml(a.role || 'unknown')}</div>
+        </div>
+        <span class="roster-status ${a.status || 'pending'}">${escapeHtml(a.status || 'pending')}</span>
+      </li>
+    `).join('');
+  }
+
+  function renderMeta() {
+    if (!sessionMeta) return;
+    const dl = document.getElementById('session-meta');
+    if (!dl) return;
+    dl.innerHTML = `
+      <dt>ID</dt><dd>${escapeHtml(sessionMeta.id || '—')}</dd>
+      <dt>Status</dt><dd>${escapeHtml(sessionMeta.status || '—')}</dd>
+      <dt>Log Level</dt><dd>${escapeHtml(sessionMeta.log_level || '—')}</dd>
+      <dt>Created</dt><dd>${sessionMeta.created_at ? fmtTime(sessionMeta.created_at) : '—'}</dd>
+      <dt>Phase</dt><dd>${escapeHtml(sessionMeta.phase || '—')}</dd>
+    `;
+  }
+
+  function renderArtifacts() {
+    const list = document.getElementById('artifacts-list');
+    if (!list) return;
+    if (!artifacts.length) {
+      list.innerHTML = '<li class="empty-state">No artifacts</li>';
+      return;
+    }
+    list.innerHTML = artifacts.map(a => `
+      <li class="artifact-item" data-id="${escapeHtml(a.id)}">
+        <div class="artifact-kind">${escapeHtml(a.kind || 'artifact')}</div>
+        <div class="artifact-path">${escapeHtml(a.path || a.id)}</div>
+      </li>
+    `).join('');
+  }
+
+  function renderAgentFilters() {
+    const container = document.getElementById('agent-filters');
+    if (!container) return;
+    const names = Array.from(agents.keys());
+    if (!names.length) {
+      container.innerHTML = '<h4>Agents</h4><div class="filter-chips"><span class="chip">all</span></div>';
+      return;
+    }
+    container.innerHTML = '<h4>Agents</h4><div class="filter-chips">' +
+      names.map(n => `<span class="chip ${agentFilters.has(n) ? 'active' : ''}" data-agent="${escapeHtml(n)}">${escapeHtml(n)}</span>`).join('') +
+      '</div>';
+    container.querySelectorAll('.chip').forEach(ch => {
+      ch.addEventListener('click', () => {
+        const a = ch.dataset.agent;
+        if (agentFilters.has(a)) agentFilters.delete(a);
+        else agentFilters.add(a);
+        renderAgentFilters();
+        renderEvents();
+        renderMessages();
+      });
+    });
+  }
+
+  // --- Tabs ---
+  function bindTabs() {
+    document.querySelectorAll('.tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        tab.classList.add('active');
+        document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+        activeTab = tab.dataset.tab;
+      });
+    });
+  }
+
+  // --- Filters ---
+  function bindFilters() {
+    document.querySelectorAll('.filter-chips .chip[data-filter]').forEach(chip => {
+      chip.addEventListener('click', () => {
+        chip.classList.toggle('active');
+        const filter = chip.dataset.filter;
+        if (chip.classList.contains('active')) typeFilters.add(filter);
+        else typeFilters.delete(filter);
+        renderEvents();
+      });
+    });
+  }
+
+  // --- Scroll ---
+  function bindScroll() {
+    const container = document.getElementById('tab-events');
+    if (!container) return;
+    container.addEventListener('scroll', () => {
+      const nearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 50;
+      autoScroll = nearBottom;
+    });
+  }
+
+  // --- UI helpers ---
+  function setSSEStatus(status) {
+    const el = document.getElementById('sse-status');
+    if (!el) return;
+    el.className = 'sse-dot ' + status;
+    el.textContent = status === 'connected' ? 'Live' : status === 'reconnecting' ? 'Reconnecting…' : 'Offline';
+
+    const dot = document.getElementById('conn-status');
+    if (dot) {
+      dot.className = 'sse-dot ' + status;
+    }
+  }
+
+  function showBanner(text, severity) {
+    const b = document.getElementById('draining-banner');
+    if (!b) return;
+    b.textContent = text;
+    b.className = 'banner show ' + severity;
+    setTimeout(() => b.classList.remove('show'), 10000);
+  }
+
+  // --- Start ---
+  init();
+})();

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Belayer</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div class="app">
+  <header class="topbar">
+    <div class="brand">Belayer <span id="daemon-id">—</span></div>
+    <div class="session-title">
+      <span id="active-session-name">No session</span>
+      <span id="active-session-status" class="status-badge hidden">—</span>
+    </div>
+    <div>
+      <span id="sse-status" class="sse-dot disconnected">Offline</span>
+    </div>
+  </header>
+
+  <div id="draining-banner" class="banner">Daemon is draining — sessions will archive soon</div>
+
+  <aside class="sidebar">
+    <div class="section">
+      <div class="section-header">
+        Sessions
+        <span id="conn-status" class="sse-dot disconnected" title="Connection status"></span>
+      </div>
+      <div class="section-body">
+        <ul id="sessions-list"></ul>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-header collapsible" id="filters-toggle">
+        Filters
+        <span class="chevron">▼</span>
+      </div>
+      <div id="filters-body" class="section-body">
+        <div class="filter-group">
+          <div class="filter-label">Event Types</div>
+          <div class="filter-chips">
+            <span class="chip active" data-filter="session_">session_*</span>
+            <span class="chip active" data-filter="agent_">agent_*</span>
+            <span class="chip active" data-filter="bridge:">bridge:*</span>
+            <span class="chip active" data-filter="message_">message_*</span>
+            <span class="chip active" data-filter="artifact_">artifact_*</span>
+            <span class="chip active" data-filter="tool_">tool_*</span>
+            <span class="chip active" data-filter="completion_">completion_*</span>
+            <span class="chip active" data-filter="pm_">pm_*</span>
+            <span class="chip active" data-filter="warning:">warning:*</span>
+            <span class="chip active" data-filter="node_">node_*</span>
+            <span class="chip active" data-filter="trace:">trace:*</span>
+            <span class="chip active" data-filter="custom_event">custom_event</span>
+          </div>
+        </div>
+        <div class="filter-group" id="agent-filters">
+          <div class="filter-label">Agents</div>
+          <div class="filter-chips">
+            <span class="chip">all</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </aside>
+
+  <section class="center">
+    <nav class="tabs">
+      <button class="tab active" data-tab="events">Events</button>
+      <button class="tab" data-tab="messages">Messages</button>
+      <button class="tab" data-tab="toolcalls">Tool Calls</button>
+    </nav>
+
+    <div class="tab-content active" id="tab-events">
+      <div id="events-feed" class="event-feed"></div>
+    </div>
+    <div class="tab-content" id="tab-messages">
+      <div id="messages-feed" class="message-list"></div>
+    </div>
+    <div class="tab-content" id="tab-toolcalls">
+      <div id="toolcalls-feed"></div>
+    </div>
+  </section>
+
+  <aside class="rightbar">
+    <div class="section">
+      <div class="section-header">Agent Roster</div>
+      <div class="section-body">
+        <ul id="agent-roster"></ul>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-header">Session Metadata</div>
+      <div class="section-body">
+        <dl id="session-meta"></dl>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-header">Artifacts</div>
+      <div class="section-body">
+        <ul id="artifacts-list"></ul>
+      </div>
+    </div>
+  </aside>
+</div>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -14,8 +14,9 @@
       <span id="active-session-name">No session</span>
       <span id="active-session-status" class="status-badge hidden">—</span>
     </div>
-    <div>
-      <span id="sse-status" class="sse-dot disconnected">Offline</span>
+    <div class="status-wrap">
+      <span id="sse-dot" class="sse-dot disconnected"></span>
+      <span id="sse-status" class="status-text">Offline</span>
     </div>
   </header>
 

--- a/web/style.css
+++ b/web/style.css
@@ -224,8 +224,20 @@ html, body {
   color: var(--accent);
 }
 
-/* Center tabs */
-.tabs {
+  .status-wrap {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .status-text {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-dim);
+    white-space: nowrap;
+  }
+
+  /* Center tabs */
+  .tabs {
   display: flex;
   background: var(--bg-1);
   border-bottom: 1px solid var(--border);

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,488 @@
+/* Belayer Web UI — Dark IDE Theme */
+
+:root {
+  --bg-0: #0d1117;
+  --bg-1: #161b22;
+  --bg-2: #21262d;
+  --border: #30363d;
+  --text: #c9d1d9;
+  --text-dim: #8b949e;
+  --text-bright: #f0f6fc;
+  --accent: #58a6ff;
+  --danger: #f85149;
+  --warn: #d29922;
+  --success: #3fb950;
+  --sidebar-w: 260px;
+  --rightbar-w: 260px;
+  --topbar-h: 48px;
+}
+
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; padding: 0;
+  height: 100%;
+  background: var(--bg-0);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  line-height: 1.45;
+  overflow: hidden;
+}
+
+/* Layout */
+.app {
+  display: grid;
+  grid-template-rows: var(--topbar-h) 1fr;
+  grid-template-columns: var(--sidebar-w) 1fr var(--rightbar-w);
+  grid-template-areas:
+    "top top top"
+    "left center right";
+  height: 100vh;
+  width: 100vw;
+}
+
+.topbar {
+  grid-area: top;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--border);
+  gap: 12px;
+}
+.sidebar {
+  grid-area: left;
+  background: var(--bg-0);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.center {
+  grid-area: center;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg-0);
+}
+.rightbar {
+  grid-area: right;
+  background: var(--bg-0);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Topbar */
+.brand {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--text-bright);
+  letter-spacing: 0.3px;
+}
+.brand span {
+  color: var(--accent);
+}
+.session-title {
+  font-weight: 600;
+  color: var(--text-bright);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.status-badge {
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+.status-badge.running { background: rgba(63,185,80,0.15); color: var(--success); }
+.status-badge.complete { background: rgba(88,166,255,0.15); color: var(--accent); }
+.status-badge.blocked { background: rgba(248,81,73,0.15); color: var(--danger); }
+.status-badge.stalled { background: rgba(210,153,34,0.15); color: var(--warn); }
+.status-badge.pending { background: rgba(139,148,158,0.15); color: var(--text-dim); }
+
+.sse-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 6px;
+}
+.sse-dot.connected { background: var(--success); box-shadow: 0 0 6px var(--success); }
+.sse-dot.reconnecting { background: var(--warn); box-shadow: 0 0 6px var(--warn); }
+.sse-dot.disconnected { background: var(--danger); box-shadow: 0 0 6px var(--danger); }
+
+/* Sidebar sections */
+.section {
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.section-header {
+  padding: 10px 12px;
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-dim);
+  background: var(--bg-1);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+}
+.section-body {
+  overflow-y: auto;
+  padding: 6px 0;
+}
+
+/* Session list */
+.session-item {
+  padding: 8px 12px;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+  transition: background 0.1s;
+}
+.session-item:hover { background: var(--bg-2); }
+.session-item.active {
+  background: var(--bg-2);
+  border-left-color: var(--accent);
+}
+.session-name {
+  font-weight: 600;
+  color: var(--text-bright);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.session-meta {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 2px;
+}
+
+/* Daemon groups (dashboard multi-daemon mode) */
+.daemon-group { border-bottom: 1px solid var(--border); }
+.daemon-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--bg-1);
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--text-bright);
+}
+.daemon-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.daemon-dot.healthy { background: var(--success); box-shadow: 0 0 4px var(--success); }
+.daemon-dot.unhealthy { background: var(--danger); box-shadow: 0 0 4px var(--danger); }
+.daemon-sessions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.daemon-sessions .session-item {
+  padding-left: 24px;
+}
+
+/* Filters */
+.filter-group {
+  padding: 6px 12px;
+}
+.filter-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+}
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.chip {
+  padding: 3px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  user-select: none;
+}
+.chip:hover { border-color: var(--text-dim); }
+.chip.active {
+  background: rgba(88,166,255,0.15);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* Center tabs */
+.tabs {
+  display: flex;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--border);
+}
+.tab {
+  padding: 10px 16px;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--text-dim);
+  border-bottom: 2px solid transparent;
+  transition: color 0.1s;
+}
+.tab:hover { color: var(--text); }
+.tab.active {
+  color: var(--text-bright);
+  border-bottom-color: var(--accent);
+}
+.tab-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+/* Event feed */
+.event-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.event-row {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  transition: border-color 0.1s;
+}
+.event-row:hover { border-color: var(--text-dim); }
+.event-row.selected { border-color: var(--accent); }
+.event-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.event-ts {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+.event-type {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+.event-payload {
+  margin-top: 6px;
+  padding: 8px;
+  background: var(--bg-0);
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 300px;
+  overflow-y: auto;
+  display: none;
+}
+.event-row.expanded .event-payload { display: block; }
+
+/* Agent pills */
+.agent-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  border-left-width: 3px;
+  border-left-style: solid;
+}
+.agent-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+/* Messages */
+.message-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.message-row {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px;
+}
+.message-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+.message-arrow {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+.message-body {
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+}
+.message-to {
+  font-size: 11px;
+  color: var(--text-dim);
+  background: var(--bg-2);
+  padding: 1px 6px;
+  border-radius: 8px;
+}
+
+/* Tool calls */
+.tool-row {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 6px;
+  overflow: hidden;
+}
+.tool-header {
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  background: var(--bg-2);
+}
+.tool-header:hover { background: #2d333b; }
+.tool-name {
+  font-weight: 600;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+}
+.tool-agent { font-size: 11px; }
+.tool-duration {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+}
+.tool-status.ok { color: var(--success); }
+.tool-status.pending { color: var(--warn); }
+.tool-body {
+  padding: 10px;
+  display: none;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.tool-row.expanded .tool-body { display: block; }
+
+/* Roster */
+.roster-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+}
+.roster-name {
+  font-weight: 600;
+  color: var(--text-bright);
+}
+.roster-role {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.roster-status {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 8px;
+}
+.roster-status.running { background: rgba(63,185,80,0.12); color: var(--success); }
+.roster-status.complete { background: rgba(88,166,255,0.12); color: var(--accent); }
+.roster-status.blocked { background: rgba(248,81,73,0.12); color: var(--danger); }
+.roster-status.pending { background: rgba(139,148,158,0.12); color: var(--text-dim); }
+
+/* Artifacts */
+.artifact-item {
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.artifact-item:hover { background: var(--bg-2); }
+.artifact-kind {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-dim);
+  margin-bottom: 2px;
+}
+.artifact-path {
+  color: var(--accent);
+  word-break: break-all;
+}
+
+/* Banner */
+.banner {
+  padding: 8px 12px;
+  background: rgba(210,153,34,0.12);
+  border-bottom: 1px solid var(--warn);
+  color: var(--warn);
+  font-weight: 600;
+  font-size: 12px;
+  display: none;
+}
+.banner.show { display: block; }
+.banner.danger { background: rgba(248,81,73,0.12); border-color: var(--danger); color: var(--danger); }
+
+.hidden { display: none !important; }
+.chevron { font-size: 10px; margin-left: 4px; }
+
+.collapsible + .section-body.collapsed { display: none; }
+
+/* Scrollbars */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: #484f58; }
+
+/* Empty state */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-dim);
+  gap: 8px;
+}
+.empty-state svg {
+  width: 48px; height: 48px;
+  opacity: 0.3;
+}
+
+/* JSON syntax highlighting (lightweight) */
+.json-key { color: #7ee787; }
+.json-string { color: #a5d6ff; }
+.json-number { color: #79c0ff; }
+.json-boolean { color: #ff7b72; }
+.json-null { color: #ff7b72; }


### PR DESCRIPTION
## Summary

This PR delivers a complete embedded Web UI for Belayer plus a multi-daemon dashboard, alongside workspace-scoped default paths.

### Embedded Web UI (daemon /ui/)
- Zero-build vanilla JS/CSS/HTML shipped via \+go:embed\+
- Live SSE event stream, agent roster, message viewer, tool calls, artifacts
- Colour-coded agent pills (supervisor purple, backend green, web amber, qa red, pm cyan, etc.)
- Auth via \+?token=\+ query param for browser EventSource compatibility
- Static assets exempt from bearer auth; API calls require token

### belayer dashboard command
- New \+internal/dashboard/\+ package: reverse-proxy + static file server
- \+GET /api/daemons\+ lists backends with live health status
- \+/api/daemons/{name}/...\+ proxies API calls + SSE streams
- Frontend auto-detects dashboard mode; falls back to single-daemon mode on 404
- Per-daemon session groups in sidebar with health dots

### Workspace-scoped defaults
- Socket: \+<cwd>/.belayer/daemon.sock\+ (was \+~/.belayer/daemon.sock\+)
- DB: \+<cwd>/.belayer/belayer.db\+ (was \+~/.belayer/belayer.db\+)
- Runtime dir: \+<cwd>/.belayer/runtime\+ (was \+~/.local/state/belayer/runtime\+)
- Enables multiple daemons on one machine without explicit flags

### Testing
- \+internal/dashboard/server_test.go\+: 9 tests (static files, proxy, SSE, config load)
- \+internal/daemon/webui_test.go\+: static file serving, auth exemption
- All existing tests pass (\+go test ./...\+)

### Docs
- \+docs/webui-spec.md\+ — technical spec for embedded UI
- \+docs/dashboard-spec.md\+ — technical spec for multi-daemon dashboard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded Web UI (dark theme) for browsing sessions, events, messages, tool calls.
  * Dashboard mode to detect and proxy multiple local daemons, plus a new dashboard CLI command.

* **Changes**
  * Browser/SSE-friendly token query-param auth and `/ui/` auth exemption.
  * CLI defaults moved to workspace-local .belayer paths and consistent runtime-dir resolution.
  * Web UI assets (HTML/JS/CSS) and client-side live dashboard behavior added.

* **Documentation**
  * Added Web UI/dashboard specs and a Proxmox LXC deployment guide.

* **Tests**
  * New coverage for web UI, dashboard server, auth paths, and health capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->