### PR TITLE
Examples: add crag-mode proof packets

### DIFF
--- a/examples/org-proofs/README.md
+++ b/examples/org-proofs/README.md
@@ -1,0 +1,12 @@
+# Organization Proof Examples
+
+These examples are the review packet for #115. They exercise the same
+artifact-first crag/climb loop in two domains:
+
+- `relay-ide-software-company/` uses a real relay-ide issue as a software
+  company task.
+- `athenaeum-tavern-story/` uses belayer-athenaeum characters in a tavern
+  celebration scene, including generated NPC team persistence.
+
+The examples are intentionally file artifacts. They let reviewers inspect the
+shape of crag mode without replaying a long agent session.

--- a/examples/org-proofs/athenaeum-tavern-story/README.md
+++ b/examples/org-proofs/athenaeum-tavern-story/README.md
@@ -1,0 +1,20 @@
+# Athenaeum Tavern Story Proof
+
+Test bed: `/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum`
+
+Scene: a tavern celebration after the party's successful adventure.
+
+This packet tests whether story teams can use the same crag/climb loop as
+software-company teams without inheriting software gates. It also tests
+generated NPC team metadata by creating and persisting a tavernkeep.
+
+## Files
+
+- `org-plan.json` - story scene plan and gates.
+- `three-act-story.md` - final creative artifact.
+- `world-state.json` - durable facts and open threads.
+- `continuity-report.json` - story gate result.
+- `generated-talents/tavernkeep-mara/talent.yaml` - persisted NPC metadata.
+- `talent-evaluation-storyteller.json` - lead team evaluation.
+- `talent-evaluation-tavernkeep-mara.json` - generated NPC evaluation.
+- `org-retro.json` - story-crag retro.

--- a/examples/org-proofs/athenaeum-tavern-story/README.md
+++ b/examples/org-proofs/athenaeum-tavern-story/README.md
@@ -1,6 +1,6 @@
 # Athenaeum Tavern Story Proof
 
-Test bed: `/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum`
+Test bed: `belayer-athenaeum`
 
 Scene: a tavern celebration after the party's successful adventure.
 

--- a/examples/org-proofs/athenaeum-tavern-story/continuity-report.json
+++ b/examples/org-proofs/athenaeum-tavern-story/continuity-report.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "belayer-continuity-report/v1",
+  "gate_id": "continuity",
+  "producer": "continuity-editor",
+  "world_state_artifact": "examples/org-proofs/athenaeum-tavern-story/world-state.json",
+  "verdict": "pass-with-notes",
+  "checks": [
+    {
+      "area": "canon",
+      "status": "pass",
+      "summary": "The story follows a successful Codex restoration without contradicting the belayer-athenaeum premise.",
+      "evidence": [
+        "/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum/README.md"
+      ]
+    },
+    {
+      "area": "character",
+      "status": "pass",
+      "summary": "Lyra, Kael, Mira, Thorne, and Zara retain distinct voices from the source character briefs.",
+      "evidence": [
+        "/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum/.design/characters.md",
+        "examples/org-proofs/athenaeum-tavern-story/three-act-story.md"
+      ]
+    },
+    {
+      "area": "open-threads",
+      "status": "warn",
+      "summary": "The silver chimney presence is intentionally unresolved and should be tracked if this location recurs.",
+      "evidence": [
+        "examples/org-proofs/athenaeum-tavern-story/world-state.json"
+      ]
+    }
+  ],
+  "required_fixes": [],
+  "checked_at": "2026-04-30T04:40:00Z"
+}

--- a/examples/org-proofs/athenaeum-tavern-story/continuity-report.json
+++ b/examples/org-proofs/athenaeum-tavern-story/continuity-report.json
@@ -10,7 +10,7 @@
       "status": "pass",
       "summary": "The story follows a successful Codex restoration without contradicting the belayer-athenaeum premise.",
       "evidence": [
-        "/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum/README.md"
+        "belayer-athenaeum/README.md"
       ]
     },
     {
@@ -18,7 +18,7 @@
       "status": "pass",
       "summary": "Lyra, Kael, Mira, Thorne, and Zara retain distinct voices from the source character briefs.",
       "evidence": [
-        "/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum/.design/characters.md",
+        "belayer-athenaeum/.design/characters.md",
         "examples/org-proofs/athenaeum-tavern-story/three-act-story.md"
       ]
     },

--- a/examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/notes.md
+++ b/examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/notes.md
@@ -1,0 +1,6 @@
+# Mara Underbough
+
+Mara is intentionally persisted as compact generated team metadata, not as a
+full `.belayer/agents/` identity. If a future story returns to the Last Lantern,
+the storyteller can rediscover her voice, relationships, and continuity
+constraints without injecting the entire tavern transcript.

--- a/examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml
+++ b/examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml
@@ -1,0 +1,25 @@
+schema_version: "belayer-generated-talent/v1"
+name: mara-underbough
+category: story
+status: candidate
+origin:
+  session_id: "example-athenaeum-tavern"
+  first_artifact: "examples/org-proofs/athenaeum-tavern-story/three-act-story.md"
+role: "tavernkeep"
+summary: "Warm, watchful keeper of the Last Lantern who remembers debts, house rules, and rumors."
+personality_hooks:
+  - "Practical hospitality with a steel edge"
+  - "Treats magical danger as a customer-service problem until it breaks house rules"
+  - "Knows more family history than she admits at first"
+voice_notes:
+  - "Plainspoken"
+  - "Dry humor"
+  - "Uses house rules as moral philosophy"
+relationships:
+  - "Respects Zara's diplomacy"
+  - "Wary of Thorne's instinct to solve mysteries with refusal"
+continuity_constraints:
+  - "Owns or manages the Last Lantern"
+  - "The tavern is built from archive stone"
+  - "The Last Lantern keeps an Athenaeum door"
+reuse_policy: "recurring"

