### PR TITLE
Docs: define organization growth contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,10 @@ The dashboard is a thin reverse-proxy + static-file server. It holds no state �
 
 ## Docs
 
+- `docs/README.md` — current docs map and historical-design warning
 - `docs/AGENT_ARCHITECTURE.md` — agent toolbox, main/side model, mail, PM gate
+- `docs/ORG_MODE.md` — talent catalogs, gate contracts, org events, proof runs
+- `docs/ARTIFACT_SCHEMAS.md` — artifact content schemas for org-mode proofs
 - `docs/DEPLOYMENT.md` — topologies, trust model, credentials, sockets
 - `docs/PHILOSOPHY.md` — the six runtime interfaces
 - `docs/LOG_FORMAT.md` — event schema, SSE, archive format

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -15,6 +15,11 @@ them into the consuming repo at `.belayer/agents/`. That project-local tree is
 owned by the consuming project. Edit it there instead of changing belayer
 source just to customize your team's roles, prompts, or tool access.
 
+For the emerging organization-mode layer, see `docs/ORG_MODE.md`. Organization
+mode builds on the same daemon, mail, events, artifacts, and Hermes plugin tool
+surface described here; it does not introduce a third agent kind or a separate
+communication path.
+
 ---
 
 ## Two kinds of agent: main and side

--- a/docs/ARTIFACT_SCHEMAS.md
+++ b/docs/ARTIFACT_SCHEMAS.md
@@ -1,0 +1,89 @@
+# Artifact Schemas
+
+Belayer artifacts are durable files registered with the daemon by `kind`, `path`,
+`producer`, and `summary`. The daemon does not parse the file content today.
+These schemas define the expected content shape for organization-mode artifacts
+so agents, prompts, tests, and future UI consumers can agree on names before the
+runtime grows typed storage.
+
+Schema files live under `docs/artifact-schemas/`.
+
+## Current Runtime Envelope
+
+The runtime stores this metadata for every artifact:
+
+```json
+{
+  "kind": "org-plan",
+  "path": "artifacts/org-plan.json",
+  "producer": "supervisor",
+  "summary": "Task plan and gate assignments"
+}
+```
+
+The artifact file at `path` should then follow the schema for its `kind`.
+
+## Organization Artifact Kinds
+
+| Kind | Schema | Producer | Purpose |
+|------|--------|----------|---------|
+| `org-plan` | [`org-plan.schema.json`](artifact-schemas/org-plan.schema.json) | lead talent | Task graph, assignments, dependencies, and gate plan |
+| `gate-result` | [`gate-result.schema.json`](artifact-schemas/gate-result.schema.json) | gate talent | Generic verdict from QA, reviewer, PM, continuity editor, or any custom gate |
+| `org-retro` | [`org-retro.schema.json`](artifact-schemas/org-retro.schema.json) | lead talent | Lessons, bottlenecks, and catalog/prompt follow-ups after a run |
+| `talent-evaluation` | [`talent-evaluation.schema.json`](artifact-schemas/talent-evaluation.schema.json) | lead or gate talent | Per-run performance evidence and growth recommendations for one talent |
+| `world-state` | [`world-state.schema.json`](artifact-schemas/world-state.schema.json) | storyteller or lorekeeper | Durable state snapshot for story-world runs |
+| `continuity-report` | [`continuity-report.schema.json`](artifact-schemas/continuity-report.schema.json) | continuity gate | Story consistency verdict and required fixes |
+
+Existing software artifacts such as `spec`, `design-doc`, `qa-report`,
+`review-report`, and `verification-report` remain valid. They can be wrapped or
+summarized by `gate-result` when a run needs a uniform gate contract.
+
+## Conventions
+
+- Use hyphenated kind names.
+- Use JSON for machine-readable org artifacts unless a human-readable markdown
+  report is explicitly more useful.
+- Keep `schema_version` at the top of every JSON artifact.
+- Put evidence paths in arrays, not prose, so later consumers can link them.
+- Use `verdict: "pass" | "pass-with-notes" | "fail" | "blocked"` for gates.
+- Preserve role neutrality: do not require `qa`, `reviewer`, or `pm` fields in
+  generic schemas.
+- Treat growth fields as recommendations unless a reviewed promotion applies
+  them to `~/.belayer/orgs/` or `~/.belayer/talent-catalog/`.
+
+## Gate Result Example
+
+```json
+{
+  "schema_version": "belayer-gate-result/v1",
+  "gate_id": "runtime-qa",
+  "stage": "task",
+  "authority": "blocking",
+  "producer": "qa",
+  "subject": {
+    "task_id": "task-2",
+    "artifact_paths": ["artifacts/runtime-notes.md"]
+  },
+  "verdict": "pass-with-notes",
+  "findings": [
+    {
+      "severity": "medium",
+      "summary": "Manual mobile viewport check still pending",
+      "evidence": ["artifacts/screenshots/desktop.png"]
+    }
+  ],
+  "required_fixes": [],
+  "checked_at": "2026-04-30T00:00:00Z"
+}
+```
+
+## Promotion Rule
+
+Do not add database tables for these artifacts until proof runs show a repeated
+query the file registry cannot answer well. Promote fields only when operators
+or dashboards need indexed access across sessions.
+
+Do not let normal runs silently mutate global org knowledge. Runs produce
+`talent-evaluation` and `org-retro` artifacts. A later reviewed promotion step
+may apply selected lessons to `~/.belayer/orgs/<org-name>/` or
+`~/.belayer/talent-catalog/<category>/`.

