### PR TITLE
feat(agent): per-agent toolset restriction via enabled_toolsets

### DIFF
--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -404,6 +404,17 @@ def main() -> None:
     if hermes_session_id:
         agent_kwargs["session_id"] = hermes_session_id
 
+    # Parse enabled_toolsets from env (comma-separated list of toolset names).
+    # When set, restricts the agent to only tools from those toolsets.
+    # Example: "file,code_execution" gives the agent read_file, write_file, patch,
+    # search_files, and execute_code only.
+    enabled_toolsets_env = os.environ.get("BELAYER_ENABLED_TOOLSETS", "")
+    if enabled_toolsets_env:
+        enabled_toolsets = [t.strip() for t in enabled_toolsets_env.split(",") if t.strip()]
+        if enabled_toolsets:
+            agent_kwargs["enabled_toolsets"] = enabled_toolsets
+            log.info("Restricting agent to toolsets: %s", enabled_toolsets)
+
     try:
         agent = AIAgent(**agent_kwargs)
     except Exception as exc:

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -405,15 +405,20 @@ def main() -> None:
         agent_kwargs["session_id"] = hermes_session_id
 
     # Parse enabled_toolsets from env (comma-separated list of toolset names).
-    # When set, restricts the agent to only tools from those toolsets.
-    # Example: "file,code_execution" gives the agent read_file, write_file, patch,
-    # search_files, and execute_code only.
+    # __all__ sentinel means "not configured" → no restriction.
+    # Empty string means explicitly empty list → zero toolsets.
+    # Non-empty list restricts to those toolsets.
     enabled_toolsets_env = os.environ.get("BELAYER_ENABLED_TOOLSETS", "")
-    if enabled_toolsets_env:
+    if enabled_toolsets_env == "__all__":
+        pass  # field not configured; no restriction
+    elif enabled_toolsets_env != "":
         enabled_toolsets = [t.strip() for t in enabled_toolsets_env.split(",") if t.strip()]
-        if enabled_toolsets:
-            agent_kwargs["enabled_toolsets"] = enabled_toolsets
-            log.info("Restricting agent to toolsets: %s", enabled_toolsets)
+        agent_kwargs["enabled_toolsets"] = enabled_toolsets
+        log.info("Restricting agent to toolsets: %s", enabled_toolsets)
+    else:
+        # explicit empty list (e.g. enabled_toolsets: [])
+        agent_kwargs["enabled_toolsets"] = []
+        log.info("Restricting agent to toolsets: []")
 
     try:
         agent = AIAgent(**agent_kwargs)

--- a/hermes_bridge/tests/test_main_runtime.py
+++ b/hermes_bridge/tests/test_main_runtime.py
@@ -84,6 +84,7 @@ def _set_required_env(monkeypatch, max_turns="7"):
     monkeypatch.delenv("BELAYER_EPHEMERAL", raising=False)
     monkeypatch.delenv("BELAYER_TRANSCRIPT_PATH", raising=False)
     monkeypatch.delenv("BELAYER_TOOLS", raising=False)
+    monkeypatch.delenv("BELAYER_ENABLED_TOOLSETS", raising=False)
 
 
 def test_main_emits_message_ack_for_consumed_pending_messages(monkeypatch):
@@ -295,3 +296,59 @@ def test_non_positive_max_turns_is_ignored(monkeypatch):
 
     assert created_agents, "expected AIAgent to be constructed"
     assert "max_iterations" not in created_agents[0].kwargs