--- a/examples/org-proofs/athenaeum-tavern-story/org-plan.json
+++ b/examples/org-proofs/athenaeum-tavern-story/org-plan.json
@@ -3,9 +3,9 @@
   "objective": "Write a short three-act tavern celebration scene after the Athenaeum party's successful adventure, using existing party characters and generated NPC team metadata.",
   "lead": "storyteller",
   "context_artifacts": [
-    "/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum/README.md",
-    "/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum/.design/characters.md",
-    "/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum/examples/quest-tale.md"
+    "belayer-athenaeum/README.md",
+    "belayer-athenaeum/.design/characters.md",
+    "belayer-athenaeum/examples/quest-tale.md"
   ],
   "tasks": [
     {

--- a/examples/org-proofs/athenaeum-tavern-story/org-plan.json
+++ b/examples/org-proofs/athenaeum-tavern-story/org-plan.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": "belayer-org-plan/v1",
+  "objective": "Write a short three-act tavern celebration scene after the Athenaeum party's successful adventure, using existing party characters and generated NPC team metadata.",
+  "lead": "storyteller",
+  "context_artifacts": [
+    "/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum/README.md",
+    "/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum/.design/characters.md",
+    "/Users/donovanyohan/Documents/Programs/personal/belayer-athenaeum/examples/quest-tale.md"
+  ],
+  "tasks": [
+    {
+      "id": "scene-setup",
+      "title": "Frame the tavern celebration and introduce returning party members",
+      "owner": "storyteller",
+      "status": "planned",
+      "dependencies": [],
+      "acceptance": [
+        "Scene starts after a successful Athenaeum adventure",
+        "At least three existing party characters appear with distinct voices"
+      ],
+      "output_artifacts": [
+        "examples/org-proofs/athenaeum-tavern-story/three-act-story.md"
+      ]
+    },
+    {
+      "id": "npc-generation",
+      "title": "Generate scene-local NPCs and persist one for rediscovery",
+      "owner": "storyteller",
+      "status": "planned",
+      "dependencies": [
+        "scene-setup"
+      ],
+      "acceptance": [
+        "At least one tavern NPC affects the scene",
+        "At least one NPC is persisted as compact generated team metadata"
+      ],
+      "output_artifacts": [
+        "examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml"
+      ]
+    },
+    {
+      "id": "continuity",
+      "title": "Check story continuity and record durable state",
+      "owner": "continuity-editor",
+      "status": "planned",
+      "dependencies": [
+        "scene-setup",
+        "npc-generation"
+      ],
+      "acceptance": [
+        "Continuity report has a clear verdict",
+        "World state records consequences, open hooks, and NPC persistence"
+      ],
+      "output_artifacts": [
+        "examples/org-proofs/athenaeum-tavern-story/continuity-report.json",
+        "examples/org-proofs/athenaeum-tavern-story/world-state.json"
+      ]
+    }
+  ],
+  "gates": [
+    {
+      "id": "continuity",
+      "stage": "session",
+      "authority": "blocking",
+      "input_artifacts": [
+        "world-state",
+        "three-act-story"
+      ],
+      "output_artifact": "continuity-report",
+      "assigned_talent": [
+        "continuity-editor"
+      ],
+      "verdicts": [
+        "pass",
+        "pass-with-notes",
+        "fail",
+        "blocked"
+      ]
+    }
+  ],
+  "risks": [
+    "NPCs can become noisy if promoted with full transcript context",
+    "Narrator may speak for characters instead of letting character team identities act"
+  ],
+  "created_at": "2026-04-30T04:20:00Z"
+}

--- a/examples/org-proofs/athenaeum-tavern-story/org-retro.json
+++ b/examples/org-proofs/athenaeum-tavern-story/org-retro.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "belayer-org-retro/v1",
+  "session_summary": "The tavern celebration proof showed that a story-world crag can use the same E2R loop while generating short-lived NPC team metadata.",
+  "what_worked": [
+    "The tavern scene gave existing party characters a natural place to speak without a puzzle-solving task.",
+    "Generated NPC team metadata worked best as compact metadata rather than a full agent identity.",
+    "Continuity and world-state gates fit the story domain without QA/PM naming."
+  ],
+  "bottlenecks": [
+    {
+      "summary": "The example packet does not prove live mail choreography between character agents.",
+      "impact": "medium",
+      "evidence": [
+        "examples/org-proofs/athenaeum-tavern-story/three-act-story.md"
+      ]
+    },
+    {
+      "summary": "Generated NPC promotion needs a clear reviewed persistence command before real runs mutate a hiring pool.",
+      "impact": "high",
+      "evidence": [
+        "examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml"
+      ]
+    }
+  ],
+  "followups": [
+    {
+      "owner": "belayer",
+      "action": "Define generated talent persistence and reviewed promotion in #120/#116.",
+      "category": "catalog"
+    },
+    {
+      "owner": "belayer",
+      "action": "Use lazy lifecycle so NPCs and townsfolk are not idle running agents.",
+      "category": "runtime"
+    }
+  ],
+  "measured_cost": {
+    "total_tokens": 0,
+    "estimated_cost_usd": 0
+  }
+}