--- a/docs/LOG_FORMAT.md
+++ b/docs/LOG_FORMAT.md
@@ -115,7 +115,9 @@ Fragment files are newline-terminated JSONL records. When a fragment is sealed (
 |------------------------|----------|
 | `kind` (string), `path` (string) | `producer` (string) |
 
-`kind` values in v1: `"spec"`, `"design-doc"`, `"verification-report"`. The canonical spelling uses hyphens. Historical data may contain `"design_doc"` (underscore); consumers SHOULD normalize by replacing `_` with `-` in `kind` before comparison. Extension values are permitted; consumers MUST tolerate unknown kinds.
+Common `kind` values in v1: `"spec"`, `"design-doc"`, `"qa-report"`, `"review-report"`, `"verification-report"`, `"org-plan"`, `"gate-result"`, `"org-retro"`, `"talent-evaluation"`, `"world-state"`, and `"continuity-report"`. The canonical spelling uses hyphens. Historical data may contain `"design_doc"` (underscore); consumers SHOULD normalize by replacing `_` with `-` in `kind` before comparison. Extension values are permitted; consumers MUST tolerate unknown kinds.
+
+Organization-mode artifact content schemas live in `docs/ARTIFACT_SCHEMAS.md`.
 
 ### 3.6 `tool_*` — Tool registration and execution
 
@@ -138,7 +140,24 @@ Fragment files are newline-terminated JSONL records. When a fragment is sealed (
 |------|------------------------|
 | `pm_spawn_failed` | `error` (string) |
 
-### 3.9 `warning:*` — Advisory conditions
+### 3.9 `org:*` — Organization-mode extension events
+
+Organization-mode events are extension events emitted through the same
+`POST /sessions/{id}/events` path as bridge and daemon events. They are direct
+event types, not `custom_event` payload subtypes. Consumers SHOULD filter them
+with `type_prefix=org:`.
+
+| Type | Key `data` fields | Notes |
+|------|-------------------|-------|
+| `org:task_planned` | `agent`, `org_plan_artifact` | Lead talent registered or updated an `org-plan` |
+| `org:task_started` | `agent`, `task_id`, `owner` | A planned task moved into execution |
+| `org:task_reviewed` | `agent`, `task_id`, `gate_result_artifact`, `verdict` | A gate produced a durable result |
+| `org:talent_evaluated` | `agent`, `talent`, `talent_evaluation_artifact`, `summary` | Optional post-task assessment for catalog learning |
+| `org:retro_recorded` | `agent`, `org_retro_artifact` | Lead talent registered an `org-retro` |
+
+Unknown `org:*` events are allowed. Consumers MUST tolerate new suffixes.
+
+### 3.10 `warning:*` — Advisory conditions
 
 | Type | Required `data` fields |
 |------|------------------------|
@@ -146,7 +165,7 @@ Fragment files are newline-terminated JSONL records. When a fragment is sealed (
 
 At most one `warning:supervisor_exited_early` event is emitted per session, for the first active specialist found.
 
-### 3.10 `node_*` — Agent-run internal lifecycle
+### 3.11 `node_*` — Agent-run internal lifecycle
 
 | Type | Typical `data` fields | Notes |
 |------|----------------------|-------|
@@ -155,19 +174,19 @@ At most one `warning:supervisor_exited_early` event is emitted per session, for 
 
 Exact payload shape is agent-defined. Consumers SHOULD treat `data` as opaque beyond `node`.
 
-### 3.11 `gate_scored`
+### 3.12 `gate_scored`
 
 Emitted by agents via `POST /sessions/{id}/events`. Payload is agent-defined. Consumers SHOULD treat `data` as opaque.
 
-### 3.12 `agent_status:*`
+### 3.13 `agent_status:*`
 
 Agent-posted events. `agent_status:incomplete` is the only type with daemon-side effects (see Section 3.2). Other subtypes are logged verbatim with no side effects.
 
-### 3.13 `custom_event`
+### 3.14 `custom_event`
 
 Extension point. Agents may post arbitrary events via `POST /sessions/{id}/events` with `type: "custom_event"`. No daemon-side effects. `data` is agent-defined.
 
-### 3.14 `trace:*` — Trace-tier filesystem and subprocess events
+### 3.15 `trace:*` — Trace-tier filesystem and subprocess events
 
 **Trace tier only.** These events are emitted at `log_level: "trace"` and are always absent at standard and verbose tiers. Consumers MUST NOT expect them unless `manifest.session.log_level == "trace"` or the `tier` capability is `"trace"`.
 
@@ -197,7 +216,7 @@ Emitted when a tool spawns a subprocess. Captures command, environment (redacted
 | `stdout_head` | string | First ≤4 KB of stdout |
 | `stderr_head` | string | First ≤4 KB of stderr |
 
-### 3.15 Type prefix recipes
+### 3.16 Type prefix recipes
 
 Common `type_prefix=` filter values for the SSE subscribe and `/search` endpoints:
 

--- a/docs/ORG_MODE.md
+++ b/docs/ORG_MODE.md
@@ -1,0 +1,330 @@
+# Organization Mode
+
+Organization mode is a thin layer over Belayer's existing run-local control
+plane. It makes team composition, task decomposition, gates, and retrospectives
+explicit without changing the core agent runtime.
+
+The current implementation target is a walking skeleton:
+
+- local talent catalogs, grouped by category
+- durable artifact content schemas
+- cross-project org knowledge under `~/.belayer/orgs/<org-name>/`
+- direct `org:*` event types in the existing event log
+- prompt guidance that works for both software delivery and story worlds
+
+It is not a new sandbox boundary, not a remote talent marketplace, and not a
+replacement for the Hermes plugin tool architecture.
+
+## Why This Fits Belayer
+
+Belayer already has the substrate an organization layer needs:
+
+- agent identity directories under `agents/<name>/` and `.belayer/agents/<name>/`
+- `kind: main | side` for mailbox-bearing peers versus scoped workers
+- a Go daemon that owns roster, mail, events, artifacts, and completion state
+- Hermes plugin tools that expose daemon-backed coordination functions to agents
+- durable artifacts that PM, QA, reviewer, or custom gates can inspect
+
+Organization mode names the higher-level contracts that currently live mostly
+in prompts.
+
+## Talent
+
+A talent is an installable agent identity plus optional metadata describing when
+and how to use it. In v1, the portable identity contract remains the existing
+directory shape:
+
+```text
+.belayer/agents/<name>/
+├── agent.yaml
+├── system-prompt.md
+└── agents.md
+```
+
+Talent metadata should live beside the identity as `talent.yaml` rather than as
+nested fields in `agent.yaml`. The current daemon only needs the existing
+identity fields at spawn time; `talent.yaml` is for catalog browsing,
+documentation, and future selection logic.
+
+```yaml
+schema_version: "belayer-talent/v1"
+name: backend-dev
+category: development
+kind: main
+summary: Backend/API implementer
+capabilities:
+  - api-design
+  - database-migrations
+  - service-tests
+compatible_adapters:
+  - hermes-plugin
+default_gates:
+  - code-review
+  - runtime-qa
+```
+
+## Persistence Scopes
+
+Organization mode has three filesystem scopes. Keeping them separate prevents
+repo-specific context from leaking into global org knowledge and prevents global
+lessons from silently changing a project run.
+
+```text
+repo/.belayer/
+  Project-local team, config, overrides, run artifacts, and explicit org link.
+
+~/.belayer/talent-catalog/<category>/
+  Reusable local talent supply, grouped by category.
+
+~/.belayer/orgs/<org-name>/
+  Cross-project org knowledge: teams, SOPs, gates, evaluations, and reviewed
+  promotion history.
+```
+
+`repo/.belayer/` answers "what does this repo need?" It is the override layer
+for a specific project. A project may link to one global org, but it should not
+receive global changes unless that link is explicit in `.belayer/config.yaml`.
+
+`~/.belayer/talent-catalog/` answers "what talents are available to install?"
+It is local-first supply, not a hosted marketplace. Repo installs copy selected
+talents into `.belayer/agents/` so each project has an auditable runtime team.
+
+`~/.belayer/orgs/<org-name>/` answers "how does this organization operate
+across projects?" It may hold reusable teams, SOPs, gate presets, and talent
+performance history:
+
+```text
+~/.belayer/orgs/software-company/
+├── org.yaml
+├── teams/
+├── sops/
+├── gates/
+├── evaluations/
+└── promotions/
+```
+
+Story-world orgs can use the same structure with domain-specific directories
+for campaign state:
+
+```text
+~/.belayer/orgs/story-world/
+├── org.yaml
+├── teams/
+├── sops/
+├── gates/
+├── evaluations/
+├── promotions/
+└── world-state/
+```
+
+The first implementation should document this contract before adding CLI
+commands. Issue #113 owns the exact filesystem semantics and precedence rules.
+
+## Catalog Categories
+
+Catalogs are local-first. The shipped examples live in the repo, while installed
+user catalogs should live under `~/.belayer/talent-catalog/`. Categories keep
+unrelated prompts from polluting each other:
+
+```text
+examples/talent-catalog/
+├── development/
+│   ├── supervisor/
+│   ├── backend-dev/
+│   ├── web-dev/
+│   ├── qa/
+│   ├── reviewer/
+│   └── pm/
+└── story/
+    ├── storyteller/
+    ├── protagonist/
+    ├── antagonist/
+    ├── lorekeeper/
+    └── continuity-editor/
+```
+
+```text
+~/.belayer/talent-catalog/
+├── development/
+└── story/
+```
+
+The planned installer should copy one category, or one talent within a category,
+into `.belayer/agents/`. It should skip existing identities by default, support
+`--force`, and print written/skipped counts. Remote catalogs and cross-project
+markets are intentionally out of scope until local catalogs prove useful.
+
+## Execution Adapter Boundary
+
+The execution adapter is the process loop that runs an identity and presents
+Belayer tools to it. Today the default adapter is Hermes plus the Belayer Hermes
+plugin.
+
+The adapter does not own agent-to-agent communication. The tools it registers
+call into the Belayer daemon:
+
+```text
+agent turn
+  -> belayer_send_message / belayer_create_artifact / belayer_report_status
+  -> Hermes plugin handler
+  -> Belayer daemon over the session socket
+  -> SQLite session bus, event log, artifact registry, roster, and gate state
+```
+
+This keeps all coordination observable and replayable in one daemon even if
+future adapters run Codex, Claude Code, clamshell, scripts, or another loop.
+
+## Gate Contract
+
+QA, reviewer, and PM are software-company presets. The generic abstraction is a
+gate: a scoped authority that inspects artifacts and produces a durable verdict.
+
+```yaml
+schema_version: "belayer-gate/v1"
+gate:
+  id: runtime-qa
+  stage: task
+  authority: blocking
+  input_artifacts:
+    - org-plan
+    - implementation-notes
+  output_artifact: gate-result
+  verdicts:
+    - pass
+    - pass-with-notes
+    - fail
+    - blocked
+  assigned_talent:
+    - qa
+```
+
+Software-company gates can map to familiar artifacts:
+
+- `qa-report` -> `gate-result` for runtime/user-path verification
+- `review-report` -> `gate-result` for code or plan review
+- `verification-report` -> `gate-result` for final acceptance
+
+Story-world gates use the same contract with different content:
+
+- `continuity-report` checks canon, tone, character consistency, and open hooks
+- `world-state` records durable state after a scene or session
+
+Do not hard-code QA/reviewer/PM into the framework. Treat them as default
+talents and default gate presets in the `development` catalog.
+
+## E2R Loop
+
+Organization mode uses the paper's Explore, Execute, Review loop in Belayer
+terms:
+
+1. Explore: a lead talent emits `org:task_planned` and registers an `org-plan`
+   artifact.
+2. Execute: assigned talents work through normal Belayer tools, mail, status,
+   and artifacts.
+3. Review: gate talents register `gate-result` artifacts and emit
+   `org:task_reviewed`.
+4. Retro: the lead registers `org-retro` to capture what to improve next run.
+
+## Talent Growth Loop
+
+Talent growth is evidence-driven, not prompt self-editing. A run can evaluate a
+talent, propose a better SOP, or recommend a catalog update, but it must not
+silently mutate global org state.
+
+```text
+session evidence
+  -> repo-local artifacts
+  -> org-retro and talent-evaluation
+  -> reviewed promotion proposal
+  -> ~/.belayer/orgs/<org-name>/ knowledge
+```
+
+The `talent-evaluation` artifact captures per-run performance for one talent:
+assigned tasks, produced artifacts, gate outcomes, common findings, cost, and
+recommended changes. The `org-retro` artifact captures run-level lessons and
+promotion proposals.
+
+Promotion is a later explicit operation. A reviewed promotion may update:
+
+- `~/.belayer/orgs/<org>/sops/` with reusable operating procedures
+- `~/.belayer/orgs/<org>/gates/` with reviewed gate presets
+- `~/.belayer/orgs/<org>/evaluations/` with summarized performance history
+- `~/.belayer/talent-catalog/<category>/<talent>/talent.yaml` with maturity or
+  capability changes
+
+Talent maturity should be recorded as metadata, not inferred from a single run:
+
+```yaml
+maturity: experimental | active | trusted | deprecated
+evaluation:
+  runs: 12
+  pass_rate: 0.83
+  common_failures:
+    - misses mobile QA evidence
+```
+
+Agents may recommend changes. Operators or explicit promotion commands apply
+them. This keeps cross-project learning auditable and reversible.
+
+## Event Types
+
+Use direct event types in the existing event log:
+
+- `org:task_planned`
+- `org:task_started`
+- `org:task_reviewed`
+- `org:talent_evaluated`
+- `org:retro_recorded`
+
+These are extension events, not a new table. Consumers should query them through
+existing event APIs with `type_prefix=org:`.
+
+## Artifact Kinds
+
+Organization mode defines content schemas for these artifact kinds:
+
+- `org-plan`
+- `gate-result`
+- `org-retro`
+- `talent-evaluation`
+- `world-state`
+- `continuity-report`
+
+The daemon stores artifact metadata only: `kind`, `path`, `producer`, and
+`summary`. The schemas in [Artifact Schemas](ARTIFACT_SCHEMAS.md) describe the
+file content agents should write before registering the artifact path.
+
+## Proof Use Cases
+
+### Software Company
+
+The development catalog models a small software organization:
+
+- lead: supervisor
+- implementers: backend-dev, web-dev
+- gates: reviewer, qa, pm
+
+Success means a run produces an `org-plan`, implementation artifacts, gate
+results for review/QA/final acceptance, and an `org-retro` without requiring new
+database tables.
+
+### Story World
+
+The story catalog models an interactive world:
+
+- lead: storyteller
+- talents: characters, factions, narrators, lorekeeper
+- gates: continuity-editor, tone/editorial check, world-state updater
+
+Success means a run produces durable `world-state` and `continuity-report`
+artifacts while using the same E2R loop and gate contract as the software case.
+No software-specific gate name should be required.
+
+## Out Of Scope For The First Proof
+
+- remote talent markets
+- runtime-enforced gate graphs
+- new daemon database tables for organization state
+- dashboard UI for task trees
+- Docker/VM/container isolation as an organization primitive
+- automatic prompt mutation or self-modifying catalogs

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Belayer Docs
+
+This directory separates current operator/reference docs from historical design
+notes. When docs disagree, prefer the current references below and treat
+`docs/design-docs/` as decision history unless its index marks a design as
+current.
+
+## Current References
+
+- [Agent Architecture](AGENT_ARCHITECTURE.md) - agent kinds, tools, mail, spawn, and PM completion gate
+- [Organization Mode](ORG_MODE.md) - talent catalogs, gate contracts, org events, and proof-run framing
+- [Artifact Schemas](ARTIFACT_SCHEMAS.md) - content contracts for durable artifacts
+- [Log Format](LOG_FORMAT.md) - external event, archive, search, and SSE contract
+- [Observability](OBSERVABILITY.md) - operator recipes for logs, events, traces, and archives
+- [Deployment](DEPLOYMENT.md) - runtime topologies, trust model, sockets, credentials, and Landlock
+- [Philosophy](PHILOSOPHY.md) - portable runtime interfaces and identity/runtime separation
+
+## Historical Design Notes
+
+`docs/design-docs/` records how Belayer got here. These files are valuable for
+context, but many contain old command shapes, older sandbox assumptions, or
+forward-looking proposals that have not shipped. Check
+[docs/design-docs/index.md](design-docs/index.md) before copying examples from
+an older design note into prompts, docs, or tests.

--- a/docs/artifact-schemas/continuity-report.schema.json
+++ b/docs/artifact-schemas/continuity-report.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/donovan-yohan/belayer/docs/artifact-schemas/continuity-report.schema.json",
+  "title": "Belayer Story Continuity Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "gate_id", "producer", "world_state_artifact", "verdict", "checks", "required_fixes"],
+  "properties": {
+    "schema_version": {
+      "const": "belayer-continuity-report/v1"
+    },
+    "gate_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "producer": {
+      "type": "string",
+      "minLength": 1
+    },
+    "world_state_artifact": {
+      "type": "string",
+      "minLength": 1
+    },
+    "verdict": {
+      "enum": ["pass", "pass-with-notes", "fail", "blocked"]
+    },
+    "checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/check"
+      }
+    },
+    "required_fixes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "checked_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "$defs": {
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["area", "status", "summary"],
+      "properties": {
+        "area": {
+          "enum": ["canon", "timeline", "character", "location", "tone", "open-threads"]
+        },
+        "status": {
+          "enum": ["pass", "warn", "fail", "blocked"]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    }
+  }
+}

--- a/docs/artifact-schemas/gate-result.schema.json
+++ b/docs/artifact-schemas/gate-result.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/donovan-yohan/belayer/docs/artifact-schemas/gate-result.schema.json",
+  "title": "Belayer Gate Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "gate_id", "stage", "authority", "producer", "subject", "verdict", "findings", "required_fixes"],
+  "properties": {
+    "schema_version": {
+      "const": "belayer-gate-result/v1"
+    },
+    "gate_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stage": {
+      "enum": ["task", "phase", "session"]
+    },
+    "authority": {
+      "enum": ["advisory", "blocking", "human-escalation"]
+    },
+    "producer": {
+      "type": "string",
+      "minLength": 1
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact_paths"],
+      "properties": {
+        "task_id": {
+          "type": "string"
+        },
+        "artifact_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    },
+    "verdict": {
+      "enum": ["pass", "pass-with-notes", "fail", "blocked"]
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
+    },
+    "required_fixes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "checked_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "$defs": {
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["severity", "summary", "evidence"],
+      "properties": {
+        "severity": {
+          "enum": ["info", "low", "medium", "high", "critical"]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    }
+  }
+}

--- a/docs/artifact-schemas/org-plan.schema.json
+++ b/docs/artifact-schemas/org-plan.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/donovan-yohan/belayer/docs/artifact-schemas/org-plan.schema.json",
+  "title": "Belayer Organization Plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "objective", "lead", "tasks", "gates"],
+  "properties": {
+    "schema_version": {
+      "const": "belayer-org-plan/v1"
+    },
+    "objective": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lead": {
+      "type": "string",
+      "minLength": 1
+    },
+    "context_artifacts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/task"
+      }
+    },
+    "gates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/gate"
+      }
+    },
+    "risks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "$defs": {
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "owner", "status", "acceptance"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "parent": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": ["planned", "ready", "running", "blocked", "review", "done"]
+        },
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "acceptance": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "output_artifacts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    },
+    "gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "stage", "authority", "assigned_talent", "verdicts"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "stage": {
+          "enum": ["task", "phase", "session"]
+        },
+        "authority": {
+          "enum": ["advisory", "blocking", "human-escalation"]
+        },
+        "input_artifacts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "output_artifact": {
+          "type": "string",
+          "default": "gate-result"
+        },
+        "assigned_talent": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "verdicts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": ["pass", "pass-with-notes", "fail", "blocked"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/artifact-schemas/org-retro.schema.json
+++ b/docs/artifact-schemas/org-retro.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/donovan-yohan/belayer/docs/artifact-schemas/org-retro.schema.json",
+  "title": "Belayer Organization Retrospective",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "session_summary", "what_worked", "bottlenecks", "followups"],
+  "properties": {
+    "schema_version": {
+      "const": "belayer-org-retro/v1"
+    },
+    "session_summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "what_worked": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "bottlenecks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/bottleneck"
+      }
+    },
+    "followups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/followup"
+      }
+    },
+    "measured_cost": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "total_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "estimated_cost_usd": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    }
+  },
+  "$defs": {
+    "bottleneck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "impact"],
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "impact": {
+          "enum": ["low", "medium", "high"]
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    },
+    "followup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner", "action"],
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "category": {
+          "enum": ["prompt", "catalog", "gate", "tooling", "runtime", "docs"]
+        }
+      }
+    }
+  }
+}

