### PR TITLE
Docs: define crag filesystem contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ The dashboard is a thin reverse-proxy + static-file server. It holds no state �
 - `docs/README.md` — current docs map and historical-design warning
 - `docs/AGENT_ARCHITECTURE.md` — agent toolbox, main/side model, mail, PM gate
 - `docs/ORG_MODE.md` — talent catalogs, gate contracts, org events, proof runs
+- `docs/ORG_FILESYSTEM.md` — repo, user catalog, and user org directory contracts
 - `docs/ARTIFACT_SCHEMAS.md` — artifact content schemas for org-mode proofs
 - `docs/DEPLOYMENT.md` — topologies, trust model, credentials, sockets
 - `docs/PHILOSOPHY.md` — the six runtime interfaces

--- a/docs/ORG_FILESYSTEM.md
+++ b/docs/ORG_FILESYSTEM.md
@@ -1,0 +1,309 @@
+# Organization Filesystem Contract
+
+This document defines the local filesystem contract for organization mode. It is
+intentionally docs-first: the CLI should implement this contract after review,
+not invent new paths while shipping.
+
+## Scopes
+
+Belayer organization mode uses three local scopes.
+
+```text
+repo/.belayer/
+  Project-local runtime config, agent overrides, run state, and explicit org link.
+
+~/.belayer/talent-catalog/<category>/
+  Reusable local talent supply grouped by category.
+
+~/.belayer/orgs/<org-name>/
+  Cross-project org knowledge: teams, SOPs, gates, evaluations, promotions,
+  and optional story-world state.
+```
+
+Global org state is opt-in. A repo only participates in a user-level org when
+its `.belayer/config.yaml` explicitly links one.
+
+## Repo-Local `.belayer/`
+
+Repo-local `.belayer/` remains the runtime override layer.
+
+```text
+repo/.belayer/
+├── config.yaml
+├── agents/
+├── runs/
+└── worktrees/
+```
+
+The `agents/` directory wins over any linked org or shipped default identity.
+This preserves the existing rule: project-local identity files are project-owned
+and should be auditable in that repo.
+
+### Org Link
+
+The first CLI implementation should write the smallest useful link:
+
+```yaml
+org:
+  name: software-company
+```
+
+`org.name` resolves to `~/.belayer/orgs/software-company`. An optional explicit
+path can support advanced setups and tests:
+
+```yaml
+org:
+  name: software-company
+  path: /absolute/path/to/org
+```
+
+If `org.path` is present, it must be absolute and must point at an org directory
+with a valid `org.yaml`.
+
+## User Talent Catalog
+
+The user catalog is local supply. It is not a running organization and it is not
+project state.
+
+```text
+~/.belayer/talent-catalog/
+├── development/
+│   └── backend-dev/
+│       ├── agent.yaml
+│       ├── system-prompt.md
+│       ├── agents.md
+│       └── talent.yaml
+└── story/
+    └── storyteller/
+        ├── agent.yaml
+        ├── system-prompt.md
+        ├── agents.md
+        └── talent.yaml
+```
+
+Category installs copy talent identity directories into
+`repo/.belayer/agents/`. Copying is deliberate: the repo gets a reviewable
+snapshot of the identities it will run.
+
+## User Org Directory
+
+An org directory is cross-project knowledge for one operating mode or team.
+
+```text
+~/.belayer/orgs/<org-name>/
+├── org.yaml
+├── teams/
+├── sops/
+├── gates/
+├── evaluations/
+├── promotions/
+└── generated-talents/
+```
+
+Story-world orgs may also include:
+
+```text
+~/.belayer/orgs/<org-name>/
+└── world-state/
+```
+
+### `org.yaml`
+
+Minimal `org.yaml`:
+
+```yaml
+schema_version: "belayer-org/v1"
+name: software-company
+kind: development
+description: "Default software-company org for implementation runs"
+default_team: core
+catalog_categories:
+  - development
+```
+
+Fields:
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `schema_version` | yes | Must be `belayer-org/v1` for this contract. |
+| `name` | yes | Directory-safe org identifier. Should match `<org-name>`. |
+| `kind` | yes | `development`, `story`, `research`, or `custom`. |
+| `description` | no | Human summary for future org-listing surfaces. |
+| `default_team` | no | Team file under `teams/` to use by default. |
+| `catalog_categories` | no | Catalog categories this org expects to draw from. |
+
+### `teams/`
+
+Teams are reusable rosters. They reference talent names; they do not embed full
+prompt content.
+
+```text
+teams/
+└── core.yaml
+```
+
+Example:
+
+```yaml
+schema_version: "belayer-team/v1"
+name: core
+lead: supervisor
+members:
+  - name: backend-dev
+    role: implementer
+  - name: reviewer
+    role: gate
+default_gates:
+  - code-review
+  - runtime-qa
+  - acceptance
+```
+
+### `sops/`
+
+SOPs are reusable instructions promoted from retros or written by humans.
+
+```text
+sops/
+├── pull-request.md
+└── story-continuity.md
+```
+
+SOPs are not injected automatically by this contract. A future workflow
+discovery layer should decide which SOPs a task needs.
+
+### `gates/`
+
+Gates are reusable review contracts.
+
+```text
+gates/
+├── acceptance.yaml
+├── code-review.yaml
+└── continuity.yaml
+```
+
+Example:
+
+```yaml
+schema_version: "belayer-gate/v1"
+id: acceptance
+stage: session
+authority: blocking
+trigger: completion_requested
+assigned_talent:
+  - pm
+requires:
+  - org-plan
+  - gate-result
+verdicts:
+  - pass
+  - fail
+  - blocked
+```
+
+### `evaluations/`
+
+Evaluations preserve summarized talent performance across projects.
+
+```text
+evaluations/
+└── backend-dev/
+    └── 2026-04-30-session-<id>.json
+```
+
+Files should use the `talent-evaluation` artifact shape where possible. They
+are records, not automatic prompt mutations.
+
+### `promotions/`
+
+Promotion records preserve explicit changes made from run evidence into org
+knowledge.
+
+```text
+promotions/
+├── accepted/
+└── rejected/
+```
+
+A promotion record should include source session, source artifacts, operator or
+reviewer, timestamp, target path, and the applied or rejected change. Rejected
+proposals stay auditable but do not alter org state.
+
+### `generated-talents/`
+
+Generated talents are short-lived workers or NPCs that were created during a
+run and then selected for possible reuse.
+
+```text
+generated-talents/
+└── tavernkeep-mara/
+    ├── talent.yaml
+    └── notes.md
+```
+
+Minimal generated talent metadata:
+
+```yaml
+schema_version: "belayer-generated-talent/v1"
+name: tavernkeep-mara
+category: story
+status: candidate
+origin:
+  session_id: "<session-id>"
+  first_artifact: "artifacts/stories/tavern-celebration.md"
+role: "tavernkeep"
+summary: "Warm, watchful innkeeper who remembers debts and rumors"
+reuse_policy: scene-local | recurring | promoted
+```
+
+Generated talents do not become full `.belayer/agents/` identities by default.
+They start as compact metadata. A later reviewed promotion can turn one into a
+catalog talent or org team member.
+
+### `world-state/`
+
+Story orgs may keep campaign or setting state here.
+
+```text
+world-state/
+├── current.json
+├── characters/
+└── locations/
+```
+
+For the first proof, story-world state may remain repo-local and be copied here
+only as an explicit evaluation artifact. The persistence decision should be made
+after #115 shows whether campaign-global or repo-linked state is more useful.
+
+## Precedence
+
+When resolving an identity or org asset, use this order:
+
+1. Repo-local override in `repo/.belayer/`.
+2. Linked org default under `~/.belayer/orgs/<org-name>/`.
+3. User talent catalog under `~/.belayer/talent-catalog/<category>/`.
+4. Shipped Belayer defaults embedded in the binary.
+
+This mirrors existing agent resolution: local project intent wins over shipped
+defaults.
+
+## Privacy And Safety
+
+Cross-project knowledge is opt-in per repo. A normal run must not silently
+mutate:
+
+- `~/.belayer/orgs/<org-name>/`
+- `~/.belayer/talent-catalog/<category>/`
+- another repo's `.belayer/`
+
+Runs produce artifacts and promotion proposals. Explicit CLI commands or human
+review apply those proposals to global org knowledge.
+
+## Out Of Scope
+
+- Hosted talent marketplace.
+- Runtime gate enforcement.
+- Daemon database tables for org state.
+- Automatic prompt mutation.
+- Loading every talent as a running process.

