### PR TITLE
feat: resolve acceptance gate for completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Not a cluster scheduler, autoscaler, hypervisor, or hosted identity service. It 
 Three layers:
 
 1. **Session bus** — Go daemon + SQLite. Sessions, agent roster, messages, events, artifacts.
-2. **Hermes driver** — Bridge subprocess (`python -m hermes_bridge`) wraps Hermes AIAgent. Identity injected via `ephemeral_system_prompt`; belayer_* tools registered by the Hermes 0.11 plugin at `plugins/belayer/` (loaded automatically by Hermes during AIAgent import).
+2. **Hermes driver** — Bridge subprocess (`python -m hermes_bridge`) wraps Hermes AIAgent. Identity injected via `ephemeral_system_prompt`; belayer_* tools registered by the Hermes 0.12 plugin at `plugins/belayer/` (loaded automatically by Hermes during AIAgent import).
 3. **Bridge transport** — Python subprocess managed by Go. Heartbeats, exit detection, event streaming over stdout.
 
 ## Agent kinds

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ full coordination model.
 |------------|---------|-------|
 | Go         | 1.22+   | Build toolchain for the daemon binary. |
 | Python     | 3.10+   | Runs the per-agent bridge subprocess. |
-| Hermes     | 0.11+   | LLM driver. Belayer ships a Hermes plugin (`plugins/belayer/`) that is auto-installed into `$HERMES_HOME/plugins/belayer/` on first daemon start. Older Hermes versions lacked the plugin surface and are no longer supported. |
+| Hermes     | 0.12+   | LLM driver. Belayer ships a Hermes plugin (`plugins/belayer/`) that is auto-installed into `$HERMES_HOME/plugins/belayer/` on first daemon start. Older Hermes versions lacked the current session persistence and plugin surface and are no longer supported. |
 | Linux kernel | 5.19+ (optional) | Required for Landlock v2 write-confinement (see `docs/DEPLOYMENT.md`). |
 
 The daemon resolves Hermes from `$HERMES_HOME` (or `~/.hermes` by default).

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -459,7 +459,7 @@ Daemon-internal events (not from bridge):
 | `warning:supervisor_exited_early` | Bridge finished handler | Supervisor exited while specialists still running |
 | `completion_rejected` | Completion rejected handler | Tracks cycle count |
 | `completion_escalated` | Rejection limit handler | Session status → needs_human_review |
-| `pm_spawn_failed` | PM spawn error | Notifies supervisor to retry |
+| `pm_spawn_failed` | Acceptance gate spawn error; historical event name retained for compatibility | Notifies supervisor to retry |
 
 ### How telemetry enables resume
 

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -797,7 +797,7 @@ flowchart LR
 | File | What it does |
 |------|--------------|
 | `agents/pm/` (shipped) and `.belayer/agents/pm/` (project-local) | PM identity: `agent.yaml`, `system-prompt.md`, `agents.md` |
-| `plugins/belayer/tools.py` | Tool schemas and handlers for every `belayer_*` tool (`request_completion`, `approve_completion`, `reject_completion`, plus `send_message` / `broadcast` / `check_mail` / `report_status` / `create_artifact` / `spawn_agent` / `escalate_to_human`) — owned by the Hermes 0.11 plugin, registered at plugin discovery time |
+| `plugins/belayer/tools.py` | Tool schemas and handlers for every `belayer_*` tool (`request_completion`, `approve_completion`, `reject_completion`, plus `send_message` / `broadcast` / `check_mail` / `report_status` / `create_artifact` / `spawn_agent` / `escalate_to_human`) — owned by the Hermes 0.12 plugin, registered at plugin discovery time |
 | `plugins/belayer/__init__.py` | Plugin `register(ctx)` entry point. Applies kind gate (main/side) and BELAYER_TOOLS allowlist to pick which tools to register per bridge subprocess. Exposes `pop_turn_mail_ids()` for the bridge's end-of-turn ack drain. |
 | `internal/cli/hermes_plugin.go` | Extracts `plugins/` from the binary into `$HERMES_HOME/plugins/` on daemon startup; idempotently enables `belayer` in `$HERMES_HOME/config.yaml` `plugins.enabled` |
 | `hermes_bridge/__main__.py` | Reads `BELAYER_SYSTEM_PROMPT` and injects as `ephemeral_system_prompt` |

--- a/docs/LOG_FORMAT.md
+++ b/docs/LOG_FORMAT.md
@@ -136,9 +136,9 @@ Organization-mode artifact content schemas live in `docs/ARTIFACT_SCHEMAS.md`.
 
 ### 3.8 `pm_*` — PM agent errors
 
-| Type | Required `data` fields |
-|------|------------------------|
-| `pm_spawn_failed` | `error` (string), optional acceptance gate talent fields |
+| Type | Required `data` fields | Optional `data` fields |
+|------|------------------------|------------------------|
+| `pm_spawn_failed` | `error` (string) | `gate` (string), `talent` (string) |
 
 ### 3.9 `org:*` — Organization-mode extension events
 

--- a/docs/LOG_FORMAT.md
+++ b/docs/LOG_FORMAT.md
@@ -138,7 +138,7 @@ Organization-mode artifact content schemas live in `docs/ARTIFACT_SCHEMAS.md`.
 
 | Type | Required `data` fields |
 |------|------------------------|
