### PR TITLE
docs: reflect Hermes 0.11 plugin migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Not a cluster scheduler, autoscaler, hypervisor, or hosted identity service. It 
 Three layers:
 
 1. **Session bus** — Go daemon + SQLite. Sessions, agent roster, messages, events, artifacts.
-2. **Hermes driver** — Bridge subprocess (`python -m hermes_bridge`) wraps Hermes AIAgent. Identity injected via `ephemeral_system_prompt`, tools registered at spawn time.
+2. **Hermes driver** — Bridge subprocess (`python -m hermes_bridge`) wraps Hermes AIAgent. Identity injected via `ephemeral_system_prompt`; belayer_* tools registered by the Hermes 0.11 plugin at `plugins/belayer/` (loaded automatically by Hermes during AIAgent import).
 3. **Bridge transport** — Python subprocess managed by Go. Heartbeats, exit detection, event streaming over stdout.
 
 ## Agent kinds
@@ -43,7 +43,9 @@ Agents coordinate through the daemon:
 Run `belayer --help` and `belayer <cmd> --help` for current commands and
 flags. Default config schema (including `exit_conditions`) is generated
 from `internal/cli/init.go`. Agent tool surface (baseline + role-specific)
-is registered in `hermes_bridge/tools.py`.
+is defined by the Hermes plugin at `plugins/belayer/tools.py` and gated
+by `plugins/belayer/__init__.py:register()` based on agent kind +
+BELAYER_TOOLS allowlist.
 
 ## Agent identity
 

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -792,7 +792,9 @@ flowchart LR
 | File | What it does |
 |------|--------------|
 | `agents/pm/` (shipped) and `.belayer/agents/pm/` (project-local) | PM identity: `agent.yaml`, `system-prompt.md`, `agents.md` |
-| `hermes_bridge/tools.py` | Tool schemas and handlers for `request_completion`, `approve_completion`, `reject_completion` |
+| `plugins/belayer/tools.py` | Tool schemas and handlers for every `belayer_*` tool (`request_completion`, `approve_completion`, `reject_completion`, plus `send_message` / `broadcast` / `check_mail` / `report_status` / `create_artifact` / `spawn_agent` / `escalate_to_human`) — owned by the Hermes 0.11 plugin, registered at plugin discovery time |
+| `plugins/belayer/__init__.py` | Plugin `register(ctx)` entry point. Applies kind gate (main/side) and BELAYER_TOOLS allowlist to pick which tools to register per bridge subprocess. Exposes `pop_turn_mail_ids()` for the bridge's end-of-turn ack drain. |
+| `internal/cli/hermes_plugin.go` | Extracts `plugins/` from the binary into `$HERMES_HOME/plugins/` on daemon startup; idempotently enables `belayer` in `$HERMES_HOME/config.yaml` `plugins.enabled` |
 | `hermes_bridge/__main__.py` | Reads `BELAYER_SYSTEM_PROMPT` and injects as `ephemeral_system_prompt` |
 | `internal/daemon/bridge_events.go` | Event handlers: `handleBridgeCompletionRequested`, `handleBridgeCompletionApproved`, `handleBridgeCompletionRejected` |
 | `internal/daemon/agents.go` | `spawnAgentInternal` for auto-spawning PM; `handleFinishAgent` intercepts supervisor finish to trigger PM gate; agent system-prompt resolution from `.belayer/agents/<name>/system-prompt.md` then `<BelayerRoot>/agents/<name>/system-prompt.md` |
@@ -848,11 +850,15 @@ Side agents (`kind: side`) do not receive mail tools. They receive their task in
 
 The daemon reads `belayer_tools` from the spawning agent's
 `agent.yaml`, passes the allowlist to the bridge subprocess via
-`BELAYER_TOOLS`, and the bridge's `register_belayer_tools(...,
-allowed_tools=...)` adds only baseline + allowed entries to the agent's
-tool inventory. An identity that forgets to declare a needed role-specific
-tool in `belayer_tools` will spawn without it — the failure mode is
-"tool missing from inventory," caught at the first attempted call.
+`BELAYER_TOOLS`, and the Hermes plugin's `register(ctx)` (at
+`plugins/belayer/__init__.py`) registers only the baseline + permitted
+tools during plugin discovery — which fires when the bridge's `from
+run_agent import AIAgent` triggers `discover_plugins()`. By the time
+`AIAgent.__init__` reads the tool registry via `get_tool_definitions`,
+only the allowed tools are visible. An identity that forgets to declare
+a needed role-specific tool in `belayer_tools` will spawn without it —
+the failure mode is "tool missing from inventory," caught at the first
+attempted call.
 
 ---
 


### PR DESCRIPTION
## Summary

Stacks on #108. Updates CLAUDE.md and docs/AGENT_ARCHITECTURE.md to point at `plugins/belayer/` as the new home for `belayer_*` tool schemas and the registration path, replacing stale references to the deleted `hermes_bridge/tools.py` and `register_belayer_tools()`.

Also decision-logged: **`ephemeral_system_prompt` stays in the bridge as an AIAgent kwarg.** The initial phase-3 plan was to migrate it to the Hermes `pre_llm_call` hook, but inspection of `run_agent.py:8917-8949` showed the hook injects `'context'` into the *user* message every turn (uncached, context-bloating), whereas `ephemeral_system_prompt` appends to the system prompt once (cached prefix, free re-reads). They are not interchangeable; `pre_llm_call` is the wrong layer for agent identity.

## Test plan
- [x] No code changes — docs only
- [x] grep shows no stale references to `hermes_bridge/tools.py` or `register_belayer_tools` outside historical context

Final PR in the Hermes 0.11 plugin migration series (#107, #108, this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)