--- a/examples/org-proofs/athenaeum-tavern-story/talent-evaluation-storyteller.json
+++ b/examples/org-proofs/athenaeum-tavern-story/talent-evaluation-storyteller.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "belayer-talent-evaluation/v1",
+  "talent": "storyteller",
+  "org": "story-world",
+  "session": {
+    "id": "example-athenaeum-tavern",
+    "repo": "donovan-yohan/belayer-athenaeum",
+    "mode": "story-world"
+  },
+  "tasks": [
+    {
+      "id": "scene-setup",
+      "summary": "Frame a tavern celebration after the Athenaeum adventure.",
+      "outcome": "completed"
+    },
+    {
+      "id": "npc-generation",
+      "summary": "Generate and persist Mara Underbough as reusable NPC talent.",
+      "outcome": "completed"
+    }
+  ],
+  "produced_artifacts": [
+    "examples/org-proofs/athenaeum-tavern-story/three-act-story.md",
+    "examples/org-proofs/athenaeum-tavern-story/world-state.json"
+  ],
+  "gate_outcomes": [
+    {
+      "gate_id": "continuity",
+      "verdict": "pass-with-notes",
+      "artifact": "examples/org-proofs/athenaeum-tavern-story/continuity-report.json"
+    }
+  ],
+  "metrics": {
+    "turns": 0,
+    "total_tokens": 0,
+    "estimated_cost_usd": 0,
+    "duration_seconds": 0
+  },
+  "observations": [
+    {
+      "type": "strength",
+      "summary": "The storyteller model can coordinate persistent characters and generated NPCs without software-role language.",
+      "evidence": [
+        "examples/org-proofs/athenaeum-tavern-story/three-act-story.md"
+      ]
+    },
+    {
+      "type": "coordination",
+      "summary": "NPCs should start as compact generated team metadata and only become full agents if reused.",
+      "evidence": [
+        "examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml"
+      ]
+    }
+  ],
+  "recommendations": [
+    {
+      "target": "sop",
+      "action": "update",
+      "summary": "Story-world runs should include an explicit entrance/exit plan for characters and NPCs."
+    },
+    {
+      "target": "talent-metadata",
+      "action": "review",
+      "summary": "Generated NPC metadata should be reviewed before promotion to recurring team identity."
+    }
+  ],
+  "evaluated_at": "2026-04-30T04:45:00Z"
+}

--- a/examples/org-proofs/athenaeum-tavern-story/talent-evaluation-tavernkeep-mara.json
+++ b/examples/org-proofs/athenaeum-tavern-story/talent-evaluation-tavernkeep-mara.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "belayer-talent-evaluation/v1",
+  "talent": "mara-underbough",
+  "org": "story-world",
+  "session": {
+    "id": "example-athenaeum-tavern",
+    "repo": "donovan-yohan/belayer-athenaeum",
+    "mode": "story-world"
+  },
+  "tasks": [
+    {
+      "id": "npc-generation",
+      "summary": "Serve as tavernkeep NPC, reveal house rules, and anchor the Last Lantern location.",
+      "outcome": "completed"
+    }
+  ],
+  "produced_artifacts": [
+    "examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml"
+  ],
+  "gate_outcomes": [
+    {
+      "gate_id": "continuity",
+      "verdict": "pass-with-notes",
+      "artifact": "examples/org-proofs/athenaeum-tavern-story/continuity-report.json"
+    }
+  ],
+  "metrics": {
+    "turns": 0,
+    "total_tokens": 0,
+    "estimated_cost_usd": 0,
+    "duration_seconds": 0
+  },
+  "observations": [
+    {
+      "type": "strength",
+      "summary": "Mara creates a reusable location anchor with clear voice and continuity constraints.",
+      "evidence": [
+        "examples/org-proofs/athenaeum-tavern-story/three-act-story.md"
+      ]
+    }
+  ],
+  "recommendations": [
+    {
+      "target": "promote",
+      "action": "review",
+      "summary": "Keep Mara as recurring generated team metadata for future Last Lantern scenes."
+    }
+  ],
+  "evaluated_at": "2026-04-30T04:50:00Z"
+}