--- a/docs/artifact-schemas/talent-evaluation.schema.json
+++ b/docs/artifact-schemas/talent-evaluation.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/donovan-yohan/belayer/docs/artifact-schemas/talent-evaluation.schema.json",
+  "title": "Belayer Talent Evaluation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "talent", "org", "session", "tasks", "gate_outcomes", "recommendations"],
+  "properties": {
+    "schema_version": {
+      "const": "belayer-talent-evaluation/v1"
+    },
+    "talent": {
+      "type": "string",
+      "minLength": 1
+    },
+    "org": {
+      "type": "string",
+      "minLength": 1
+    },
+    "session": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repo": {
+          "type": "string"
+        },
+        "mode": {
+          "enum": ["software-company", "story-world", "custom"]
+        }
+      }
+    },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/task_summary"
+      }
+    },
+    "produced_artifacts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "gate_outcomes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/gate_outcome"
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "turns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "estimated_cost_usd": {
+          "type": "number",
+          "minimum": 0
+        },
+        "duration_seconds": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "observations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/observation"
+      },
+      "default": []
+    },
+    "recommendations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/recommendation"
+      }
+    },
+    "evaluated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "$defs": {
+    "task_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "summary", "outcome"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "outcome": {
+          "enum": ["completed", "blocked", "reassigned", "failed"]
+        }
+      }
+    },
+    "gate_outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["gate_id", "verdict"],
+      "properties": {
+        "gate_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verdict": {
+          "enum": ["pass", "pass-with-notes", "fail", "blocked"]
+        },
+        "artifact": {
+          "type": "string"
+        }
+      }
+    },
+    "observation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "summary"],
+      "properties": {
+        "type": {
+          "enum": ["strength", "failure", "risk", "cost", "coordination"]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    },
+    "recommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "action", "summary"],
+      "properties": {
+        "target": {
+          "enum": ["prompt", "talent-metadata", "sop", "gate", "offboard", "promote", "no-change"]
+        },
+        "action": {
+          "enum": ["review", "update", "deprecate", "promote", "split", "keep"]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/docs/artifact-schemas/world-state.schema.json
+++ b/docs/artifact-schemas/world-state.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/donovan-yohan/belayer/docs/artifact-schemas/world-state.schema.json",
+  "title": "Belayer Story World State",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "world", "timeline", "characters", "locations", "open_threads"],
+  "properties": {
+    "schema_version": {
+      "const": "belayer-world-state/v1"
+    },
+    "world": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "premise"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "premise": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tone": {
+          "type": "string"
+        }
+      }
+    },
+    "timeline": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/timeline_event"
+      }
+    },
+    "characters": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/entity_state"
+      }
+    },
+    "locations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/entity_state"
+      }
+    },
+    "open_threads": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/thread"
+      }
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "$defs": {
+    "timeline_event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "summary"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "participants": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    },
+    "entity_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "state"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state": {
+          "type": "string",
+          "minLength": 1
+        },
+        "relationships": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    },
+    "thread": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "summary", "status"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": ["open", "resolved", "dormant"]
+        }
+      }
+    }
+  }
+}