--- a/docs/ORG_FILESYSTEM.md
+++ b/docs/ORG_FILESYSTEM.md
@@ -57,8 +57,8 @@ crag:
   path: /absolute/path/to/crag
 ```
 
-If `crag.path` is present, it must be absolute and must point at a crag
-directory with a valid `crag.yaml`.
+If `crag.path` is present, it must be absolute or relative to the repository
+root, and must point at a crag directory with a valid `crag.yaml`.
 
 ## User Team Catalog
 
@@ -127,7 +127,7 @@ Fields:
 | Field | Required | Meaning |
 |-------|----------|---------|
 | `schema_version` | yes | Must be `belayer-crag/v1` for this contract. |
-| `name` | yes | Directory-safe crag identifier. Should match `<crag-name>`. |
+| `name` | yes | Directory-safe crag identifier. Must match `<crag-name>`. |
 | `kind` | yes | `development`, `story`, `research`, or `custom`. |
 | `description` | no | Human summary for future crag-listing surfaces. |
 | `default_team` | no | Team file under `teams/` to use by default. |
@@ -188,7 +188,7 @@ Example:
 
 ```yaml
 schema_version: "belayer-gate/v1"
-id: acceptance
+name: acceptance
 stage: session
 authority: blocking
 trigger: completion_requested