--- a/examples/org-proofs/athenaeum-tavern-story/three-act-story.md
+++ b/examples/org-proofs/athenaeum-tavern-story/three-act-story.md
@@ -1,0 +1,143 @@
+# The Last Lantern Toast
+
+## Act I: Warmth After The Vault
+
+The Last Lantern had never hosted heroes before, but Mara Underbough polished
+the bar as if she had been expecting them for years.
+
+Rain ticked against the windows. Crystal dust still clung to the party's boots.
+The restored Codex Machina pulsed in a wrapped case beneath Zara's chair, dim
+and steady as a sleeping heart.
+
+"No riddles on the table," Thorne said, setting his gauntlets beside a bowl of
+stew. "No maps. No suspiciously glowing doors."
+
+Lyra lifted one eyebrow. "That sounds statistically unlikely."
+
+Kael already had three napkins covered in notes. "Historically, taverns are
+where at least forty percent of quests begin, end, or become worse."
+
+Mira turned her mug in both hands, watching foam settle into a little spiral.
+"This one has good structure. Main room, back stair, cellar hatch, six exits if
+you count the kitchen window."
+
+Mara leaned over the bar. "I count seven, dear. The chimney has opinions."
+
+For the first time in days, Zara laughed before planning what the laugh meant.
+"Then we drink to the seventh exit."
+
+The room answered with raised cups. A guard named Pell clapped Thorne on the
+shoulder, discovered the shoulder did not move, and pretended he had meant to
+test the armor. A fiddler struck a bright, crooked reel. Townsfolk pressed near
+enough to glimpse the party and far enough not to be recruited.
+
+The celebration held.
+
+## Act II: The Wrong Toast
+
+It broke when the old clock above the hearth struck thirteen.
+
+Every cup on the table rang once. The Codex case shivered beneath Zara's chair.
+The fiddler missed a note and did not recover it.
+
+Mara's smile thinned. "That clock has never done that sober."
+
+A boy from the stables pointed at the wall behind the party. The soot-dark
+stones were writing themselves in silver:
+
+> THE ARCHIVE REMEMBERS WHO OPENED IT.
+
+Kael stood so quickly his bench scraped the floor. "Ah. Interesting. Terrible,
+but interesting."
+
+Lyra leaned closer to the message. "Not a threat. A checksum."
+
+"You cannot know that from six words," Thorne said.
+
+"I can know it from spacing, repetition, and the fact that it did not choose a
+verb of violence."
+
+Mira was already mapping the strokes. "The letters are not appearing. They are
+being uncovered. There was text here before the soot."
+
+The guard Pell drew his sword in the wrong direction and nearly challenged the
+coat rack. The townsfolk backed away. The party's celebration became a circle
+with fear on one side and duty on the other.
+
+Mara reached beneath the bar, not for a weapon, but for a ledger bound in green
+thread. She placed it before Kael.
+
+"My grandmother kept this place before me. She said the Last Lantern was built
+from archive stone. I thought she meant expensive stone."
+
+Zara looked from the ledger to the Codex case. "So the tavern is part of the
+Athenaeum's outer memory."
+
+The message on the wall changed:
+
+> RETURN WHAT WAS BORROWED.
+
+Thorne reached for the Codex. "No."
+
+Lyra reached for the ledger. "Maybe."
+
+Mara folded her arms. "If anyone breaks my wall, they pay before saving the
+world."
+
+That was when the party understood the choice. The Codex was restored, but the
+story of restoring it had been taken from the stones that remembered the first
+keepers. The Last Lantern wanted its page back.
+
+## Act III: A Page For A Promise
+
+Kael found the page near the ledger's spine: a tavern bill from seventy-three
+years ago, written on archive vellum. Mira saw the matching tear in the wall's
+silver script. Lyra calculated the placement. Zara softened the room with one
+hand raised, palm open.
+
+"We return the record," she said, "not the Codex."
+
+Thorne did not move aside. "And if the wall asks again?"
+
+"Then we ask Mara what the house rules are."
+
+Mara considered this, then took a brass pin from her apron. "House rule one:
+nobody bleeds on the good floor. House rule two: debts are remembered. House
+rule three: stories paid forward are not debts."
+
+She pinned the old bill to the wall.
+
+The silver letters bent around it, reading the paper like a mouth remembering a
+song. The hearth flared blue. For one breath, the tavern became larger inside:
+aisles of shelves, lanterns floating over long tables, the Athenaeum's lost
+outer hall visible through woodsmoke.
+
+Then the vision folded away.
+
+The wall wrote one final line:
+
+> THE LAST LANTERN KEEPS THE DOOR.
+
+The clock struck twelve.
+
+The tavern exhaled. Pell sheathed his sword and bowed to the coat rack just in
+case. The fiddler found the reel again, slower now, but sweeter.
+
+Mara poured six drinks and one for herself.
+
+"To debts remembered," she said.
+
+"To exits correctly counted," Mira added.
+
+"To clocks with better manners," said Thorne.
+
+Kael lifted his cup. "To primary sources in unexpected architecture."
+
+Lyra's smile was almost invisible. "To constraints that resolve."
+
+Zara touched the Codex case beneath her chair. It pulsed once, answering the
+wall.
+
+Outside, the rain stopped. In the chimney, something small and silver laughed.
+
+No one followed it yet.

--- a/examples/org-proofs/athenaeum-tavern-story/world-state.json
+++ b/examples/org-proofs/athenaeum-tavern-story/world-state.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": "belayer-world-state/v1",
+  "world": {
+    "name": "Relics of the Athenaeum",
+    "premise": "The party restored the Codex Machina and now discovers that fragments of the Athenaeum's memory persist in ordinary places.",
+    "tone": "warm adventure with mystery, banter, and latent consequence"
+  },
+  "timeline": [
+    {
+      "id": "after-codex-restoration",
+      "summary": "The party celebrates at the Last Lantern after restoring the Codex Machina.",
+      "participants": [
+        "lyra",
+        "kael",
+        "mira",
+        "thorne",
+        "zara",
+        "mara-underbough"
+      ]
+    },
+    {
+      "id": "last-lantern-awakens",
+      "summary": "The tavern reveals that it was built from archive stone and keeps one of the Athenaeum's outer doors.",
+      "participants": [
+        "mara-underbough",
+        "party"
+      ]
+    }
+  ],
+  "characters": [
+    {
+      "id": "mara-underbough",
+      "name": "Mara Underbough",
+      "state": "Tavernkeep of the Last Lantern; knows the house rules and now understands her tavern keeps an Athenaeum door.",
+      "relationships": [
+        "Respects Zara's diplomacy",
+        "Treats the party as debt-bearing regulars"
+      ]
+    },
+    {
+      "id": "thorne",
+      "name": "Thorne the Sentinel",
+      "state": "Still protective of the Codex and skeptical of celebratory magic.",
+      "relationships": [
+        "Distrusts any demand to return the Codex"
+      ]
+    },
+    {
+      "id": "kael",
+      "name": "Kael the Chronicler",
+      "state": "Interested in the Last Lantern as a primary source and architectural memory site.",
+      "relationships": [
+        "Likely to revisit Mara's ledger"
+      ]
+    }
+  ],
+  "locations": [
+    {
+      "id": "last-lantern",
+      "name": "The Last Lantern",
+      "state": "A tavern built from archive stone; contains or guards an outer Athenaeum door.",
+      "relationships": [
+        "Mara Underbough is its keeper",
+        "The chimney may hold a small silver presence"
+      ]
+    }
+  ],
+  "open_threads": [
+    {
+      "id": "silver-chimney-laughter",
+      "summary": "Something small and silver laughed in the chimney after the wall accepted the returned page.",
+      "status": "open"
+    },
+    {
+      "id": "last-lantern-door",
+      "summary": "The tavern keeps an Athenaeum door, but the destination and rules are unknown.",
+      "status": "open"
+    }
+  ],
+  "updated_at": "2026-04-30T04:35:00Z"
+}