-| `pm_spawn_failed` | `error` (string) |
+| `pm_spawn_failed` | `error` (string), optional acceptance gate talent fields |
 
 ### 3.9 `org:*` — Organization-mode extension events
 

--- a/docs/design-docs/2026-04-15-hermes-bridge-sidecar.md
+++ b/docs/design-docs/2026-04-15-hermes-bridge-sidecar.md
@@ -237,7 +237,9 @@ Option (b) is recommended. The broker's `Subscribe` / `Send` / `Interrupt` model
 - **JSON session log** (`_save_session_log`): Incremental, after each tool iteration (`run_agent.py:10249`). Always current.
 - **SQLite session DB** (`_flush_messages_to_session_db`): Written on exit paths only (completion, errors, interrupts). Lags during normal operation.
 
-The bridge wires `step_callback` to periodically flush SQLite. This calls `agent._persist_session(agent._session_messages, None)` every ~5 iterations. This is a private API dependency (`_persist_session` and `_session_messages` are underscore-prefixed). Acknowledged as fragile. If Hermes changes these internals, the flush breaks silently and we fall back to exit-path-only persistence.
+The bridge passes Hermes a shared `SessionDB` and relies on Hermes' normal
+session creation/flush paths. `step_callback` is used for Belayer events and
+transcript records, not for calling Hermes private persistence methods.
 
 ### Bridge process dies
 
@@ -254,7 +256,7 @@ history = db.get_messages_as_conversation(hermes_session_id)
 history = [m for m in history if m.get("role") != "session_meta"]
 
 agent = AIAgent(model=model, quiet_mode=True, session_id=hermes_session_id,
-                session_db=db, persist_session=True, ...)
+                session_db=db, ...)
 register_belayer_tools(agent, config)
 wire_callbacks(agent, agent_id)
 
@@ -390,7 +392,9 @@ Remove `internal/tmux/`, tmux-specific daemon code, finish markers, capture-pane
 ## Risks
 
 ### Hermes API changes
-Bridge is ~200 lines wrapping Hermes internals. When Hermes changes, we update the wrapper. The `_persist_session` / `_session_messages` dependency for periodic SQLite flush is the most fragile part.
+Bridge is ~200 lines wrapping Hermes internals. When Hermes changes, we update
+the wrapper. Belayer requires Hermes 0.12+ and relies on the public
+`session_db` constructor contract for persistence.
 
 ### Memory overhead
 Each Python process is ~50-100MB. Three agents = 150-300MB. For a Nightshift worker on a dedicated machine, this is negligible. If it becomes a problem, we can share a Python process (the original ThreadPoolExecutor model), but we'd need to solve the registry collision problem.

--- a/embed.go
+++ b/embed.go
@@ -35,7 +35,7 @@ var DefaultBridge embed.FS
 //go:embed all:web
 var WebUI embed.FS
 
-// DefaultPlugins is the Hermes 0.11+ plugin tree shipped inside the belayer
+// DefaultPlugins is the Hermes 0.12+ plugin tree shipped inside the belayer
 // binary. Extracted to $HERMES_HOME/plugins/ at daemon startup so the
 // Hermes plugin loader (which scans that directory) can discover them.
 // The extractor filters __pycache__/ and *.pyc to avoid leaking host

--- a/hermes_bridge/README.md
+++ b/hermes_bridge/README.md
@@ -13,9 +13,10 @@ venv at `~/.hermes/hermes-agent/venv/`. The daemon's spawn logic resolves
 that path and points `PYTHONPATH` at the hermes-agent source tree (see
 `internal/bridge/bridge.go`).
 
-**Hermes 0.11+** is required: the `belayer_*` tool surface is registered by
+**Hermes 0.12+** is required: the `belayer_*` tool surface is registered by
 the Belayer Hermes plugin (`plugins/belayer/`) at plugin discovery time,
-which depends on the plugin manager added in 0.11. The bridge no longer
+and the bridge relies on the 0.12 `session_db` constructor contract for
+session persistence. The bridge no longer
 calls a `register_belayer_tools()` shim — when `from run_agent import AIAgent`
 runs, the plugin loader populates `agent.tools` for us. The bridge then uses
 the plugin's `pop_turn_mail_ids()` helper to drain `check_mail` ack ids

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -14,7 +14,6 @@ import os
 import sys
 import json
 import logging
-import inspect
 import queue
 import time
 
@@ -32,6 +31,7 @@ except AttributeError:
 try:
     from run_agent import AIAgent  # type: ignore[import]
     from hermes_state import SessionDB  # type: ignore[import]