--- a/docs/design-docs/2026-04-30-org-mode-nightshift-plan.md
+++ b/docs/design-docs/2026-04-30-org-mode-nightshift-plan.md
@@ -1,0 +1,134 @@
+# Org Mode Nightshift Plan
+
+**Date:** 2026-04-30
+**Epic:** #111
+**Base PR:** #117
+
+This plan turns the organization-mode discussion into a stacked implementation
+sequence. The work should stay evidence-driven: build the local substrate, run
+the two proofs, then decide which runtime concepts deserve first-class support.
+
+## Stack
+
+```text
+master
+  -> issue/112-org-growth-contract        # PR #117
+    -> issue/113-org-filesystem-contract  # stack A
+      -> issue/114-org-cli                # stack B
+        -> issue/115-org-proof-examples   # stack C
+```
+
+## Stack A: #113 Filesystem Contract
+
+Goal: lock the local filesystem shape before CLI behavior exists.
+
+Deliverables:
+
+- Document `~/.belayer/orgs/<org>/`.
+- Document `~/.belayer/talent-catalog/<category>/`.
+- Document repo-local `.belayer/config.yaml` org linking.
+- Define `org.yaml` minimal fields.
+- Define precedence: repo-local override, linked org default, shipped fallback.
+- Include generated NPC/talent storage at contract level.
+
+Review focus:
+
+- Are the names and directory responsibilities understandable?
+- Does the design avoid hidden cross-project mutation?
+- Is the contract simple enough for a boring CLI implementation?
+
+## Stack B: #114 CLI Implementation
+
+Goal: implement local-only org and talent commands against the contract from
+stack A.
+
+Deliverables:
+
+- `belayer talent list`
+- `belayer talent install <category>`
+- `belayer talent install <category>/<talent>`
+- `belayer org list`
+- `belayer org init <name>`
+- `belayer org link <name>`
+
+Implementation constraints:
+
+- Installs copy selected talents into `.belayer/agents/`.
+- Existing files are skipped by default.
+- `--force` overwrites installed files.
+- Path traversal and unknown category/talent inputs are rejected.
+- `org link` writes only a repo-local config pointer; it does not import global
+  learnings into the repo.
+
+Review focus:
+
+- Is the CLI predictable and local-first?
+- Are skip/force counts clear enough for operators?
+- Are config edits minimal and reversible?
+
+## Stack C: #115 Proof And Evaluation
+
+Goal: prove the model in two different domains and produce a reviewable
+evaluation packet.
+
+Software-company proof:
+
+- Test bed: `/Users/donovanyohan/Documents/Programs/personal/relay-ide`.
+- Use a real relay-ide GitHub issue as the PRD.
+- Prefer a small scoped issue, initially #320 if still appropriate.
+- Produce `org-plan`, implementation evidence, gate evidence,
+  `talent-evaluation`, and `org-retro`.
+- Open a relay-ide PR if the selected issue is small and shippable; otherwise
+  preserve a local evaluated change and explain why no PR was opened.
+
+Story-world proof:
+
+- Test bed: `/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum`.
+- Scene: tavern celebration after the party's successful adventure.
+- Use existing athenaeum agents as characters/world talents where possible.
+- Generate short-lived NPC talents for the tavern scene.
+- Persist at least one NPC into a rediscoverable local story/hiring pool.
+- Produce `org-plan`, `world-state`, `continuity-report`,
+  `talent-evaluation`, `org-retro`, generated NPC metadata, and a final
+  three-act story artifact.
+
+Evaluation packet:
+
+- Did the same E2R loop work in both domains?
+- Which artifacts felt natural versus forced?
+- Were direct `org:*` events sufficient for observability?
+- Did file artifacts provide enough queryability?
+- Did the run expose a need for typed org tables?
+- Did `talent-evaluation` capture useful growth signals?
+- Did the software proof remain compatible with the existing PM gate?
+- Did the story proof avoid software-company assumptions?
+- Did generated NPC talent work as a short-lived worker model?
+- When did a talent need to be running versus merely defined or assigned?
+- What should #116, #118, #119, and #120 preserve or change?
+
+Review focus:
+
+- The output should be easy to review without replaying the whole run.
+- The evaluation should include concrete artifact paths, session IDs if
+  available, command/test outputs, and a go/no-go recommendation for promotion
+  tooling.
+
+## Developer Experience Note
+
+The planning conversation that produced this stack is itself part of the product
+surface Belayer should eventually support. Today the workflow is close to
+"make a spec and ship it to Belayer." Organization mode should support a more
+collaborative path:
+
+```text
+brainstorm with the operator
+  -> converge on a plan the operator accepts
+  -> persist the plan as artifacts/issues
+  -> hand off to the organization to implement
+  -> return reviewable evidence and decisions
+```
+
+That means proof runs should not only test execution. They should also record
+which handoff instructions were easy for agents to consume, which questions were
+missing, and what review surfaces made the result easy for the operator to
+judge the next morning.

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -1,17 +1,29 @@
 # Design Documents
 