--- a/examples/org-proofs/evaluation-report.md
+++ b/examples/org-proofs/evaluation-report.md
@@ -1,0 +1,97 @@
+# Org Mode Proof Evaluation
+
+## Summary
+
+The artifact-first model works well enough to proceed with the next runtime
+designs, but the proofs expose two important follow-ups:
+
+- The PM path should become the default `acceptance` gate preset inside a
+  configurable gate framework.
+- Large team catalogs need lazy lifecycle. Most teams should be definitions or
+  assigned workers until a task actually needs a running process.
+
+## Proofs
+
+| Proof | Test bed | Output |
+|-------|----------|--------|
+| Software company | relay-ide issue #320 | Planning, review, QA, acceptance, retro, talent evaluation |
+| Story world | belayer-athenaeum tavern celebration | Three-act story, world-state, continuity report, generated NPC |
+
+## E2R Fit
+
+Both proofs used the same loop:
+
+1. Explore: create `org-plan`.
+2. Execute: assign teams and produce domain output.
+3. Review: produce gate evidence.
+4. Retro: produce `org-retro` and `talent-evaluation`.
+
+The loop is clearer than the current "make a spec and ship to Belayer" flow
+because it gives the operator review points before execution and after proof.
+
+## Artifact Fit
+
+Natural artifacts:
+
+- `org-plan`
+- `gate-result`
+- `world-state`
+- `continuity-report`
+- `org-retro`
+
+More awkward artifacts:
+
+- `talent-evaluation` is useful, but it wants aggregation over time. One climb is
+  only a sample, not a maturity signal.
+- Software runtime evidence wants links to real command output or PR checks.
+  A static packet can describe the expected evidence, but real runs should
+  attach command logs or PR URLs.
+
+## Event Fit
+
+Direct `org:*` events are enough for first-pass observability. The missing piece
+is not event shape; it is policy. Consumers will need to know which gate events
+are required for a given task. That belongs in #118 workflow discovery.
+
+## Queryability
+
+File artifacts are enough for #115 review. Typed tables become useful when we
+need cross-session queries:
+
+- Which teams repeatedly fail a specific gate?
+- Which generated NPCs are candidates for promotion?
+- Which SOP changes were accepted or rejected?
+- Which task traits usually require a security or continuity gate?
+
+That argues for #116/#118 after proof, not before it.
+
+## Generated NPC Result
+
+The tavern scene generated `mara-underbough`, a tavernkeep. Persisting her as
+compact metadata worked better than creating a full `.belayer/agents/` identity
+immediately. She is rediscoverable without dragging the whole story transcript
+into future context.
+
+## Lazy Lifecycle Result
+
+The proofs separate three states:
+
+- available: team identity exists in catalog or crag metadata
+- assigned: team identity is selected for a task or scene beat
+- active: a running agent process is needed
+
+The story proof especially benefits from this. Townsfolk and guards should not
+be idle processes. They should be generated, used, evaluated, and either
+discarded or persisted.
+
+## Recommendation
+
+Proceed with:
+
+1. #118 gate framework and workflow discovery.
+2. #119 lazy talent lifecycle.
+3. #120 generated team persistence.
+4. #116 reviewed promotion flow after those contracts are clearer.
+
+Do not add crag database tables yet. Keep the next implementation local-first
+and artifact-driven until real sessions produce repeated query pressure.

--- a/examples/org-proofs/relay-ide-software-company/README.md
+++ b/examples/org-proofs/relay-ide-software-company/README.md
@@ -1,0 +1,25 @@
+# Relay IDE Software-Company Proof
+
+Test bed: `/Users/donovanyohan/Documents/Programs/personal/relay-ide`
+
+Selected PRD: https://github.com/donovan-yohan/relay-ide/issues/320
+
+This packet models a software-company crag climb for issue #320. It does not alter
+relay-ide directly in this Belayer PR. That was deliberate: the goal for #115 is
+to verify the crag-mode artifact shape and review criteria before handing the
+task to a real implementation run.
+
+## Files
+
+- `org-plan.json` - decomposition and gate plan.
+- `gate-result-code-review.json` - code-review gate expectation.
+- `gate-result-runtime-qa.json` - runtime QA gate expectation.
+- `talent-evaluation-backend-dev.json` - per-climb team growth sample.
+- `org-retro.json` - crag-level retro and follow-up recommendations.
+
+## Handoff Decision
+
+Issue #320 is a good first real software-company run because it is small, has
+clear acceptance criteria, and touches a bounded module. A future Belayer run
+should implement it in relay-ide and attach the real PR/check URLs to these
+same artifact kinds.

--- a/examples/org-proofs/relay-ide-software-company/README.md
+++ b/examples/org-proofs/relay-ide-software-company/README.md
@@ -1,6 +1,6 @@
 # Relay IDE Software-Company Proof
 
-Test bed: `/Users/donovanyohan/Documents/Programs/personal/relay-ide`
+Test bed: `relay-ide`
 
 Selected PRD: https://github.com/donovan-yohan/relay-ide/issues/320
 

--- a/examples/org-proofs/relay-ide-software-company/gate-result-code-review.json
+++ b/examples/org-proofs/relay-ide-software-company/gate-result-code-review.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "belayer-gate-result/v1",
+  "gate_id": "code-review",
+  "stage": "task",
+  "authority": "blocking",
+  "producer": "reviewer",
+  "subject": {
+    "task_id": "task-2",
+    "artifact_paths": [
+      "artifacts/relay-ide/implementation-notes.md"
+    ]
+  },
+  "verdict": "pass-with-notes",
+  "findings": [
+    {
+      "severity": "medium",
+      "summary": "The implementation must check active #200 work before changing PortAllocator semantics.",
+      "evidence": [
+        "https://github.com/donovan-yohan/relay-ide/issues/320",
+        "https://github.com/donovan-yohan/relay-ide/issues/200"
+      ]
+    }
+  ],
+  "required_fixes": [],
+  "checked_at": "2026-04-30T04:05:00Z"
+}