@@ -255,7 +255,7 @@ origin:
   first_artifact: "artifacts/stories/tavern-celebration.md"
 role: "tavernkeep"
 summary: "Warm, watchful innkeeper who remembers debts and rumors"
-reuse_policy: scene-local | recurring | promoted
+reuse_policy: scene-local # options: scene-local | recurring | promoted
 ```
 
 Generated talents do not become full `.belayer/agents/` identities by default.

--- a/docs/ORG_FILESYSTEM.md
+++ b/docs/ORG_FILESYSTEM.md
@@ -1,26 +1,26 @@
-# Organization Filesystem Contract
+# Crag Filesystem Contract
 
-This document defines the local filesystem contract for organization mode. It is
-intentionally docs-first: the CLI should implement this contract after review,
-not invent new paths while shipping.
+This document defines the local filesystem contract for Belayer crags. A crag
+is a persistent operating context: a software company, story world, research
+group, or any other durable team-and-memory boundary.
 
 ## Scopes
 
-Belayer organization mode uses three local scopes.
+Belayer crag mode uses three local scopes.
 
 ```text
 repo/.belayer/
-  Project-local runtime config, agent overrides, run state, and explicit org link.
+  Project-local runtime config, agent overrides, climb state, and explicit crag link.
 
 ~/.belayer/talent-catalog/<category>/
   Reusable local talent supply grouped by category.
 
-~/.belayer/orgs/<org-name>/
-  Cross-project org knowledge: teams, SOPs, gates, evaluations, promotions,
+~/.belayer/crags/<crag-name>/
+  Cross-project crag knowledge: teams, SOPs, gates, evaluations, promotions,
   and optional story-world state.
 ```
 
-Global org state is opt-in. A repo only participates in a user-level org when
+Global crag state is opt-in. A repo only participates in a user-level crag when
 its `.belayer/config.yaml` explicitly links one.
 
 ## Repo-Local `.belayer/`
@@ -31,36 +31,36 @@ Repo-local `.belayer/` remains the runtime override layer.
 repo/.belayer/
 ├── config.yaml
 ├── agents/
-├── runs/
+├── runs/        # current runtime climb state
 └── worktrees/
 ```
 
-The `agents/` directory wins over any linked org or shipped default identity.
+The `agents/` directory wins over any linked crag or shipped default identity.
 This preserves the existing rule: project-local identity files are project-owned
 and should be auditable in that repo.
 
-### Org Link
+### Crag Link
 
 The first CLI implementation should write the smallest useful link:
 
 ```yaml
-org:
+crag:
   name: software-company
 ```
 
-`org.name` resolves to `~/.belayer/orgs/software-company`. An optional explicit
+`crag.name` resolves to `~/.belayer/crags/software-company`. An optional explicit
 path can support advanced setups and tests:
 
 ```yaml
-org:
+crag:
   name: software-company
-  path: /absolute/path/to/org
+  path: /absolute/path/to/crag
 ```
 
-If `org.path` is present, it must be absolute and must point at an org directory
-with a valid `org.yaml`.
+If `crag.path` is present, it must be absolute and must point at a crag
+directory with a valid `crag.yaml`.
 
-## User Talent Catalog
+## User Team Catalog
 
 The user catalog is local supply. It is not a running organization and it is not
 project state.