-- [Belayer run model for Nightshift v1](2026-04-15-belayer-run-model-for-nightshift-v1.md) — Three-layer run model: session bus, Hermes harness driver, transport adapter
-- [Nightshift v1 deployment topology](2026-04-15-nightshift-v1-deployment-topology.md) — One request per worker, two control planes, Belayer as intra-run session bus
-- [Hermes bridge sidecar](2026-04-15-hermes-bridge-sidecar.md) — Bridge subprocess design: how Hermes agents are spawned and coordinated
-- [Crag daemon](2026-04-15-crag-daemon.md) — Forward-looking: always-on worker control plane (outer layer)
-- [Git-backed agent identity](2026-04-15-git-backed-agent-identity.md) — Forward-looking: soul + capabilities materialization
-- [Product manager agent](2026-04-16-product-manager-agent.md) — PM completion gate: adversarial spec-vs-reality verification
-- [Tool catalog and identity](2026-04-16-tool-catalog-and-identity.md) — Co-locate belayer tools with agent templates, role-based tool gating
-- ~~[VM sandbox and template bootstrap](2026-04-16-vm-sandbox-and-template-bootstrap.md)~~ — Superseded by sandbox-runtime-and-crag-proof
-- [Sandbox, runtime, and crag proof](2026-04-16-sandbox-runtime-and-crag-proof.md) — SandboxDriver + RuntimeProvider interfaces, lightweight crag, arielcharts E2E proof
-- [Embed hermes_bridge + deployment docs](2026-04-17-embed-hermes-bridge-design.md) — Ship bridge embedded in binary, extract via belayer init; rewrite SANDBOXING.md with prod/dev topologies and known security gaps
-- [Belayer-in-clamshell](2026-04-17-belayer-in-clamshell-design.md) — One-container-per-run model; belayer daemon + bridges run inside a single clamshell sandbox; apikey provider consumed at boot; arielcharts + `pnpm run dev` as E2E proof
+These files are design history. The current reference docs live one directory
+up; start with `docs/README.md` before copying command examples or runtime
+claims from a design note.
 