+    from hermes_cli import __version__ as HERMES_VERSION  # type: ignore[import]
 except ImportError:
     print(
         "ERROR: hermes-agent package not found. Install hermes-agent first.",
@@ -49,6 +49,9 @@ logging.basicConfig(
 )
 log = logging.getLogger("main")
 
+MIN_HERMES_VERSION = (0, 12, 0)
+MIN_HERMES_VERSION_TEXT = "0.12.0"
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -61,6 +64,30 @@ def _require_env(name: str) -> str:
         log.error("Required env var %s is not set", name)
         sys.exit(1)
     return val
+
+
+def parse_semver(version: str) -> tuple[int, int, int] | None:
+    """Parse the numeric major.minor.patch prefix from a semver-ish string."""
+    parts = version.split("-", 1)[0].split("+", 1)[0].split(".")
+    if len(parts) < 3:
+        return None
+    try:
+        return (int(parts[0]), int(parts[1]), int(parts[2]))
+    except ValueError:
+        return None
+
+
+def require_supported_hermes_version() -> None:
+    """Abort early when the bridge is running against an unsupported Hermes."""
+    parsed = parse_semver(str(HERMES_VERSION))
+    if parsed is not None and parsed >= MIN_HERMES_VERSION:
+        return
+    log.error(
+        "Hermes %s or newer is required; found %s. Upgrade Hermes before running Belayer.",
+        MIN_HERMES_VERSION_TEXT,
+        HERMES_VERSION,
+    )
+    sys.exit(1)
 
 
 def fetch_pending_messages(socket_path: str, session_id: str, agent_id: str) -> list[dict]:
@@ -285,24 +312,14 @@ def extract_session_usage(agent: object) -> dict:
     return usage
 
 
-def aia_agent_accepts_kwarg(name: str) -> bool:
-    """Return whether the active Hermes AIAgent constructor accepts name."""
-    try:
-        sig = inspect.signature(AIAgent.__init__)
-    except (TypeError, ValueError):
-        return True
-    for param in sig.parameters.values():
-        if param.kind == inspect.Parameter.VAR_KEYWORD:
-            return True
-    return name in sig.parameters
-
-
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
 
 def main() -> None:
+    require_supported_hermes_version()
+
     # --- Config from environment -------------------------------------------
     session_id = _require_env("BELAYER_SESSION_ID")
     agent_id = _require_env("BELAYER_AGENT_ID")
@@ -360,7 +377,7 @@ def main() -> None:
             log.warning("Profile dir %s not found, using default", profile_home)
 
     # --- Resolve passthroughs and construct AIAgent --------------------------
-    # Hermes 0.11+ loads credentials, base_url, provider, and api_mode from
+    # Hermes 0.12+ loads credentials, base_url, provider, and api_mode from
     # the active profile (HERMES_HOME) via the transport layer. Auth refresh
     # (OAuth, token rotation) is handled by the transport, not the bridge.
     # We only override via BELAYER_* env vars when the daemon explicitly
@@ -388,8 +405,6 @@ def main() -> None:
         "quiet_mode": True,
         "session_db": session_db,
     }
-    if aia_agent_accepts_kwarg("persist_session"):
-        agent_kwargs["persist_session"] = True
     if system_prompt:
         agent_kwargs["ephemeral_system_prompt"] = system_prompt
     if model:
@@ -424,7 +439,7 @@ def main() -> None:
         sys.exit(1)
 
     # TODO(upstream-hermes): Remove once transports handle HTTPS_PROXY.
-    # Hermes 0.11's transport ABC should eventually handle proxy config per-
+    # Hermes' transport ABC should eventually handle proxy config per-
     # transport. Until then, monkey-patch _create_openai_client to inject a
     # proxy-aware httpx.Client for OpenAI-format transports.
     _proxy_url = os.environ.get("HTTPS_PROXY", "") or os.environ.get("https_proxy", "")

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -31,10 +31,18 @@ except AttributeError:
 try:
     from run_agent import AIAgent  # type: ignore[import]
     from hermes_state import SessionDB  # type: ignore[import]