@@ -81,17 +81,18 @@ project state.
         └── talent.yaml
 ```
 
-Category installs copy talent identity directories into
-`repo/.belayer/agents/`. Copying is deliberate: the repo gets a reviewable
+Category add commands should copy team identity directories into
+`repo/.belayer/agents/`. Category remove commands should remove copied
+identities from that project. Copying is deliberate: the repo gets a reviewable
 snapshot of the identities it will run.
 
-## User Org Directory
+## User Crag Directory
 
-An org directory is cross-project knowledge for one operating mode or team.
+A crag directory is cross-project knowledge for one operating mode or team.
 
 ```text
-~/.belayer/orgs/<org-name>/
-├── org.yaml
+~/.belayer/crags/<crag-name>/
+├── crag.yaml
 ├── teams/
 ├── sops/
 ├── gates/
@@ -100,22 +101,22 @@ An org directory is cross-project knowledge for one operating mode or team.
 └── generated-talents/
 ```
 
-Story-world orgs may also include:
+Story-world crags may also include:
 
 ```text
-~/.belayer/orgs/<org-name>/
+~/.belayer/crags/<crag-name>/
 └── world-state/
 ```
 
-### `org.yaml`
+### `crag.yaml`
 
-Minimal `org.yaml`:
+Minimal `crag.yaml`:
 
 ```yaml
-schema_version: "belayer-org/v1"
+schema_version: "belayer-crag/v1"
 name: software-company
 kind: development
-description: "Default software-company org for implementation runs"
+description: "Default software-company crag for implementation climbs"
 default_team: core
 catalog_categories:
   - development
@@ -125,12 +126,12 @@ Fields:
 
 | Field | Required | Meaning |
 |-------|----------|---------|
-| `schema_version` | yes | Must be `belayer-org/v1` for this contract. |
-| `name` | yes | Directory-safe org identifier. Should match `<org-name>`. |
+| `schema_version` | yes | Must be `belayer-crag/v1` for this contract. |
+| `name` | yes | Directory-safe crag identifier. Should match `<crag-name>`. |
 | `kind` | yes | `development`, `story`, `research`, or `custom`. |
-| `description` | no | Human summary for future org-listing surfaces. |
+| `description` | no | Human summary for future crag-listing surfaces. |
 | `default_team` | no | Team file under `teams/` to use by default. |
-| `catalog_categories` | no | Catalog categories this org expects to draw from. |
+| `catalog_categories` | no | Catalog categories this crag expects to draw from. |
 
 ### `teams/`
 
@@ -217,7 +218,7 @@ are records, not automatic prompt mutations.
 
 ### `promotions/`
 
-Promotion records preserve explicit changes made from run evidence into org
+Promotion records preserve explicit changes made from run evidence into crag
 knowledge.
 
 ```text
@@ -228,7 +229,7 @@ promotions/
 
 A promotion record should include source session, source artifacts, operator or
 reviewer, timestamp, target path, and the applied or rejected change. Rejected
-proposals stay auditable but do not alter org state.
+proposals stay auditable but do not alter crag state.
 
 ### `generated-talents/`
 
@@ -259,11 +260,11 @@ reuse_policy: scene-local | recurring | promoted
 
 Generated talents do not become full `.belayer/agents/` identities by default.
 They start as compact metadata. A later reviewed promotion can turn one into a
-catalog talent or org team member.
+catalog talent or crag team member.
 
 ### `world-state/`
 
-Story orgs may keep campaign or setting state here.
+Story crags may keep campaign or setting state here.
 
 ```text
 world-state/
@@ -278,10 +279,10 @@ after #115 shows whether campaign-global or repo-linked state is more useful.
 
 ## Precedence
 
-When resolving an identity or org asset, use this order:
+When resolving an identity or crag asset, use this order:
 
 1. Repo-local override in `repo/.belayer/`.
-2. Linked org default under `~/.belayer/orgs/<org-name>/`.
+2. Linked crag default under `~/.belayer/crags/<crag-name>/`.
 3. User talent catalog under `~/.belayer/talent-catalog/<category>/`.
 4. Shipped Belayer defaults embedded in the binary.
 
@@ -293,17 +294,17 @@ defaults.
 Cross-project knowledge is opt-in per repo. A normal run must not silently
 mutate:
 
-- `~/.belayer/orgs/<org-name>/`
+- `~/.belayer/crags/<crag-name>/`
 - `~/.belayer/talent-catalog/<category>/`
 - another repo's `.belayer/`
 
 Runs produce artifacts and promotion proposals. Explicit CLI commands or human
-review apply those proposals to global org knowledge.
+review apply those proposals to global crag knowledge.
 
 ## Out Of Scope
 
 - Hosted talent marketplace.
 - Runtime gate enforcement.