-## Current Designs
+## Current Or Recently Implemented Designs
 
-- [Observability log tiers and API design](2026-04-19-observability-log-tiers-and-api-design.md) — Tiered logging (standard/verbose/trace), consolidated CLI+HTTP API, SSE with digests, per-agent spill files, Nightshift-friendly archives (2026-04-19)
+- [Observability log tiers and API design](2026-04-19-observability-log-tiers-and-api-design.md) — Tiered logging, consolidated CLI+HTTP API, SSE with digests, per-agent spill files, Nightshift-friendly archives.
+- [Template-team exit conditions, prompt discipline, and CI lint](2026-04-20-template-team-exit-conditions-and-prompt-discipline.md) — Implemented prompt/tool/doc-drift cleanup. This file already carries implementation deviations; check shipped prompts and current docs before copying examples.
+- [Belayer-in-clamshell](2026-04-17-belayer-in-clamshell-design.md) — Current direction for container-per-run sandboxing, but not the organization-mode execution adapter boundary.
+- [Embed hermes_bridge + deployment docs](2026-04-17-embed-hermes-bridge-design.md) — Historical design behind embedded bridge distribution and deployment docs.
+
+## Historical Or Superseded Designs
+
+- [Belayer run model for Nightshift v1](2026-04-15-belayer-run-model-for-nightshift-v1.md) — Historical framing for session bus, Hermes harness driver, and transport adapter. Prefer `docs/AGENT_ARCHITECTURE.md` and `docs/PHILOSOPHY.md` for current wording.
+- [Nightshift v1 deployment topology](2026-04-15-nightshift-v1-deployment-topology.md) — Historical deployment framing. Prefer `docs/DEPLOYMENT.md`.
+- [Hermes bridge sidecar](2026-04-15-hermes-bridge-sidecar.md) — Historical bridge subprocess design. Prefer `docs/AGENT_ARCHITECTURE.md` plus the current Hermes plugin implementation.
+- [Product manager agent](2026-04-16-product-manager-agent.md) — Historical PM-gate proposal. PM completion gates have shipped; prefer `docs/AGENT_ARCHITECTURE.md`.
+- [Tool catalog and identity](2026-04-16-tool-catalog-and-identity.md) — Historical role-based tool gating proposal. Prefer `agents/README.md` and current `agent.yaml#belayer_tools` examples.
+- [Sandbox, runtime, and crag proof](2026-04-16-sandbox-runtime-and-crag-proof.md) — Historical proof plan. Prefer `docs/DEPLOYMENT.md` for current trust/sandbox boundaries.
+- ~~[VM sandbox and template bootstrap](2026-04-16-vm-sandbox-and-template-bootstrap.md)~~ — Superseded by later sandbox/runtime work.
+- [Belayer-in-clamshell review](2026-04-17-belayer-in-clamshell-review.md) — Historical review notes for the clamshell direction.
+- [Tool catalog and identity implementation plan](2026-04-16-tool-catalog-and-identity-plan.md) — Historical execution checklist; do not treat as current prompt guidance.
+
+## Forward-Looking, Not Implemented
+
+- [Crag daemon](2026-04-15-crag-daemon.md) — Forward-looking always-on worker control plane.
+- [Git-backed agent identity](2026-04-15-git-backed-agent-identity.md) — Forward-looking identity/versioning direction.