-    from hermes_cli import __version__ as HERMES_VERSION  # type: ignore[import]
 except ImportError:
     print(
         "ERROR: hermes-agent package not found. Install hermes-agent first.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+try:
+    from hermes_cli import __version__ as HERMES_VERSION  # type: ignore[import]
+except ImportError:
+    print(
+        "ERROR: Hermes 0.12.0 or newer is required; hermes_cli module not found.",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/hermes_bridge/__main__.py
+++ b/hermes_bridge/__main__.py
@@ -14,6 +14,7 @@ import os
 import sys
 import json
 import logging
+import inspect
 import queue
 import time
 
@@ -284,6 +285,18 @@ def extract_session_usage(agent: object) -> dict:
     return usage
 
 
+def aia_agent_accepts_kwarg(name: str) -> bool:
+    """Return whether the active Hermes AIAgent constructor accepts name."""
+    try:
+        sig = inspect.signature(AIAgent.__init__)
+    except (TypeError, ValueError):
+        return True
+    for param in sig.parameters.values():
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+    return name in sig.parameters
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -373,9 +386,10 @@ def main() -> None:
 
     agent_kwargs: dict = {
         "quiet_mode": True,
-        "persist_session": True,
         "session_db": session_db,
     }
+    if aia_agent_accepts_kwarg("persist_session"):
+        agent_kwargs["persist_session"] = True
     if system_prompt:
         agent_kwargs["ephemeral_system_prompt"] = system_prompt
     if model:

--- a/hermes_bridge/tests/test_main_runtime.py
+++ b/hermes_bridge/tests/test_main_runtime.py
@@ -7,10 +7,13 @@ import sys
 import types
 from unittest.mock import MagicMock
 
+import pytest
+
 
 def _load_main_module(monkeypatch):
     fake_run_agent = types.ModuleType("run_agent")
     fake_state = types.ModuleType("hermes_state")
+    fake_hermes_cli = types.ModuleType("hermes_cli")
 
     class _PlaceholderAIAgent:
         def __init__(self, **kwargs):
@@ -26,8 +29,10 @@ def _load_main_module(monkeypatch):
 
     fake_run_agent.AIAgent = _PlaceholderAIAgent
     fake_state.SessionDB = _PlaceholderSessionDB
+    fake_hermes_cli.__version__ = "0.12.0"
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
     monkeypatch.setitem(sys.modules, "hermes_state", fake_state)
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
     monkeypatch.delitem(sys.modules, "hermes_bridge.__main__", raising=False)
     return importlib.import_module("hermes_bridge.__main__")
 
@@ -118,6 +123,7 @@ def test_main_emits_message_ack_for_consumed_pending_messages(monkeypatch):
 
     assert created_agents, "expected AIAgent to be constructed"
     assert created_agents[0].kwargs["max_iterations"] == 7
+    assert "persist_session" not in created_agents[0].kwargs
     assert "[Message from peer]: hello" in created_agents[0].last_run["user_message"]
 
     ack_calls = [c for c in post_event.call_args_list if c.args[3] == "bridge:message_ack"]
@@ -131,53 +137,15 @@ def test_main_emits_message_ack_for_consumed_pending_messages(monkeypatch):
     assert len(finished_calls) == 1
 
 
-def test_main_does_not_pass_removed_persist_session_kwarg(monkeypatch):
+def test_main_requires_hermes_0_12_or_newer(monkeypatch, caplog):
     module = _load_main_module(monkeypatch)
-    _set_required_env(monkeypatch, max_turns="7")
+    monkeypatch.setattr(module, "HERMES_VERSION", "0.11.0")
 
-    created_agents = []
+    with pytest.raises(SystemExit) as exc:
+        module.require_supported_hermes_version()
 
-    class FakeAIAgent:
-        def __init__(self, quiet_mode=False, session_db=None, max_iterations=90):
-            self.kwargs = {
-                "quiet_mode": quiet_mode,
-                "session_db": session_db,
-                "max_iterations": max_iterations,
-            }
-            self.session_id = "hermes-session-123"
-            created_agents.append(self)
-
-        def run_conversation(self, **kwargs):
-            return {
-                "budget_exhausted": True,
-                "turns_used": 1,
-                "final_response": "done",
-                "last_message": "done",
-                "messages": [],
-            }
-
-    monkeypatch.setattr(module, "AIAgent", FakeAIAgent)
-    monkeypatch.setattr(module, "fetch_pending_messages", lambda *args, **kwargs: [])
-    monkeypatch.setattr(module, "make_callbacks", lambda *args, **kwargs: {})
-    monkeypatch.setattr(module, "start_heartbeat_thread", lambda *args, **kwargs: types.SimpleNamespace(set=lambda: None))
-
-    class DummyReader:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def start(self):
-            return None
-
-        def stop(self):
-            return None
-
-    monkeypatch.setattr(module, "StdinReader", DummyReader)
-    monkeypatch.setattr(module, "post_event", MagicMock())
-
-    module.main()
-
-    assert created_agents, "expected AIAgent to be constructed"
-    assert created_agents[0].kwargs["max_iterations"] == 7
+    assert exc.value.code == 1
+    assert "Hermes 0.12.0 or newer is required" in caplog.text
 
 
 def test_main_emits_budget_exhausted_and_passes_max_turns(monkeypatch):
@@ -207,6 +175,7 @@ def test_main_emits_budget_exhausted_and_passes_max_turns(monkeypatch):
 
     assert created_agents, "expected AIAgent to be constructed"
     assert created_agents[0].kwargs["max_iterations"] == 9
+    assert "persist_session" not in created_agents[0].kwargs
 
     budget_calls = [c for c in post_event.call_args_list if c.args[3] == "bridge:budget_exhausted"]
     assert len(budget_calls) == 1

--- a/hermes_bridge/tests/test_main_runtime.py
+++ b/hermes_bridge/tests/test_main_runtime.py
@@ -131,6 +131,55 @@ def test_main_emits_message_ack_for_consumed_pending_messages(monkeypatch):
     assert len(finished_calls) == 1
 
 
+def test_main_does_not_pass_removed_persist_session_kwarg(monkeypatch):
+    module = _load_main_module(monkeypatch)
+    _set_required_env(monkeypatch, max_turns="7")
+
+    created_agents = []
+
+    class FakeAIAgent:
+        def __init__(self, quiet_mode=False, session_db=None, max_iterations=90):
+            self.kwargs = {
+                "quiet_mode": quiet_mode,
+                "session_db": session_db,
+                "max_iterations": max_iterations,
+            }
+            self.session_id = "hermes-session-123"
+            created_agents.append(self)
+
+        def run_conversation(self, **kwargs):
+            return {
+                "budget_exhausted": True,
+                "turns_used": 1,
+                "final_response": "done",
+                "last_message": "done",
+                "messages": [],
+            }
+
+    monkeypatch.setattr(module, "AIAgent", FakeAIAgent)
+    monkeypatch.setattr(module, "fetch_pending_messages", lambda *args, **kwargs: [])
+    monkeypatch.setattr(module, "make_callbacks", lambda *args, **kwargs: {})
+    monkeypatch.setattr(module, "start_heartbeat_thread", lambda *args, **kwargs: types.SimpleNamespace(set=lambda: None))
+
+    class DummyReader:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            return None
+
+        def stop(self):
+            return None
+
+    monkeypatch.setattr(module, "StdinReader", DummyReader)
+    monkeypatch.setattr(module, "post_event", MagicMock())
+
+    module.main()
+
+    assert created_agents, "expected AIAgent to be constructed"
+    assert created_agents[0].kwargs["max_iterations"] == 7
+
+
 def test_main_emits_budget_exhausted_and_passes_max_turns(monkeypatch):
     module = _load_main_module(monkeypatch)
     _set_required_env(monkeypatch, max_turns="9")

--- a/internal/cli/hermes_plugin.go
+++ b/internal/cli/hermes_plugin.go
@@ -30,7 +30,7 @@ func resolveHermesHome() (string, error) {
 }
 
 // extractPluginsToHermesHome mirrors extractBridgeToRuntimeDir but for the
-// Hermes 0.11 plugin tree. The Hermes PluginManager discovers plugins at
+// Hermes 0.12 plugin tree. The Hermes PluginManager discovers plugins at
 // $HERMES_HOME/plugins/<name>/, so we extract there.
 //
 // Idempotent (SHA-256 match skips writes), strips __pycache__ / *.pyc /

--- a/internal/cli/nightshift.go
+++ b/internal/cli/nightshift.go
@@ -180,14 +180,14 @@ func newFinishCmd() *cobra.Command {
 }
 
 type spawnAgentRequest struct {
-	Name       string `json:"name"`
-	Identity   string `json:"identity,omitempty"` // identity template under .belayer/agents/<identity>/; defaults to Name
-	Role       string `json:"role"`
-	Kind       string `json:"kind,omitempty"`
-	Profile    string `json:"profile"`
-	Repo       string `json:"repo,omitempty"`
-	Workdir    string `json:"workdir,omitempty"`
-	Branch     string `json:"branch,omitempty"` // git branch for worktree-isolated spawns
+	Name     string `json:"name"`
+	Identity string `json:"identity,omitempty"` // identity template under .belayer/agents/<identity>/; defaults to Name
+	Role     string `json:"role"`
+	Kind     string `json:"kind,omitempty"`
+	Profile  string `json:"profile"`
+	Repo     string `json:"repo,omitempty"`
+	Workdir  string `json:"workdir,omitempty"`
+	Branch   string `json:"branch,omitempty"` // git branch for worktree-isolated spawns
 }
 
 type AgentRunView struct {
@@ -283,7 +283,7 @@ func newRequestCompletionCmd() *cobra.Command {
 			if err := c.LogEvent(sessID, "bridge:completion_requested", eventData); err != nil {
 				return fmt.Errorf("request completion: %w", err)
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "Completion review requested. PM agent will be spawned to verify.")
+			fmt.Fprintln(cmd.OutOrStdout(), "Completion review requested. Acceptance gate agent will be spawned to verify.")
 			return nil
 		},
 	}

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -481,7 +481,7 @@ func (d *Daemon) handleFinishAgent(w http.ResponseWriter, r *http.Request) {
 		})
 		writeJSON(w, http.StatusOK, map[string]string{
 			"status":  "pending_verification",
-			"message": "PM agent spawned for spec verification",
+			"message": "Acceptance gate agent spawned for spec verification",
 		})
 		return
 	}