+
+
+def test_main_honors_enabled_toolsets_env(monkeypatch):
+    module = _load_main_module(monkeypatch)
+    _set_required_env(monkeypatch, max_turns="5")
+    monkeypatch.setenv("BELAYER_ENABLED_TOOLSETS", "file, code_execution")
+
+    created_agents = []
+    result = {
+        "completed": True,
+        "final_response": "done",
+        "messages": [],
+    }
+    _patch_bridge_runtime(
+        monkeypatch,
+        module,
+        result,
+        pending_messages=[],
+        created_agents=created_agents,
+    )
+
+    post_event = MagicMock()
+    monkeypatch.setattr(module, "post_event", post_event)
+
+    module.main()
+
+    assert created_agents, "expected AIAgent to be constructed"
+    assert created_agents[0].kwargs["enabled_toolsets"] == ["file", "code_execution"]
+
+
+def test_main_ignores_empty_enabled_toolsets_env(monkeypatch):
+    module = _load_main_module(monkeypatch)
+    _set_required_env(monkeypatch, max_turns="5")
+    monkeypatch.setenv("BELAYER_ENABLED_TOOLSETS", "")
+
+    created_agents = []
+    result = {
+        "completed": True,
+        "final_response": "done",
+        "messages": [],
+    }
+    _patch_bridge_runtime(
+        monkeypatch,
+        module,
+        result,
+        pending_messages=[],
+        created_agents=created_agents,
+    )
+
+    post_event = MagicMock()
+    monkeypatch.setattr(module, "post_event", post_event)
+
+    module.main()
+
+    assert created_agents, "expected AIAgent to be constructed"
+    assert "enabled_toolsets" not in created_agents[0].kwargs

--- a/hermes_bridge/tests/test_main_runtime.py
+++ b/hermes_bridge/tests/test_main_runtime.py
@@ -351,4 +351,32 @@ def test_main_ignores_empty_enabled_toolsets_env(monkeypatch):
     module.main()
 
     assert created_agents, "expected AIAgent to be constructed"