--- a/examples/talent-catalog/README.md
+++ b/examples/talent-catalog/README.md
@@ -1,0 +1,26 @@
+# Talent Catalog Examples
+
+This directory is the planned local-first catalog surface for organization mode.
+Categories are intentionally separate so software-development identities do not
+pollute story-world prompts, and story identities do not leak into development
+runs.
+
+The first implementation should install a category into `.belayer/agents/` by
+copying identity directories. Until that installer exists, these README files
+define the category boundaries only.
+
+## Categories
+
+- `development/` - software-company talents and gate presets
+- `story/` - interactive-world talents and continuity gates
+
+Each talent directory should eventually contain the standard Belayer identity
+files plus optional `talent.yaml` metadata:
+
+```text
+<category>/<talent>/
+├── agent.yaml
+├── system-prompt.md
+├── agents.md
+└── talent.yaml
+```

--- a/examples/talent-catalog/development/README.md
+++ b/examples/talent-catalog/development/README.md
@@ -1,0 +1,14 @@
+# Development Talent Catalog
+
+Development talents model a small software organization. The default shipped
+team already has the core identities:
+
+- `supervisor` - lead talent and task planner
+- `backend-dev` - backend/API implementer
+- `web-dev` - frontend/web implementer
+- `reviewer` - code and plan review gate
+- `qa` - runtime and user-path verification gate
+- `pm` - final acceptance gate
+
+This category should stay software-specific. Story-world prompts, continuity
+rules, and character state belong under `../story/`.

--- a/examples/talent-catalog/story/README.md
+++ b/examples/talent-catalog/story/README.md
@@ -1,0 +1,16 @@
+# Story Talent Catalog
+
+Story talents model a living world for interactive storytelling. The catalog is
+separate from `../development/` so story prompts do not affect software-delivery
+runs.
+
+Expected first identities:
+
+- `storyteller` - lead talent; frames scenes and manages the E2R loop
+- `lorekeeper` - maintains durable world state
+- `continuity-editor` - gate talent for canon, timeline, character, and tone
+- `protagonist` - example character talent
+- `antagonist` - example character talent
+
+The first proof should produce `world-state` and `continuity-report` artifacts
+using the same gate contract as development runs.