--- a/examples/org-proofs/relay-ide-software-company/gate-result-runtime-qa.json
+++ b/examples/org-proofs/relay-ide-software-company/gate-result-runtime-qa.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "belayer-gate-result/v1",
+  "gate_id": "runtime-qa",
+  "stage": "task",
+  "authority": "blocking",
+  "producer": "qa",
+  "subject": {
+    "task_id": "task-3",
+    "artifact_paths": [
+      "artifacts/relay-ide/runtime-qa.md"
+    ]
+  },
+  "verdict": "blocked",
+  "findings": [
+    {
+      "severity": "high",
+      "summary": "This proof packet did not execute relay-ide tests because it is a Belayer examples PR, not the relay-ide implementation run.",
+      "evidence": [
+        "examples/org-proofs/relay-ide-software-company/README.md"
+      ]
+    }
+  ],
+  "required_fixes": [
+    "When #320 is implemented for real, run relay-ide port allocator tests and attach command output or PR checks."
+  ],
+  "checked_at": "2026-04-30T04:10:00Z"
+}

--- a/examples/org-proofs/relay-ide-software-company/org-plan.json
+++ b/examples/org-proofs/relay-ide-software-company/org-plan.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": "belayer-org-plan/v1",
+  "objective": "Fix relay-ide issue #320 so port-assignments.json no longer leaks into the repo root during local development.",
+  "lead": "supervisor",
+  "context_artifacts": [
+    "https://github.com/donovan-yohan/relay-ide/issues/320"
+  ],
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "Inspect PortAllocator path resolution",
+      "owner": "backend-dev",
+      "status": "planned",
+      "dependencies": [],
+      "acceptance": [
+        "Identify where configPath resolves to ./config.json in local dev",
+        "Find tests covering port allocator path behavior"
+      ],
+      "output_artifacts": [
+        "artifacts/relay-ide/port-allocator-analysis.md"
+      ]
+    },
+    {
+      "id": "task-2",
+      "title": "Move assignments path to user config workspace scope",
+      "owner": "backend-dev",
+      "status": "planned",
+      "dependencies": [
+        "task-1"
+      ],
+      "acceptance": [
+        "Assignments path is under user config, not repo root",
+        "Path is keyed by repo or workspace identity",
+        "Existing root file is migrated or safely ignored"
+      ],
+      "output_artifacts": [
+        "artifacts/relay-ide/implementation-notes.md"
+      ]
+    },
+    {
+      "id": "task-3",
+      "title": "Verify path isolation and no #200 regression",
+      "owner": "qa",
+      "status": "planned",
+      "dependencies": [
+        "task-2"
+      ],
+      "acceptance": [
+        "test/port-allocator.test.ts covers new path resolution",
+        "Multiple worktrees do not collide",
+        "Repo root does not receive port-assignments.json"
+      ],
+      "output_artifacts": [
+        "artifacts/relay-ide/runtime-qa.md"
+      ]
+    }
+  ],
+  "gates": [
+    {
+      "id": "code-review",
+      "stage": "task",
+      "authority": "blocking",
+      "input_artifacts": [
+        "artifacts/relay-ide/implementation-notes.md"
+      ],
+      "output_artifact": "gate-result",
+      "assigned_talent": [
+        "reviewer"
+      ],
+      "verdicts": [
+        "pass",
+        "pass-with-notes",
+        "fail",
+        "blocked"
+      ]
+    },
+    {
+      "id": "runtime-qa",
+      "stage": "task",
+      "authority": "blocking",
+      "input_artifacts": [
+        "artifacts/relay-ide/runtime-qa.md"
+      ],
+      "output_artifact": "gate-result",
+      "assigned_talent": [
+        "qa"
+      ],
+      "verdicts": [
+        "pass",
+        "pass-with-notes",
+        "fail",
+        "blocked"
+      ]
+    },
+    {
+      "id": "acceptance",
+      "stage": "session",
+      "authority": "blocking",
+      "input_artifacts": [
+        "org-plan",
+        "gate-result"
+      ],
+      "output_artifact": "gate-result",
+      "assigned_talent": [
+        "pm"
+      ],
+      "verdicts": [
+        "pass",
+        "fail",
+        "blocked"
+      ]
+    }
+  ],
+  "risks": [
+    "Issue #200 is related and may have an in-progress branch touching the same module",
+    "Workspace identity must avoid leaking absolute paths into portable config"
+  ],
+  "created_at": "2026-04-30T04:00:00Z"
+}

--- a/examples/org-proofs/relay-ide-software-company/org-retro.json
+++ b/examples/org-proofs/relay-ide-software-company/org-retro.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "belayer-org-retro/v1",
+  "session_summary": "Relay-ide issue #320 is a good software-company proof target, but this examples PR intentionally stopped before changing relay-ide.",
+  "what_worked": [
+    "A real GitHub issue maps cleanly into org-plan tasks and gate contracts.",
+    "The existing PM concept maps naturally to a session-level acceptance gate."
+  ],
+  "bottlenecks": [
+    {
+      "summary": "Runtime QA is blocked until a real relay-ide implementation run exists.",
+      "impact": "medium",
+      "evidence": [
+        "examples/org-proofs/relay-ide-software-company/gate-result-runtime-qa.json"
+      ]
+    },
+    {
+      "summary": "Related active work on issue #200 must be checked before implementation.",
+      "impact": "medium",
+      "evidence": [
+        "https://github.com/donovan-yohan/relay-ide/issues/200"
+      ]
+    }
+  ],
+  "followups": [
+    {
+      "owner": "software-company",
+      "action": "Run a real relay-ide implementation pass for issue #320 and attach PR/test evidence.",
+      "category": "runtime"
+    },
+    {
+      "owner": "belayer",
+      "action": "Represent PM as the default acceptance gate preset in the configurable gate framework.",
+      "category": "gate"
+    }
+  ],
+  "measured_cost": {
+    "total_tokens": 0,
+    "estimated_cost_usd": 0
+  }
+}