--- a/internal/daemon/bridge_events.go
+++ b/internal/daemon/bridge_events.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/donovan-yohan/belayer/internal/broker"
+	"github.com/donovan-yohan/belayer/internal/gates"
 	"github.com/donovan-yohan/belayer/internal/store"
 	"github.com/google/uuid"
 	"go.yaml.in/yaml/v3"
@@ -604,6 +605,27 @@ func (d *Daemon) resolveExitConditions(sessionID string) ([]string, string) {
 	return file.ExitConditions, "config"
 }
 
+func (d *Daemon) resolveAcceptanceGate(sessionID string) (gates.Gate, string) {
+	sess, err := d.store.GetSession(sessionID)
+	if err != nil || sess.WorkspaceDir == "" {
+		return gates.BuiltInAcceptance(), "builtin"
+	}
+	cfgPath := filepath.Join(sess.WorkspaceDir, ".belayer", "config.yaml")
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return gates.BuiltInAcceptance(), "builtin"
+	}
+	gate, ok, err := gates.AcceptanceFromConfig(raw)
+	if err != nil {
+		log.Printf("resolveAcceptanceGate: failed to parse gates for session %s: %v (using built-in acceptance)", sessionID, err)
+		return gates.BuiltInAcceptance(), "builtin"
+	}
+	if !ok {
+		return gates.BuiltInAcceptance(), "builtin"
+	}
+	return gate, "config"
+}
+
 // resolvePersistenceStrategy returns the authoritative persistence-strategy
 // list for the session plus the source it came from ("override" for a
 // --persistence-strategy flag at climb start, "config" for .belayer/config.yaml,