--- a/internal/agentlint/agentlint_test.go
+++ b/internal/agentlint/agentlint_test.go
@@ -283,6 +283,7 @@ func TestAgentPromptsOnlyReferenceRealCommands(t *testing.T) {
 	scanDirs := []string{
 		"agents",
 		"examples/templates",
+		"examples/talent-catalog",
 		"skills",
 		"docs",
 	}

--- a/internal/agentlint/docs_test.go
+++ b/internal/agentlint/docs_test.go
@@ -34,11 +34,11 @@ func TestArtifactSchemasAreValidJSON(t *testing.T) {
 			t.Errorf("%s: invalid JSON schema: %v", path, err)
 			continue
 		}
-		if schema["$schema"] == "" {
-			t.Errorf("%s: missing $schema", path)
+		if s, _ := schema["$schema"].(string); s == "" {
+			t.Errorf("%s: missing or empty $schema", path)
 		}
-		if schema["title"] == "" {
-			t.Errorf("%s: missing title", path)
+		if s, _ := schema["title"].(string); s == "" {
+			t.Errorf("%s: missing or empty title", path)
 		}
 		if schema["type"] != "object" {
 			t.Errorf("%s: root type = %v, want object", path, schema["type"])

--- a/internal/agentlint/docs_test.go
+++ b/internal/agentlint/docs_test.go
@@ -1,0 +1,109 @@
+package agentlint_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestArtifactSchemasAreValidJSON(t *testing.T) {
+	root := repoRoot(t)
+	schemaDir := filepath.Join(root, "docs", "artifact-schemas")
+
+	entries, err := os.ReadDir(schemaDir)
+	if err != nil {
+		t.Fatalf("read schema dir: %v", err)
+	}
+
+	seen := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".schema.json") {
+			continue
+		}
+		seen++
+		path := filepath.Join(schemaDir, entry.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+
+		var schema map[string]any
+		if err := json.Unmarshal(raw, &schema); err != nil {
+			t.Errorf("%s: invalid JSON schema: %v", path, err)
+			continue
+		}
+		if schema["$schema"] == "" {
+			t.Errorf("%s: missing $schema", path)
+		}
+		if schema["title"] == "" {
+			t.Errorf("%s: missing title", path)
+		}
+		if schema["type"] != "object" {
+			t.Errorf("%s: root type = %v, want object", path, schema["type"])
+		}
+		if _, ok := schema["required"].([]any); !ok {
+			t.Errorf("%s: missing required array", path)
+		}
+		props, ok := schema["properties"].(map[string]any)
+		if !ok {
+			t.Errorf("%s: missing properties object", path)
+			continue
+		}
+		if _, ok := props["schema_version"]; !ok {
+			t.Errorf("%s: missing schema_version property", path)
+		}
+	}
+
+	if seen < 6 {
+		t.Fatalf("found %d artifact schemas, want at least 6", seen)
+	}
+}
+
+func TestArtifactSchemaDocsReferenceEverySchema(t *testing.T) {
+	root := repoRoot(t)
+	docPath := filepath.Join(root, "docs", "ARTIFACT_SCHEMAS.md")
+	doc, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", docPath, err)
+	}
+	docText := string(doc)
+
+	schemaDir := filepath.Join(root, "docs", "artifact-schemas")
+	entries, err := os.ReadDir(schemaDir)
+	if err != nil {
+		t.Fatalf("read schema dir: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".schema.json") {
+			continue
+		}
+		if !strings.Contains(docText, entry.Name()) {
+			t.Errorf("%s does not reference %s", docPath, entry.Name())
+		}
+	}
+}
+
+func TestDesignDocsIndexMarksHistoricalMaterial(t *testing.T) {
+	root := repoRoot(t)
+	indexPath := filepath.Join(root, "docs", "design-docs", "index.md")
+	raw, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", indexPath, err)
+	}
+	text := string(raw)
+
+	required := []string{
+		"Current Or Recently Implemented Designs",
+		"Historical Or Superseded Designs",
+		"Forward-Looking, Not Implemented",
+		"start with `docs/README.md`",
+	}
+	for _, needle := range required {
+		if !strings.Contains(text, needle) {
+			t.Errorf("%s missing deprecation/audit marker %q", indexPath, needle)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #112. Part of #111.

- Adds current organization-mode docs covering talent catalogs, gate contracts, direct `org:*` events, proof-run framing, and the Hermes-plugin execution adapter boundary.
- Defines cross-project org persistence under `~/.belayer/orgs/<org-name>/`, reusable local talent supply under `~/.belayer/talent-catalog/<category>/`, and repo-local overrides under `.belayer/`.
- Adds artifact schema docs plus JSON schemas for `org-plan`, `gate-result`, `org-retro`, `talent-evaluation`, `world-state`, and `continuity-report`.
- Audits the docs entrypoints so current references are separated from historical/superseded design notes.
- Extends agentlint to scan talent-catalog docs and validate artifact schema files.
- Adds `docs/design-docs/2026-04-30-org-mode-nightshift-plan.md` as the stacked execution plan for #113/#114/#115.

## Open Questions

- Exact `org.yaml` fields and precedence rules are intentionally deferred to #113.
- CLI command names and copy/link behavior are intentionally deferred to #114.
- Whether artifact schemas should remain docs-only or get runtime validation should be decided after the proof runs in #115.
- Story-world persistence needs one more decision in #113/#115: whether `world-state/` under `~/.belayer/orgs/<org>/` is campaign-global, repo-linked, or both.
- Promotion provenance details, including reviewer/operator identity and rejected proposal retention, are intentionally deferred to #116.

## Verification

- `go test ./internal/agentlint`
- `go test ./...`
- `git diff --check`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced Organization Mode specification with team/talent management, gate contracts, and evidence-driven workflows
  * Added artifact schema definitions and documentation for organization artifacts
  * Updated event logging format with organization-mode event types
  * Provided talent catalog examples and structure

* **Tests**
  * Added validation tests for artifact schemas and documentation organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->