--- a/examples/org-proofs/relay-ide-software-company/talent-evaluation-backend-dev.json
+++ b/examples/org-proofs/relay-ide-software-company/talent-evaluation-backend-dev.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "belayer-talent-evaluation/v1",
+  "talent": "backend-dev",
+  "org": "software-company",
+  "session": {
+    "id": "example-relay-ide-issue-320",
+    "repo": "donovan-yohan/relay-ide",
+    "mode": "software-company"
+  },
+  "tasks": [
+    {
+      "id": "task-1",
+      "summary": "Analyze PortAllocator path leak and propose user-config path resolution.",
+      "outcome": "completed"
+    },
+    {
+      "id": "task-2",
+      "summary": "Implementation reserved for a real relay-ide run.",
+      "outcome": "blocked"
+    }
+  ],
+  "produced_artifacts": [
+    "examples/org-proofs/relay-ide-software-company/org-plan.json"
+  ],
+  "gate_outcomes": [
+    {
+      "gate_id": "code-review",
+      "verdict": "pass-with-notes",
+      "artifact": "examples/org-proofs/relay-ide-software-company/gate-result-code-review.json"
+    },
+    {
+      "gate_id": "runtime-qa",
+      "verdict": "blocked",
+      "artifact": "examples/org-proofs/relay-ide-software-company/gate-result-runtime-qa.json"
+    }
+  ],
+  "metrics": {
+    "turns": 0,
+    "total_tokens": 0,
+    "estimated_cost_usd": 0,
+    "duration_seconds": 0
+  },
+  "observations": [
+    {
+      "type": "coordination",
+      "summary": "The selected task is small enough for a real implementation run, but this proof should not silently mutate relay-ide from the Belayer examples branch.",
+      "evidence": [
+        "https://github.com/donovan-yohan/relay-ide/issues/320"
+      ]
+    }
+  ],
+  "recommendations": [
+    {
+      "target": "sop",
+      "action": "update",
+      "summary": "Software-company runs should record whether they are dry-run packets or implementation runs before QA gates evaluate runtime evidence."
+    }
+  ],
+  "evaluated_at": "2026-04-30T04:15:00Z"
+}

--- a/internal/agentlint/proof_examples_test.go
+++ b/internal/agentlint/proof_examples_test.go
@@ -57,6 +57,31 @@ func TestOrgProofExamplesAreValidArtifacts(t *testing.T) {
 	}
 }
 