+    assert created_agents[0].kwargs["enabled_toolsets"] == []
+
+
+def test_main_ignores_all_sentinel_enabled_toolsets_env(monkeypatch):
+    module = _load_main_module(monkeypatch)
+    _set_required_env(monkeypatch, max_turns="5")
+    monkeypatch.setenv("BELAYER_ENABLED_TOOLSETS", "__all__")
+
+    created_agents = []
+    result = {
+        "completed": True,
+        "final_response": "done",
+        "messages": [],
+    }
+    _patch_bridge_runtime(
+        monkeypatch,
+        module,
+        result,
+        pending_messages=[],
+        created_agents=created_agents,
+    )
+
+    post_event = MagicMock()
+    monkeypatch.setattr(module, "post_event", post_event)
+
+    module.main()
+
+    assert created_agents, "expected AIAgent to be constructed"
     assert "enabled_toolsets" not in created_agents[0].kwargs

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -201,8 +201,14 @@ func BuildEnv(cfg Config) []string {
 	if cfg.Provider != "" {
 		env = appendEnv(env, "BELAYER_PROVIDER", cfg.Provider)
 	}
-	// Always emit toolset/tool vars to override any parent env leakage.
-	env = appendEnv(env, "BELAYER_ENABLED_TOOLSETS", strings.Join(cfg.EnabledToolsets, ","))
+	// Always emit toolset/tool vars to prevent parent env leakage.
+	// __all__ sentinel means "not configured" (no restriction); anything else
+	// is an explicit list (empty string = zero toolsets).
+	if cfg.EnabledToolsets != nil {
+		env = appendEnv(env, "BELAYER_ENABLED_TOOLSETS", strings.Join(cfg.EnabledToolsets, ","))
+	} else {
+		env = appendEnv(env, "BELAYER_ENABLED_TOOLSETS", "__all__")
+	}
 	env = appendEnv(env, "BELAYER_TOOLS", strings.Join(cfg.BelayerTools, ","))
 	if cfg.Message != "" {
 		env = appendEnv(env, "BELAYER_MESSAGE", cfg.Message)

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -71,6 +71,7 @@ type Config struct {
 	BelayerRoot         string   // directory containing hermes_bridge/ package (for PYTHONPATH)
 	Ephemeral           bool     // true = exit on task completion, false = stay alive for more work
 	BelayerTools        []string // role-specific belayer tools from agent.yaml
+	EnabledToolsets     []string // hermes toolsets to enable for this agent (e.g. ["file", "code_execution"])
 	TranscriptPath      string   // absolute path to per-agent JSONL; empty = capture disabled (standard log level)
 	LogLevel            string   // "standard", "verbose", or "trace"; empty treated as "standard"
 	SkipOpenRouterProbe bool     // when true, injects HERMES_SKIP_OPENROUTER_PROBE=1 to suppress the openrouter metadata fetch at bridge startup
@@ -199,6 +200,12 @@ func BuildEnv(cfg Config) []string {
 	}
 	if cfg.Provider != "" {
 		env = appendEnv(env, "BELAYER_PROVIDER", cfg.Provider)
+	}
+	if len(cfg.EnabledToolsets) > 0 {
+		env = appendEnv(env, "BELAYER_ENABLED_TOOLSETS", strings.Join(cfg.EnabledToolsets, ","))
+	}
+	if len(cfg.BelayerTools) > 0 {
+		env = appendEnv(env, "BELAYER_TOOLS", strings.Join(cfg.BelayerTools, ","))
 	}
 	if cfg.Message != "" {
 		env = appendEnv(env, "BELAYER_MESSAGE", cfg.Message)

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -201,12 +201,9 @@ func BuildEnv(cfg Config) []string {
 	if cfg.Provider != "" {
 		env = appendEnv(env, "BELAYER_PROVIDER", cfg.Provider)
 	}
-	if len(cfg.EnabledToolsets) > 0 {
-		env = appendEnv(env, "BELAYER_ENABLED_TOOLSETS", strings.Join(cfg.EnabledToolsets, ","))
-	}
-	if len(cfg.BelayerTools) > 0 {
-		env = appendEnv(env, "BELAYER_TOOLS", strings.Join(cfg.BelayerTools, ","))
-	}
+	// Always emit toolset/tool vars to override any parent env leakage.
+	env = appendEnv(env, "BELAYER_ENABLED_TOOLSETS", strings.Join(cfg.EnabledToolsets, ","))
+	env = appendEnv(env, "BELAYER_TOOLS", strings.Join(cfg.BelayerTools, ","))
 	if cfg.Message != "" {
 		env = appendEnv(env, "BELAYER_MESSAGE", cfg.Message)
 	}
@@ -218,9 +215,6 @@ func BuildEnv(cfg Config) []string {
 	}
 	if !cfg.Ephemeral {
 		env = appendEnv(env, "BELAYER_EPHEMERAL", "false")
-	}
-	if len(cfg.BelayerTools) > 0 {
-		env = appendEnv(env, "BELAYER_TOOLS", strings.Join(cfg.BelayerTools, ","))
 	}
 	if cfg.TranscriptPath != "" {
 		env = appendEnv(env, "BELAYER_TRANSCRIPT_PATH", cfg.TranscriptPath)

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -823,19 +823,22 @@ func TestBuildEnvOmitsOptionalVars(t *testing.T) {
 			t.Errorf("expected %s to be absent from env, but it was set", key)
 		}
 	}
-	// BELAYER_TOOLS and BELAYER_ENABLED_TOOLSETS are always emitted (even empty)
-	// to prevent parent env leakage.
+	// BELAYER_TOOLS and BELAYER_ENABLED_TOOLSETS are always emitted.
+	// BELAYER_ENABLED_TOOLSETS uses __all__ sentinel when not configured.
 	for _, key := range []string{"BELAYER_TOOLS", "BELAYER_ENABLED_TOOLSETS"} {
 		if _, ok := envMap[key]; !ok {
-			t.Errorf("expected %s to be present in env (even when empty)", key)
+			t.Errorf("expected %s to be present in env", key)
 		}
+	}
+	if envMap["BELAYER_ENABLED_TOOLSETS"] != "__all__" {
+		t.Errorf("BELAYER_ENABLED_TOOLSETS = %q, want __all__", envMap["BELAYER_ENABLED_TOOLSETS"])
 	}
 }
 
-// TestBelayerToolsEnvVarOmittedWhenEmpty verifies that BELAYER_TOOLS is set to
-// an empty string when the tool list is empty (baseline-only agents), ensuring
+// TestBelayerToolsEnvVarSetEmptyWhenNil verifies that BELAYER_TOOLS is set to
+// an empty string when the tool list is nil (baseline-only agents), ensuring
 // parent env leakage is prevented.
-func TestBelayerToolsEnvVarOmittedWhenEmpty(t *testing.T) {
+func TestBelayerToolsEnvVarSetEmptyWhenNil(t *testing.T) {
 	cfg := Config{
 		SessionID:    "sess-abc",
 		AgentID:      "worker",
@@ -862,6 +865,38 @@ func TestBelayerToolsEnvVarOmittedWhenEmpty(t *testing.T) {
 
 	if !strings.Contains(output, "BELAYER_TOOLS=") {
 		t.Errorf("expected BELAYER_TOOLS to be present in env (empty string to prevent leakage)")
+	}
+}
+
+// TestEnabledToolsetsEnvVarAllSentinel verifies that BELAYER_ENABLED_TOOLSETS
+// is set to __all__ when the field is not configured (no restriction).
+func TestEnabledToolsetsEnvVarAllSentinel(t *testing.T) {
+	cfg := Config{
+		SessionID:       "sess-abc",
+		AgentID:         "worker",
+		Role:            "implementer",
+		Profile:         "default",
+		Workdir:         t.TempDir(),
+		SocketPath:      "/tmp/test.sock",
+		RunDir:          t.TempDir(),
+		EnabledToolsets: nil,
+		Cmd:             []string{"env"},
+	}
+
+	p, err := Spawn(cfg)
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	<-p.Done()
+
+	logData, err := os.ReadFile(cfg.RunDir + "/bridge-stdout.log")
+	if err != nil {
+		t.Fatalf("read stdout log: %v", err)
+	}
+	output := string(logData)
+
+	if !strings.Contains(output, "BELAYER_ENABLED_TOOLSETS=__all__") {
+		t.Errorf("expected BELAYER_ENABLED_TOOLSETS=__all__ in env output\ngot:\n%s", output)
 	}
 }
 
@@ -899,7 +934,7 @@ func TestEnabledToolsetsEnvVarInjected(t *testing.T) {
 }
 
 // TestEnabledToolsetsEnvVarEmpty verifies that BELAYER_ENABLED_TOOLSETS is
-// present even when the list is empty, preventing parent env leakage.
+// set to an empty string when the list is explicitly empty (zero toolsets).
 func TestEnabledToolsetsEnvVarEmpty(t *testing.T) {
 	cfg := Config{
 		SessionID:       "sess-abc",
@@ -909,7 +944,7 @@ func TestEnabledToolsetsEnvVarEmpty(t *testing.T) {
 		Workdir:         t.TempDir(),
 		SocketPath:      "/tmp/test.sock",
 		RunDir:          t.TempDir(),
-		EnabledToolsets: nil,
+		EnabledToolsets: []string{},
 		Cmd:             []string{"env"},
 	}
 
@@ -926,7 +961,10 @@ func TestEnabledToolsetsEnvVarEmpty(t *testing.T) {
 	output := string(logData)
 
 	if !strings.Contains(output, "BELAYER_ENABLED_TOOLSETS=") {
-		t.Errorf("expected BELAYER_ENABLED_TOOLSETS to be present in env (empty string to prevent leakage)")
+		t.Errorf("expected BELAYER_ENABLED_TOOLSETS to be present in env")
+	}
+	if strings.Contains(output, "BELAYER_ENABLED_TOOLSETS=__all__") {
+		t.Errorf("expected BELAYER_ENABLED_TOOLSETS to be empty (explicit []), got __all__")
 	}
 }
 

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -817,17 +817,24 @@ func TestBuildEnvOmitsOptionalVars(t *testing.T) {
 		"BELAYER_MESSAGE",
 		"BELAYER_SYSTEM_PROMPT",
 		"BELAYER_HERMES_SESSION_ID",
-		"BELAYER_TOOLS",
 		"BELAYER_TRANSCRIPT_PATH",
 	} {
 		if _, ok := envMap[key]; ok {
 			t.Errorf("expected %s to be absent from env, but it was set", key)
 		}
 	}
+	// BELAYER_TOOLS and BELAYER_ENABLED_TOOLSETS are always emitted (even empty)
+	// to prevent parent env leakage.
+	for _, key := range []string{"BELAYER_TOOLS", "BELAYER_ENABLED_TOOLSETS"} {
+		if _, ok := envMap[key]; !ok {
+			t.Errorf("expected %s to be present in env (even when empty)", key)
+		}
+	}
 }
 
-// TestBelayerToolsEnvVarOmittedWhenEmpty verifies that BELAYER_TOOLS is not
-// set when the tool list is empty (baseline-only agents).
+// TestBelayerToolsEnvVarOmittedWhenEmpty verifies that BELAYER_TOOLS is set to
+// an empty string when the tool list is empty (baseline-only agents), ensuring
+// parent env leakage is prevented.
 func TestBelayerToolsEnvVarOmittedWhenEmpty(t *testing.T) {
 	cfg := Config{
 		SessionID:    "sess-abc",
@@ -853,8 +860,73 @@ func TestBelayerToolsEnvVarOmittedWhenEmpty(t *testing.T) {
 	}
 	output := string(logData)
 
-	if strings.Contains(output, "BELAYER_TOOLS=") {
-		t.Errorf("expected BELAYER_TOOLS to be absent from env, but found it in output")
+	if !strings.Contains(output, "BELAYER_TOOLS=") {
+		t.Errorf("expected BELAYER_TOOLS to be present in env (empty string to prevent leakage)")
+	}
+}
+
+// TestEnabledToolsetsEnvVarInjected verifies that EnabledToolsets are passed as
+// a comma-separated BELAYER_ENABLED_TOOLSETS env var.
+func TestEnabledToolsetsEnvVarInjected(t *testing.T) {
+	cfg := Config{
+		SessionID:       "sess-abc",
+		AgentID:         "supervisor",
+		Role:            "supervisor",
+		Profile:         "default",
+		Workdir:         t.TempDir(),
+		SocketPath:      "/tmp/test.sock",
+		RunDir:          t.TempDir(),
+		EnabledToolsets: []string{"file", "code_execution"},
+		Cmd:             []string{"env"},
+	}
+
+	p, err := Spawn(cfg)
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	<-p.Done()
+
+	logData, err := os.ReadFile(cfg.RunDir + "/bridge-stdout.log")
+	if err != nil {
+		t.Fatalf("read stdout log: %v", err)
+	}
+	output := string(logData)
+
+	expected := "BELAYER_ENABLED_TOOLSETS=file,code_execution"
+	if !strings.Contains(output, expected) {
+		t.Errorf("expected %q in env output\ngot:\n%s", expected, output)
+	}
+}
+
+// TestEnabledToolsetsEnvVarEmpty verifies that BELAYER_ENABLED_TOOLSETS is
+// present even when the list is empty, preventing parent env leakage.
+func TestEnabledToolsetsEnvVarEmpty(t *testing.T) {
+	cfg := Config{
+		SessionID:       "sess-abc",
+		AgentID:         "worker",
+		Role:            "implementer",
+		Profile:         "default",
+		Workdir:         t.TempDir(),
+		SocketPath:      "/tmp/test.sock",
+		RunDir:          t.TempDir(),
+		EnabledToolsets: nil,
+		Cmd:             []string{"env"},
+	}
+
+	p, err := Spawn(cfg)
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	<-p.Done()
+
+	logData, err := os.ReadFile(cfg.RunDir + "/bridge-stdout.log")
+	if err != nil {
+		t.Fatalf("read stdout log: %v", err)
+	}
+	output := string(logData)
+
+	if !strings.Contains(output, "BELAYER_ENABLED_TOOLSETS=") {
+		t.Errorf("expected BELAYER_ENABLED_TOOLSETS to be present in env (empty string to prevent leakage)")
 	}
 }
 

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -626,19 +626,35 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 				inToolsets = false
 				continue
 			}
-			if trimmed == "belayer_tools:" || trimmed == "belayer_tools: []" {
-				inTools = true
+			if strings.HasPrefix(trimmed, "belayer_tools:") {
+				inTools = false
 				inToolsets = false
-				if trimmed == "belayer_tools: []" {
-					continue // explicit empty list
+				raw := strings.TrimSpace(strings.TrimPrefix(trimmed, "belayer_tools:"))
+				switch {
+				case raw == "":
+					inTools = true
+				case raw == "[]":
+					// explicit empty list
+				default:
+					if items := parseInlineYAMLList(raw); items != nil {
+						belayerTools = append(belayerTools, items...)
+					}
 				}
 				continue
 			}
-			if trimmed == "enabled_toolsets:" || trimmed == "enabled_toolsets: []" {
-				inToolsets = true
+			if strings.HasPrefix(trimmed, "enabled_toolsets:") {
+				inToolsets = false
 				inTools = false
-				if trimmed == "enabled_toolsets: []" {
-					continue // explicit empty list
+				raw := strings.TrimSpace(strings.TrimPrefix(trimmed, "enabled_toolsets:"))
+				switch {
+				case raw == "":
+					inToolsets = true
+				case raw == "[]":
+					// explicit empty list
+				default:
+					if items := parseInlineYAMLList(raw); items != nil {
+						enabledToolsets = append(enabledToolsets, items...)
+					}
 				}
 				continue
 			}
@@ -1445,6 +1461,29 @@ func splitLines(s string) []string {
 		s = s[i+1:]
 	}
 	return lines
+}
+
+// parseInlineYAMLList extracts comma-separated items from an inline YAML list
+// like `[file, code_execution]` or `["a", 'b']`. Returns nil if the raw string
+// does not start with '[' and end with ']'.
+func parseInlineYAMLList(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if !strings.HasPrefix(raw, "[") || !strings.HasSuffix(raw, "]") {
+		return nil
+	}
+	inner := strings.TrimSpace(raw[1 : len(raw)-1])
+	if inner == "" {
+		return []string{}
+	}
+	var out []string
+	for _, item := range strings.Split(inner, ",") {
+		item = strings.TrimSpace(item)
+		item = strings.Trim(item, `"'`)
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 // buildAgentInitialMessage prepends a workspace context header to the agent's

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -629,6 +629,7 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 			if strings.HasPrefix(trimmed, "belayer_tools:") {
 				inTools = false
 				inToolsets = false
+				belayerTools = []string{} // mark as explicitly configured
 				raw := strings.TrimSpace(strings.TrimPrefix(trimmed, "belayer_tools:"))
 				switch {
 				case raw == "":
@@ -645,6 +646,7 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 			if strings.HasPrefix(trimmed, "enabled_toolsets:") {
 				inToolsets = false
 				inTools = false
+				enabledToolsets = []string{} // mark as explicitly configured
 				raw := strings.TrimSpace(strings.TrimPrefix(trimmed, "enabled_toolsets:"))
 				switch {
 				case raw == "":

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -592,9 +592,10 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		}
 	}
 
-	// Load belayer_tools and model from <agent-dir>/agent.yaml if it exists. Same
-	// project-local-over-shipped resolution as the system prompt.
+	// Load belayer_tools, enabled_toolsets, and model from <agent-dir>/agent.yaml
+	// if it exists. Same project-local-over-shipped resolution as the system prompt.
 	var belayerTools []string
+	var enabledToolsets []string
 	agentModel := req.Model // explicit spawn request takes precedence
 	agentMaxTurns := 0
 	for _, yamlPath := range agentIdentityPaths(workdir, d.config.BelayerRoot, identity, "agent.yaml") {
@@ -604,13 +605,16 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		}
 		// Simple line-based parse — avoid YAML library dependency.
 		// Looks for "belayer_tools:" then collects "  - tool_name" lines.
+		// Also reads "enabled_toolsets:" with the same list syntax.
 		// Also reads "model: <value>" for the default model.
 		inTools := false
+		inToolsets := false
 		for _, line := range splitLines(string(data)) {
 			trimmed := strings.TrimSpace(line)
 			if strings.HasPrefix(trimmed, "model:") && agentModel == "" {
 				agentModel = strings.TrimSpace(strings.TrimPrefix(trimmed, "model:"))
 				inTools = false
+				inToolsets = false
 				continue
 			}
 			if strings.HasPrefix(trimmed, "max_turns:") && agentMaxTurns == 0 {
@@ -619,12 +623,22 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 					agentMaxTurns = n
 				}
 				inTools = false
+				inToolsets = false
 				continue
 			}
 			if trimmed == "belayer_tools:" || trimmed == "belayer_tools: []" {
 				inTools = true
+				inToolsets = false
 				if trimmed == "belayer_tools: []" {
-					break // explicit empty list
+					continue // explicit empty list
+				}
+				continue
+			}
+			if trimmed == "enabled_toolsets:" || trimmed == "enabled_toolsets: []" {
+				inToolsets = true
+				inTools = false
+				if trimmed == "enabled_toolsets: []" {
+					continue // explicit empty list
 				}
 				continue
 			}
@@ -633,11 +647,19 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 					tool := strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
 					belayerTools = append(belayerTools, tool)
 				} else {
-					break // end of list
+					inTools = false
+				}
+			}
+			if inToolsets {
+				if strings.HasPrefix(trimmed, "- ") {
+					ts := strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
+					enabledToolsets = append(enabledToolsets, ts)
+				} else {
+					inToolsets = false
 				}
 			}
 		}
-		log.Printf("Loaded agent.yaml from %s for agent %s (identity=%s): model=%q tools=%v", yamlPath, req.Name, identity, agentModel, belayerTools)
+		log.Printf("Loaded agent.yaml from %s for agent %s (identity=%s): model=%q tools=%v toolsets=%v", yamlPath, req.Name, identity, agentModel, belayerTools, enabledToolsets)
 		break
 	}
 
@@ -748,6 +770,7 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 		// destroy the module required for spawning peer bridges.
 		BelayerRoot:         d.config.RuntimeDir,
 		BelayerTools:        belayerTools,
+		EnabledToolsets:     enabledToolsets,
 		TranscriptPath:      transcriptPath,
 		LogLevel:            sess.LogLevel,
 		SkipOpenRouterProbe: d.config.SkipOpenRouterProbe,


### PR DESCRIPTION
## Summary

Allows agent.yaml to specify enabled_toolsets (e.g. [file, code_execution]) which restricts the agent to only tools from those Hermes toolsets.

## Use Case

This enables RPG/quest scenarios, sandboxed coding, and multi-agent collaboration where agents have distinct capability profiles:
- **Researchers**: web + file, no code execution (must delegate computation)
- **Scribes**: file only (read/write narrative artifacts, nothing else)
- **Validators**: file + code_execution (can run tests and validation scripts)
- **Integrators**: file + code_execution + terminal (can orchestrate builds)

## Changes

- **internal/daemon/agents.go**: Parse enabled_toolsets from agent.yaml (same list syntax as belayer_tools)
- **internal/bridge/bridge.go**: Pass EnabledToolsets through Config and BuildEnv as BELAYER_ENABLED_TOOLSETS
- **hermes_bridge/__main__.py**: Read BELAYER_ENABLED_TOOLSETS and pass to AIAgent(..., enabled_toolsets=[...])

## Testing

This was used successfully in a 5-act multi-agent quest ("Relics of the Athenaeum") with 6+ agents running kimi-k2.6, each with distinct toolsets. The restriction forced actual inter-agent communication — e.g. a researcher agent with no code execution would broadcast findings and explicitly ask a coder agent to run verification.

## Backwards Compatibility

If enabled_toolsets is omitted from agent.yaml, behavior is unchanged (agent gets all available tools).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can be limited to specific toolsets via configuration or an environment variable.
  * Agent startup now reliably reports and honors configured toolsets.
* **Bug Fixes**
  * Tool-related environment values are emitted deterministically to avoid parent-process leakage.
* **Tests**
  * Added runtime and unit tests validating toolset parsing and env-var behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->