@@ -831,9 +853,41 @@ func (d *Daemon) maybeRepromptForPersistence(sessionID, supervisorDetail string)
 	return true
 }
 
+func renderAcceptanceGateBlock(gate gates.Gate, source string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Acceptance gate for this climb (source: %s):\n", source)
+	fmt.Fprintf(&b, "- name: %s\n", gate.Name)
+	fmt.Fprintf(&b, "- stage: %s\n", gate.Stage)
+	fmt.Fprintf(&b, "- authority: %s\n", gate.Authority)
+	if gate.Trigger != "" {
+		fmt.Fprintf(&b, "- trigger: %s\n", gate.Trigger)
+	}
+	if len(gate.AssignedTalent) > 0 {
+		fmt.Fprintf(&b, "- assigned_talent: %s\n", strings.Join(gate.AssignedTalent, ", "))
+	}
+	if len(gate.Requires) > 0 {
+		b.WriteString("- requires:\n")
+		for _, req := range gate.Requires {
+			fmt.Fprintf(&b, "  - %s\n", req)
+		}
+	}
+	if len(gate.Conditions) > 0 {
+		b.WriteString("- conditions:\n")
+		for _, condition := range gate.Conditions {
+			fmt.Fprintf(&b, "  - %s\n", condition)
+		}
+	}
+	if len(gate.Verdicts) > 0 {
+		fmt.Fprintf(&b, "- verdicts: %s\n", strings.Join(gate.Verdicts, ", "))
+	}
+	return b.String()
+}
+
 func (d *Daemon) handleBridgeCompletionRequested(sessionID, agentName string, data map[string]any) {
 	summary, _ := data["summary"].(string)
 	specArtifact, _ := data["spec_artifact"].(string)
+	acceptanceGate, gateSource := d.resolveAcceptanceGate(sessionID)
+	acceptanceTalent := acceptanceGate.PrimaryTalent()
 
 	// Build context for the PM: spec location, artifact list, supervisor summary.
 	artifacts, _ := d.store.ListArtifacts(sessionID)
@@ -885,8 +939,10 @@ func (d *Daemon) handleBridgeCompletionRequested(sessionID, agentName string, da
 		}
 	}
 
+	gateBlock := renderAcceptanceGateBlock(acceptanceGate, gateSource)
+
 	// Build PM initial message with full context.
-	pmMessage := fmt.Sprintf(
+	gateMessage := fmt.Sprintf(
 		`[System] The supervisor has signaled that all implementation work is complete. Your job is to verify.
 
 Supervisor's summary:
@@ -898,35 +954,42 @@ Registered artifacts:
 %s
 
 %s
+
+%s
 Instructions:
 1. Read the spec artifact (or find the spec in the workspace if none was registered).
 2. Use git diff to see what changed during this climb.
 3. Walk through the spec section by section. For each requirement, find evidence in the code.
-4. For each exit condition listed above, demand concrete evidence it holds.
+4. For each acceptance gate condition and exit condition listed above, demand concrete evidence it holds.
 5. Check for deferred work: TODO comments, placeholder implementations, empty test bodies.
 6. Produce a structured verification report (Passed / Failed / Deferred).
 
-If ALL spec items and exit conditions are satisfied: call belayer_approve_completion with your verification report.
+If ALL acceptance gate conditions, spec items, and exit conditions are satisfied: call belayer_approve_completion with your verification report.
 If gaps exist: call belayer_reject_completion with the specific gaps so the supervisor can fix them.`,
-		summary, specLine, artifactSummary, exitBlock,
+		summary, specLine, artifactSummary, gateBlock, exitBlock,
 	)
 
-	// Auto-spawn the PM agent.
+	// Auto-spawn the acceptance gate talent. The built-in preset keeps the
+	// historical PM path intact unless a project config overrides it.
 	go func() {
 		_, err := d.spawnAgentInternal(agentSpawnRequest{
 			SessionID: sessionID,
-			Name:      "pm",
-			Role:      "pm",
+			Name:      acceptanceTalent,
+			Role:      acceptanceTalent,
 			Kind:      "side",
 			Profile:   "default",
-			Message:   pmMessage,
+			Message:   gateMessage,
 		})
 		if err != nil {
-			log.Printf("Failed to auto-spawn PM for session %s: %v", sessionID, err)
+			log.Printf("Failed to auto-spawn acceptance gate talent %s for session %s: %v", acceptanceTalent, sessionID, err)
 			_ = d.store.LogEvent(store.SessionEvent{
 				SessionID: sessionID,
 				Type:      "pm_spawn_failed",
-				Data:      mustJSON(map[string]string{"error": err.Error()}),
+				Data: mustJSON(map[string]string{
+					"error":  err.Error(),
+					"gate":   acceptanceGate.Name,
+					"talent": acceptanceTalent,
+				}),
 			})
 			// Notify supervisor that PM spawn failed.
 			msg := broker.Message{
@@ -935,7 +998,7 @@ If gaps exist: call belayer_reject_completion with the specific gaps so the supe
 				SenderID:    "system",
 				RecipientID: "supervisor",
 				Type:        broker.MessageStateChange,
-				Content:     "PM agent failed to spawn for completion verification. You may call belayer_request_completion again to retry.",
+				Content:     "Acceptance gate agent failed to spawn for completion verification. You may call belayer_request_completion again to retry.",
 				Urgent:      true,
 				Timestamp:   time.Now().UTC(),
 			}
@@ -950,7 +1013,7 @@ If gaps exist: call belayer_reject_completion with the specific gaps so the supe
 			})
 			_ = d.broker.Interrupt(sessionID, "supervisor", msg)
 		} else {
-			log.Printf("Auto-spawned PM agent for completion review in session %s", sessionID)
+			log.Printf("Auto-spawned acceptance gate talent %s for completion review in session %s", acceptanceTalent, sessionID)
 		}
 	}()
 }