+func TestOrgProofExamplesDoNotUseLocalAbsolutePaths(t *testing.T) {
+	root := repoRoot(t)
+	proofRoot := filepath.Join(root, "examples", "org-proofs")
+
+	err := filepath.WalkDir(proofRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(raw), "/Users/") {
+			t.Errorf("%s contains local absolute path", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk proof examples: %v", err)
+	}
+}
+
 func TestOrgProofExamplesKeepStoryAndSoftwareContractsSeparate(t *testing.T) {
 	root := repoRoot(t)
 	proofRoot := filepath.Join(root, "examples", "org-proofs")

--- a/internal/agentlint/proof_examples_test.go
+++ b/internal/agentlint/proof_examples_test.go
@@ -1,0 +1,165 @@
+package agentlint_test
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func TestOrgProofExamplesAreValidArtifacts(t *testing.T) {
+	root := repoRoot(t)
+	proofRoot := filepath.Join(root, "examples", "org-proofs")
+
+	expectedFiles := map[string]string{
+		"evaluation-report.md": "",
+
+		filepath.Join("relay-ide-software-company", "README.md"):                          "",
+		filepath.Join("relay-ide-software-company", "org-plan.json"):                      "belayer-org-plan/v1",
+		filepath.Join("relay-ide-software-company", "gate-result-code-review.json"):       "belayer-gate-result/v1",
+		filepath.Join("relay-ide-software-company", "gate-result-runtime-qa.json"):        "belayer-gate-result/v1",
+		filepath.Join("relay-ide-software-company", "talent-evaluation-backend-dev.json"): "belayer-talent-evaluation/v1",
+		filepath.Join("relay-ide-software-company", "org-retro.json"):                     "belayer-org-retro/v1",
+
+		filepath.Join("athenaeum-tavern-story", "README.md"):                                           "",
+		filepath.Join("athenaeum-tavern-story", "org-plan.json"):                                       "belayer-org-plan/v1",
+		filepath.Join("athenaeum-tavern-story", "three-act-story.md"):                                  "",
+		filepath.Join("athenaeum-tavern-story", "world-state.json"):                                    "belayer-world-state/v1",
+		filepath.Join("athenaeum-tavern-story", "continuity-report.json"):                              "belayer-continuity-report/v1",
+		filepath.Join("athenaeum-tavern-story", "talent-evaluation-storyteller.json"):                  "belayer-talent-evaluation/v1",
+		filepath.Join("athenaeum-tavern-story", "talent-evaluation-tavernkeep-mara.json"):              "belayer-talent-evaluation/v1",
+		filepath.Join("athenaeum-tavern-story", "org-retro.json"):                                      "belayer-org-retro/v1",
+		filepath.Join("athenaeum-tavern-story", "generated-talents", "tavernkeep-mara", "talent.yaml"): "",
+		filepath.Join("athenaeum-tavern-story", "generated-talents", "tavernkeep-mara", "notes.md"):    "",
+	}
+
+	for rel, wantSchema := range expectedFiles {
+		path := filepath.Join(proofRoot, rel)
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if wantSchema == "" {
+			continue
+		}
+
+		var artifact map[string]any
+		if err := json.Unmarshal(raw, &artifact); err != nil {
+			t.Fatalf("%s: invalid JSON: %v", path, err)
+		}
+		if got := artifact["schema_version"]; got != wantSchema {
+			t.Errorf("%s: schema_version = %v, want %s", path, got, wantSchema)
+		}
+	}
+}
+
+func TestOrgProofExamplesKeepStoryAndSoftwareContractsSeparate(t *testing.T) {
+	root := repoRoot(t)
+	proofRoot := filepath.Join(root, "examples", "org-proofs")
+
+	storyPlanPath := filepath.Join(proofRoot, "athenaeum-tavern-story", "org-plan.json")
+	storyPlan := readJSONMap(t, storyPlanPath)
+	storyGates := storyPlan["gates"].([]any)
+	if len(storyGates) != 1 {
+		t.Fatalf("%s: got %d gates, want 1 continuity gate", storyPlanPath, len(storyGates))
+	}
+	gate := storyGates[0].(map[string]any)
+	if gate["id"] != "continuity" || gate["output_artifact"] != "continuity-report" {
+		t.Fatalf("%s: story gate = %#v, want continuity-report gate", storyPlanPath, gate)
+	}
+
+	relayPlanPath := filepath.Join(proofRoot, "relay-ide-software-company", "org-plan.json")
+	relayPlan := readJSONMap(t, relayPlanPath)
+	relayGates := relayPlan["gates"].([]any)
+	for _, want := range []string{"code-review", "runtime-qa", "acceptance"} {
+		if !jsonObjectArrayContains(relayGates, "id", want) {
+			t.Errorf("%s: missing software-company gate %q", relayPlanPath, want)
+		}
+	}
+}
+
+func TestOrgProofExamplesPersistGeneratedStoryTalent(t *testing.T) {
+	root := repoRoot(t)
+	proofRoot := filepath.Join(root, "examples", "org-proofs")
+	path := filepath.Join(proofRoot, "athenaeum-tavern-story", "generated-talents", "tavernkeep-mara", "talent.yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var talent map[string]any
+	if err := yaml.Unmarshal(raw, &talent); err != nil {
+		t.Fatalf("%s: invalid YAML: %v", path, err)
+	}
+
+	if got := talent["schema_version"]; got != "belayer-generated-talent/v1" {
+		t.Errorf("%s: schema_version = %v, want belayer-generated-talent/v1", path, got)
+	}
+	if got := talent["name"]; got != "mara-underbough" {
+		t.Errorf("%s: name = %v, want mara-underbough", path, got)
+	}
+	origin, ok := talent["origin"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s: missing origin object", path)
+	}
+	if got := origin["session_id"]; got != "example-athenaeum-tavern" {
+		t.Errorf("%s: origin.session_id = %v, want example-athenaeum-tavern", path, got)
+	}
+	firstArtifact, ok := origin["first_artifact"].(string)
+	if !ok || !strings.Contains(firstArtifact, "athenaeum-tavern-story/three-act-story.md") {
+		t.Errorf("%s: origin.first_artifact = %v, want tavern story artifact", path, origin["first_artifact"])
+	}
+	if _, ok := talent["continuity_constraints"]; !ok {
+		t.Errorf("%s: missing continuity_constraints", path)
+	}
+}
+
+func TestOrgProofExamplesAllJSONHasSchemaVersion(t *testing.T) {
+	root := repoRoot(t)
+	proofRoot := filepath.Join(root, "examples", "org-proofs")
+
+	err := filepath.WalkDir(proofRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+
+		artifact := readJSONMap(t, path)
+		if artifact["schema_version"] == "" {
+			t.Errorf("%s: missing schema_version", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", proofRoot, err)
+	}
+}
+
+func readJSONMap(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var artifact map[string]any
+	if err := json.Unmarshal(raw, &artifact); err != nil {
+		t.Fatalf("%s: invalid JSON: %v", path, err)
+	}
+	return artifact
+}
+
+func jsonObjectArrayContains(items []any, key, want string) bool {
+	for _, item := range items {
+		object, ok := item.(map[string]any)
+		if ok && object[key] == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Adds the #115 proof packet under `examples/org-proofs/`.
- Provides a software-company example using relay-ide issue #320 as the task seed.
- Provides a story-world example using the belayer-athenaeum tavern celebration, including a generated NPC persisted as compact team metadata.
- Adds agentlint tests that pin the proof packet inventory, JSON schema versions, software/story gate separation, and generated NPC metadata contract.

Advances #115.

## Decisions Captured
- The examples are artifact-first proof packets, not replayable live sessions. This keeps #115 reviewable while the runtime gate/lifecycle work is still being designed.
- The packet wording now uses crag/climb/team where it is not schema-bound.
- Existing artifact/event names stay as `org-plan`, `org-retro`, `talent-evaluation`, `assigned_talent`, and `org:*` for now. Renaming schemas/events should be a deliberate migration, not a side effect of the CLI rename.
- The relay-ide packet intentionally does not mutate relay-ide in this PR. Its runtime QA gate is `blocked` until a future real software-company climb produces command output, PR links, and test evidence.
- The story proof uses a generic continuity gate rather than software PM/QA/reviewer gates, validating that crag mode should use configurable gates by domain.
- Generated NPCs start as compact `belayer-generated-talent/v1` metadata under `generated-talents/`; promotion to full catalog identities should be reviewed later.
- The evaluation report recommends implementing gate/workflow discovery (#118), lazy team lifecycle (#119), generated team persistence (#120), and then reviewed promotion (#116).

## Hiccups / Limits
- Static proof packets cannot prove daemon `org:*` event emission, cost/token measurement, or queryability across runs.
- relay-ide #320 is a strong first real software-company task, but it still needs its own implementation PR in relay-ide to complete the live half of #115.
- Story dialogue is represented as a finished artifact. The next runtime proof should exercise live narrator/character turn-taking and entrances/exits.

## Review Criteria
Please review #115 through these questions:
- Does `examples/org-proofs/relay-ide-software-company/org-plan.json` decompose relay-ide #320 into the right teams and gates?
- Is the blocked runtime QA artifact honest and useful as a handoff shape for a future live implementation climb?
- Does `examples/org-proofs/athenaeum-tavern-story/three-act-story.md` demonstrate the story-world flow without inheriting software-company gates?
- Does `world-state.json` plus `generated-talents/tavernkeep-mara/talent.yaml` capture enough durable state for a later story to rediscover Mara and the Last Lantern?
- Does `examples/org-proofs/evaluation-report.md` point to the right next implementation order for #118/#119/#120/#116?

## Verification
- `go test ./internal/agentlint`
- `go test ./...`
- `git diff --check`