-- Daemon database tables for org state.
+- Daemon database tables for crag state.
 - Automatic prompt mutation.
 - Loading every talent as a running process.

--- a/docs/ORG_MODE.md
+++ b/docs/ORG_MODE.md
@@ -185,7 +185,7 @@ gate: a scoped authority that inspects artifacts and produces a durable verdict.
 ```yaml
 schema_version: "belayer-gate/v1"
 gate:
-  id: runtime-qa
+  name: runtime-qa
   stage: task
   authority: blocking
   input_artifacts:

--- a/docs/ORG_MODE.md
+++ b/docs/ORG_MODE.md
@@ -69,6 +69,9 @@ Organization mode has three filesystem scopes. Keeping them separate prevents
 repo-specific context from leaking into global org knowledge and prevents global
 lessons from silently changing a project run.
 
+`docs/ORG_FILESYSTEM.md` is the normative filesystem contract. This section
+summarizes the model.
+
 ```text
 repo/.belayer/
   Project-local team, config, overrides, run artifacts, and explicit org link.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ current.
 
 - [Agent Architecture](AGENT_ARCHITECTURE.md) - agent kinds, tools, mail, spawn, and PM completion gate
 - [Organization Mode](ORG_MODE.md) - talent catalogs, gate contracts, org events, and proof-run framing
+- [Organization Filesystem](ORG_FILESYSTEM.md) - repo, user catalog, and user org directory contracts
 - [Artifact Schemas](ARTIFACT_SCHEMAS.md) - content contracts for durable artifacts
 - [Log Format](LOG_FORMAT.md) - external event, archive, search, and SSE contract
 - [Observability](OBSERVABILITY.md) - operator recipes for logs, events, traces, and archives

--- a/internal/agentlint/docs_test.go
+++ b/internal/agentlint/docs_test.go
@@ -120,8 +120,8 @@ func TestOrgFilesystemContractCoversRequiredScopes(t *testing.T) {
 	required := []string{
 		"repo/.belayer/",
 		"~/.belayer/talent-catalog/<category>/",
-		"~/.belayer/orgs/<org-name>/",
-		"schema_version: \"belayer-org/v1\"",
+		"~/.belayer/crags/<crag-name>/",
+		"schema_version: \"belayer-crag/v1\"",
 		"teams/",
 		"sops/",
 		"gates/",

--- a/internal/agentlint/docs_test.go
+++ b/internal/agentlint/docs_test.go
@@ -107,3 +107,33 @@ func TestDesignDocsIndexMarksHistoricalMaterial(t *testing.T) {
 		}
 	}
 }
+
+func TestOrgFilesystemContractCoversRequiredScopes(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, "docs", "ORG_FILESYSTEM.md")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	text := string(raw)
+
+	required := []string{
+		"repo/.belayer/",
+		"~/.belayer/talent-catalog/<category>/",
+		"~/.belayer/orgs/<org-name>/",
+		"schema_version: \"belayer-org/v1\"",
+		"teams/",
+		"sops/",
+		"gates/",
+		"evaluations/",
+		"generated-talents/",
+		"world-state/",
+		"Repo-local override",
+		"Cross-project knowledge is opt-in per repo",
+	}
+	for _, needle := range required {
+		if !strings.Contains(text, needle) {
+			t.Errorf("%s missing filesystem contract marker %q", path, needle)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Defines the local filesystem contract for Belayer crags.
- Establishes `~/.belayer/crags/<crag-name>/` as the persistent cross-project space for teams, SOPs, gates, evaluations, promotions, generated talents, and optional story world state.
- Defines repo-local crag links with a `crag:` block in `.belayer/config.yaml` and `crag.yaml` as the minimal crag metadata file.
- Keeps local team supply separate under `~/.belayer/talent-catalog/<category>/` while preserving existing identity files under `.belayer/agents/`.
- Updates agentlint docs coverage so the crag contract cannot drift silently.

## Decisions Captured
- `crag` is the Belayer-specific persistent-space name. `space` can remain an operator-friendly alias at the CLI layer, but the folder convention is `crags`.
- Gate terminology stays unchanged. Gates are still the generic review contract across software and story worlds.
- Existing runtime climb state still uses `.belayer/runs/` for now; a future `.belayer/climbs/` migration should be handled separately because current daemon/runtime code already depends on `.belayer/runs/`.
- Cross-project knowledge remains opt-in per repo. Normal runs produce artifacts/proposals and must not silently mutate global crag state.

## Verification
- `go test ./internal/agentlint`
- `git diff --check`