--- a/internal/daemon/completion_gate_test.go
+++ b/internal/daemon/completion_gate_test.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -102,5 +104,93 @@ func TestCompletionRequested_AutoSpawnsPM(t *testing.T) {
 	}
 	if !sawPM {
 		t.Fatalf("spawnBridgeAgent never called with name=pm; saw: %v", spawnedNames)
+	}
+}
+
+func TestCompletionRequested_UsesConfiguredAcceptanceGateTalent(t *testing.T) {
+	d := testDaemon(t)
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, ".belayer"), 0o755); err != nil {
+		t.Fatalf("mkdir .belayer: %v", err)
+	}
+	config := `gates:
+  - name: acceptance
+    stage: session
+    authority: blocking
+    trigger: completion_requested
+    assigned_talent:
+      - acceptance-editor
+    requires:
+      - spec-or-task
+    conditions:
+      - "The delivered work satisfies the task"
+    verdicts:
+      - pass
+      - fail
+      - blocked
+`
+	if err := os.WriteFile(filepath.Join(workspace, ".belayer", "config.yaml"), []byte(config), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	sessionID, err := d.store.CreateSession(store.Session{Name: "configured-gate", WorkspaceDir: workspace, Status: "running"})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := d.store.CreateAgentRun(store.AgentRun{
+		SessionID: sessionID,
+		Name:      "supervisor",
+		Role:      "supervisor",
+		Profile:   "default",
+		Status:    "running",
+		Transport: "tmux",
+	}); err != nil {
+		t.Fatalf("create supervisor run: %v", err)
+	}
+
+	var mu sync.Mutex
+	var spawnedNames []string
+	var spawnedMessages []string
+	spawned := make(chan struct{}, 4)
+	d.spawnBridgeAgent = func(req agentSpawnRequest) (*bridge.Process, error) {
+		mu.Lock()
+		spawnedNames = append(spawnedNames, req.Name)
+		spawnedMessages = append(spawnedMessages, req.Message)
+		mu.Unlock()
+		proc, _ := newLiveProc()
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			proc.MarkLive()
+		}()
+		select {
+		case spawned <- struct{}{}:
+		default:
+		}
+		return proc, nil
+	}
+
+	rr := postBridgeEvent(t, d, sessionID, "bridge:completion_requested", map[string]any{
+		"agent":   "supervisor",
+		"summary": "implemented the configured gate flow",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	select {
+	case <-spawned:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for acceptance gate spawn after completion_requested")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(spawnedNames) != 1 {
+		t.Fatalf("expected one spawned acceptance gate talent, got %v", spawnedNames)
+	}
+	if spawnedNames[0] != "acceptance-editor" {
+		t.Fatalf("spawned %q, want configured acceptance talent %q", spawnedNames[0], "acceptance-editor")
+	}
+	if !strings.Contains(spawnedMessages[0], "The delivered work satisfies the task") {
+		t.Fatalf("spawn message did not include configured gate condition: %q", spawnedMessages[0])
 	}
 }

--- a/internal/daemon/completion_gate_test.go
+++ b/internal/daemon/completion_gate_test.go
@@ -182,6 +182,23 @@ func TestCompletionRequested_UsesConfiguredAcceptanceGateTalent(t *testing.T) {
 		t.Fatal("timed out waiting for acceptance gate spawn after completion_requested")
 	}
 
+	var acceptanceRun store.AgentRun
+	var acceptanceErr error
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		acceptanceRun, acceptanceErr = d.store.GetAgentRun(sessionID, "acceptance-editor")
+		if acceptanceErr == nil && acceptanceRun.Status == "running" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if acceptanceErr != nil {
+		t.Fatalf("expected acceptance gate agent run to exist after completion_requested: %v", acceptanceErr)
+	}
+	if acceptanceRun.Status != "running" {
+		t.Fatalf("acceptance-editor status = %q, want %q", acceptanceRun.Status, "running")
+	}
+
 	mu.Lock()
 	defer mu.Unlock()
 	if len(spawnedNames) != 1 {

--- a/internal/gates/gates.go
+++ b/internal/gates/gates.go
@@ -1,0 +1,114 @@
+package gates
+
+import (
+	"fmt"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	SchemaVersion = "belayer-gate/v1"
+
+	AcceptanceName        = "acceptance"
+	CompletionRequested   = "completion_requested"
+	DefaultAcceptanceRole = "pm"
+)
+
+type Gate struct {
+	SchemaVersion  string   `json:"schema_version,omitempty" yaml:"schema_version,omitempty"`
+	Name           string   `json:"name" yaml:"name"`
+	Stage          string   `json:"stage" yaml:"stage"`
+	Authority      string   `json:"authority" yaml:"authority"`
+	Trigger        string   `json:"trigger,omitempty" yaml:"trigger,omitempty"`
+	AssignedTalent []string `json:"assigned_talent" yaml:"assigned_talent"`
+	Requires       []string `json:"requires,omitempty" yaml:"requires,omitempty"`
+	InputArtifacts []string `json:"input_artifacts,omitempty" yaml:"input_artifacts,omitempty"`
+	Conditions     []string `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	OutputArtifact string   `json:"output_artifact,omitempty" yaml:"output_artifact,omitempty"`
+	Verdicts       []string `json:"verdicts" yaml:"verdicts"`
+}
+
+type configFile struct {
+	Gates []Gate `yaml:"gates"`
+}
+
+func BuiltInAcceptance() Gate {
+	return Gate{
+		SchemaVersion: SchemaVersion,
+		Name:          AcceptanceName,
+		Stage:         "session",
+		Authority:     "blocking",
+		Trigger:       CompletionRequested,
+		AssignedTalent: []string{
+			DefaultAcceptanceRole,
+		},
+		Requires: []string{
+			"spec-or-task",
+			"registered-artifacts",
+		},
+		Conditions: []string{
+			"The delivered work satisfies the original task or spec",
+			"All configured exit conditions have observable evidence",
+		},
+		OutputArtifact: "gate-result",
+		Verdicts: []string{
+			"pass",
+			"fail",
+			"blocked",
+		},
+	}
+}
+
+func AcceptanceFromConfig(raw []byte) (Gate, bool, error) {
+	var cfg configFile
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return Gate{}, false, fmt.Errorf("parse gates config: %w", err)
+	}
+	for _, gate := range cfg.Gates {
+		if gate.isAcceptanceGate() {
+			gate.applyDefaults()
+			return gate, true, nil
+		}
+	}
+	return Gate{}, false, nil
+}
+
+func (g Gate) PrimaryTalent() string {
+	for _, talent := range g.AssignedTalent {
+		if talent = strings.TrimSpace(talent); talent != "" {
+			return talent
+		}
+	}
+	return DefaultAcceptanceRole
+}
+
+func (g Gate) isAcceptanceGate() bool {
+	name := strings.TrimSpace(strings.ToLower(g.Name))
+	trigger := strings.TrimSpace(strings.ToLower(g.Trigger))
+	return name == AcceptanceName && (trigger == "" || trigger == CompletionRequested)
+}
+
+func (g *Gate) applyDefaults() {
+	if strings.TrimSpace(g.SchemaVersion) == "" {
+		g.SchemaVersion = SchemaVersion
+	}
+	if strings.TrimSpace(g.Stage) == "" {
+		g.Stage = "session"
+	}
+	if strings.TrimSpace(g.Authority) == "" {
+		g.Authority = "blocking"
+	}
+	if strings.TrimSpace(g.Trigger) == "" {
+		g.Trigger = CompletionRequested
+	}
+	if strings.TrimSpace(g.OutputArtifact) == "" {
+		g.OutputArtifact = "gate-result"
+	}
+	if len(g.AssignedTalent) == 0 {
+		g.AssignedTalent = []string{DefaultAcceptanceRole}
+	}
+	if len(g.Verdicts) == 0 {
+		g.Verdicts = []string{"pass", "fail", "blocked"}
+	}
+}

--- a/plugins/belayer/tests/test_plugin_register.py
+++ b/plugins/belayer/tests/test_plugin_register.py
@@ -1,4 +1,4 @@
-"""Tests for plugins.belayer — the Hermes 0.11 plugin entry point.
+"""Tests for plugins.belayer — the Hermes 0.12 plugin entry point.
 
 Verifies the plugin's register(ctx) wiring: which tools it registers, how
 env vars drive kind-gating and the BELAYER_TOOLS allowlist, that missing


### PR DESCRIPTION
## Summary

- add a small `belayer-gate/v1` model with built-in `acceptance` fallback
- resolve repo-local configured acceptance gates when `completion_requested` fires
- spawn the configured acceptance gate talent while preserving PM as the default
- include gate conditions in the acceptance agent prompt and update completion-facing wording
- require Hermes 0.12+ for the bridge contract and remove the stale `persist_session` constructor compatibility path
- address review feedback on `pm_spawn_failed` docs and acceptance-gate test synchronization

Closes #118.

## Testing

- `go test ./internal/gates ./internal/daemon ./internal/cli ./internal/agentlint`
- `uv run pytest hermes_bridge/tests/test_main_runtime.py -q`
- `go test ./...`
- `uv run pytest hermes_bridge/tests plugins/belayer/tests -q`
- `hermes --version` -> `Hermes Agent v0.12.0 (2026.4.30)`
- Real-repo smoke against `/Users/donovanyohan/Documents/Programs/personal/lisper` using `/tmp/belayer-smoke`, Hermes profile `ebi` (Codex/gpt-5.5), session `ddee23ed-c6f5-4d9d-b9d8-4e1f34a3c857`; supervisor reported `agent_status:done`.
