### PR TITLE
Define talent lifecycle contract

### DIFF
--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -319,7 +319,38 @@ Sides are excluded from broadcast fan-out by construction.
 
 ---
 
-## Agent lifecycle: party mains vs. summoned sides
+## Agent lifecycle: bridge mechanics and talent lifecycle
+
+`kind: main | side` and `ephemeral` are current bridge/runtime mechanics, not the
+long-term crag talent contract. `kind` controls today's mail/tool surface:
+mains have the pull mailbox and broadcast membership, while sides receive work
+through spawn messages and report through final responses, artifacts, status, or
+urgent messages. `ephemeral` controls whether the bridge exits after task
+completion or idles for more work.
+
+Crag/talent metadata should describe runtime intent with
+`runtime.lifecycle: resident | resumable | ephemeral`:
+
+```text
+resident
+  Live process for the climb; idles and wakes in-process.
+
+resumable
+  Assigned durable talent; process may stop, but direct mail or explicit spawn
+  can wake it later with prior Hermes session context.
+
+ephemeral
+  One-shot process; no durable mailbox/wake contract after completion.
+```
+
+The current daemon already persists `agent_runs.hermes_session_id` and can carry
+that value into a same-name respawn. Issue #119 extends that model by making
+assignment, dormant state, and wake-on-direct-mail daemon-owned lifecycle
+concepts instead of prompt-only conventions. Broadcasts should remain scoped to
+resident/live party members by default so dormant talent pools do not wake as a
+side effect of general announcements.
+
+The sections below describe the bridge behavior that exists today.
 
 Two distinct lifecycle models exist inside a single climb. The shape maps
 onto `kind`: mains live through the climb as peer party members; sides are

--- a/docs/CRAG_MODE.md
+++ b/docs/CRAG_MODE.md
@@ -20,7 +20,7 @@ replacement for the Hermes plugin tool architecture.
 Belayer already has the substrate an organization layer needs:
 
 - agent identity directories under `agents/<name>/` and `.belayer/agents/<name>/`
-- `kind: main | side` for mailbox-bearing peers versus scoped workers
+- bridge-level `kind` and `ephemeral` mechanics for current Hermes spawns
 - a Go daemon that owns roster, mail, events, artifacts, and completion state
 - Hermes plugin tools that expose daemon-backed coordination functions to agents
 - durable artifacts that PM, QA, reviewer, or custom gates can inspect
@@ -28,9 +28,9 @@ Belayer already has the substrate an organization layer needs:
 Crag mode names the higher-level contracts that currently live mostly
 in prompts.
 
-## Team Identities
+## Talent Identities
 
-A team identity is an addable agent identity plus optional metadata describing
+A talent identity is an addable agent identity plus optional metadata describing
 when and how to use it. In v1, the portable identity contract remains the
 existing directory shape:
 
@@ -41,27 +41,99 @@ existing directory shape:
 └── agents.md
 ```
 
-Team metadata currently lives beside the identity as `talent.yaml` to preserve
+Talent metadata currently lives beside the identity as `talent.yaml` to preserve
 the existing artifact/schema vocabulary. The current daemon only needs the
 existing identity fields at spawn time; metadata is for catalog browsing,
 documentation, and future selection logic.
 
 ```yaml
 schema_version: "belayer-talent/v1"
-name: backend-dev
+name: design-engineer
 category: development
-kind: main
-summary: Backend/API implementer
+summary: Product/design talent for UX review and interaction design
+role: "design engineer"
+domain: "product"
 capabilities:
-  - api-design
-  - database-migrations
-  - service-tests
-compatible_adapters:
-  - hermes-plugin
+  - interaction-design
+  - ux-review
+  - accessibility-review
+activation:
+  mode: on_demand
+runtime:
+  lifecycle: resumable
+contract:
+  accepts:
+    - task
+    - gate-request
+  produces:
+    - design-review-notes
+  requires:
+    - repo-workspace
+authority:
+  tools: []
+  gates:
+    - design-review
+memory:
+  scope: crag
+retention:
+  scope: crag
+  promotion: proposed
 default_gates:
-  - code-review
-  - runtime-qa
+  - design-review
 ```
+
+`role` and `domain` are prompt-visible metadata, not framework enums. A
+software crag can use roles like "CEO", "HR", "QA engineer", or "design
+engineer"; a story crag can use "storyteller", "lorekeeper", or "tavernkeep".
+Belayer core should route on the smaller generic contract:
+
+- `activation.mode`: `climb_start`, `on_demand`, `gate_triggered`, or
+  `generated`
+- `runtime.lifecycle`: `resident`, `resumable`, or `ephemeral`
+- `contract.accepts` / `contract.produces` / `contract.requires`
+- `authority.tools` and `authority.gates`
+- `memory.scope` and `retention`
+
+The existing `agent.yaml#kind` and bridge `ephemeral` flag remain compatibility
+mechanics for current Hermes spawns. New crag metadata should describe the
+talent contract above and let the adapter derive bridge settings when possible.
+
+## Talent Lifecycle
+
+Crag mode separates a talent definition from a running process:
+
+```text
+catalog talent
+  -> assigned talent
+  -> active employee
+  -> checkpointed/dormant employee
+  -> resumed or retired
+```
+
+`catalog talent` is metadata, prompt, and tool contract with no process.
+`assigned talent` is selected for a task or gate but may not be spawned yet.
+`active employee` has a running bridge/session. `dormant employee` has no live
+process but remains addressable through its assignment, prior Hermes session ID,
+artifacts, and mailbox cursor. `retired` talent is retained for audit history but
+not selected by default.
+
+Lifecycle names are runtime behavior, not company roles:
+
+```text
+resident
+  Live for the climb. Idles and wakes in-process. Suitable for the lead.
+
+resumable
+  Durable assigned talent. Can shut down after work, then wake later with prior
+  context when directly mailed or explicitly spawned.
+
+ephemeral
+  One-shot worker. No durable mailbox or wake contract after completion.
+```
+
+The framework should not know "CEO", "HR", "QA", or "design engineer" as
+special cases. Those are roles/capabilities in talent metadata. The enforceable
+parts are activation, lifecycle, authority, contract shape, and gate binding.
 
 ## Persistence Scopes
 
@@ -296,6 +368,30 @@ terms:
 3. Review: gate talents register `gate-result` artifacts and emit
    `org:task_reviewed`.
 4. Retro: the lead registers `org-retro` to capture what to improve next climb.
+
+Top-down decomposition and agent-to-agent communication are complementary.
+Decomposition creates task addresses; communication resolves work inside those
+addresses; artifacts and gates aggregate results back up.
+
+```text
+lead decomposes
+  -> task id, owner, acceptance, expected outputs, gates
+talents communicate
+  -> questions, handoffs, blockers, review notes
+talents publish
+  -> artifacts, gate-results, final reports
+lead aggregates
+  -> task state, org-retro, talent-evaluation
+```
+
+Messages, artifacts, gate results, and talent evaluations should carry a
+`task_id` when the interaction is about a planned task. Belayer does not need a
+full workflow engine to enforce this on day one, but task binding keeps direct
+agent communication from becoming invisible coordination fog.
+
+Every meaningful agent conversation should advance a task, create or update an
+artifact, unblock another talent, or trigger a gate. The auditable record is the
+task-linked artifact and event trail, not the raw chat transcript alone.
 
 ## Talent Growth Loop
 

--- a/docs/artifact-schemas/org-plan.schema.json
+++ b/docs/artifact-schemas/org-plan.schema.json
@@ -4,7 +4,7 @@
   "title": "Belayer Organization Plan",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "objective", "lead", "tasks", "gates"],
+  "required": ["schema_version", "objective", "lead", "tasks", "assignments", "gates"],
   "properties": {
     "schema_version": {
       "const": "belayer-org-plan/v1"
@@ -62,7 +62,7 @@
     "task": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "title", "owner", "status", "acceptance"],
+      "required": ["id", "title", "owner", "status", "acceptance", "expected_outputs", "gates", "attempts"],
       "properties": {
         "id": {
           "type": "string",
@@ -80,7 +80,7 @@
           "minLength": 1
         },
         "status": {
-          "enum": ["planned", "ready", "running", "active", "blocked", "review", "done", "passed", "failed"]
+          "enum": ["planned", "ready", "running", "blocked", "review", "done", "passed", "failed", "incomplete"]
         },
         "dependencies": {
           "type": "array",
@@ -100,6 +100,7 @@
         },
         "expected_outputs": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "string",
             "minLength": 1
@@ -108,6 +109,7 @@
         },
         "gates": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "string",
             "minLength": 1
@@ -117,6 +119,7 @@
         "attempts": {
           "type": "object",
           "additionalProperties": false,
+          "required": ["max", "used"],
           "properties": {
             "max": {
               "type": "integer",
@@ -189,7 +192,27 @@
           },
           "default": []
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "enum": ["on_demand", "gate_triggered"]
+              }
+            },
+            "required": ["mode"]
+          },
+          "then": {
+            "required": ["triggers"],
+            "properties": {
+              "triggers": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      ]
     },
     "runtime": {
       "type": "object",

--- a/docs/artifact-schemas/org-plan.schema.json
+++ b/docs/artifact-schemas/org-plan.schema.json
@@ -104,8 +104,7 @@
           "items": {
             "type": "string",
             "minLength": 1
-          },
-          "default": []
+          }
         },
         "gates": {
           "type": "array",
@@ -113,8 +112,7 @@
           "items": {
             "type": "string",
             "minLength": 1
-          },
-          "default": []
+          }
         },
         "attempts": {
           "type": "object",

--- a/docs/artifact-schemas/org-plan.schema.json
+++ b/docs/artifact-schemas/org-plan.schema.json
@@ -32,6 +32,13 @@
         "$ref": "#/$defs/task"
       }
     },
+    "assignments": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/assignment"
+      },
+      "default": []
+    },
     "gates": {
       "type": "array",
       "items": {
@@ -73,7 +80,7 @@
           "minLength": 1
         },
         "status": {
-          "enum": ["planned", "ready", "running", "blocked", "review", "done"]
+          "enum": ["planned", "ready", "running", "active", "blocked", "review", "done", "passed", "failed"]
         },
         "dependencies": {
           "type": "array",
@@ -91,7 +98,137 @@
             "minLength": 1
           }
         },
+        "expected_outputs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "gates": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "attempts": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "max": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "used": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
         "output_artifacts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    },
+    "assignment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["talent", "source", "reason", "activation", "runtime", "contract"],
+      "properties": {
+        "talent": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "enum": ["project", "crag", "catalog", "generated"]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "activation": {
+          "$ref": "#/$defs/activation"
+        },
+        "runtime": {
+          "$ref": "#/$defs/runtime"
+        },
+        "contract": {
+          "$ref": "#/$defs/talent_contract"
+        },
+        "task_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    },
+    "activation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode"],
+      "properties": {
+        "mode": {
+          "enum": ["climb_start", "on_demand", "gate_triggered", "generated"]
+        },
+        "triggers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["lifecycle"],
+      "properties": {
+        "lifecycle": {
+          "enum": ["resident", "resumable", "ephemeral"]
+        },
+        "idle_after": {
+          "enum": ["task_done", "gate_result_submitted", "session_complete", "manual"]
+        },
+        "resume": {
+          "enum": ["hermes_session", "none"]
+        }
+      }
+    },
+    "talent_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["accepts", "produces"],
+      "properties": {
+        "accepts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "produces": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "requires": {
           "type": "array",
           "items": {
             "type": "string",

--- a/docs/artifact-schemas/talent-evaluation.schema.json
+++ b/docs/artifact-schemas/talent-evaluation.schema.json
@@ -40,6 +40,9 @@
         "$ref": "#/$defs/task_summary"
       }
     },
+    "assignment": {
+      "$ref": "#/$defs/assignment"
+    },
     "produced_artifacts": {
       "type": "array",
       "items": {
@@ -95,6 +98,34 @@
     }
   },
   "$defs": {
+    "assignment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "lifecycle", "state", "task_ids"],
+      "properties": {
+        "source": {
+          "enum": ["project", "crag", "catalog", "generated"]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "lifecycle": {
+          "enum": ["resident", "resumable", "ephemeral"]
+        },
+        "state": {
+          "enum": ["available", "assigned", "running", "dormant", "resumed", "spawned_new", "not_available"]
+        },
+        "task_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
     "task_summary": {
       "type": "object",
       "additionalProperties": false,

--- a/docs/artifact-schemas/talent-evaluation.schema.json
+++ b/docs/artifact-schemas/talent-evaluation.schema.json
@@ -4,7 +4,7 @@
   "title": "Belayer Talent Evaluation",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "talent", "org", "session", "tasks", "gate_outcomes", "recommendations"],
+  "required": ["schema_version", "talent", "org", "session", "tasks", "assignment", "gate_outcomes", "recommendations"],
   "properties": {
     "schema_version": {
       "const": "belayer-talent-evaluation/v1"
@@ -114,7 +114,7 @@
           "enum": ["resident", "resumable", "ephemeral"]
         },
         "state": {
-          "enum": ["available", "assigned", "running", "dormant", "resumed", "spawned_new", "not_available"]
+          "enum": ["available", "assigned", "running", "dormant", "resumed", "spawned_new", "not_available", "retired"]
         },
         "task_ids": {
           "type": "array",

--- a/docs/design-docs/2026-05-01-talent-lifecycle-contract-plan.md
+++ b/docs/design-docs/2026-05-01-talent-lifecycle-contract-plan.md
@@ -1,0 +1,73 @@
+# Talent Lifecycle Contract Plan
+
+## Goal
+
+Issue #119 needs Belayer to distinguish talent availability from running bridge
+processes. This plan formalizes the revised contract discussed for OMC-style
+crags: top-down task decomposition creates task addresses, direct
+agent-to-agent communication resolves work inside those addresses, and
+task-linked artifacts/gates aggregate the results.
+
+## Scope
+
+This PR is the docs/schema/proof-example step. It does not implement daemon
+wake-on-mail yet. It defines the contract that runtime work should implement
+next:
+
+- talent metadata separates `role` and `domain` from runtime behavior
+- `activation.mode` describes when a talent is brought into a climb
+- `runtime.lifecycle` describes whether a talent is resident, resumable, or
+  ephemeral
+- `contract.accepts`, `contract.produces`, and `contract.requires` describe the
+  typed organizational interface without hard-coding software roles
+- `assignment` records why a talent was selected, where it came from, and which
+  tasks it owns
+- task nodes carry expected outputs, gate bindings, and attempt budgets
+- talent evaluations record whether talent was available, assigned, running,
+  dormant, resumed, newly spawned, or unavailable
+
+## Implementation Tasks
+
+1. Update `docs/CRAG_MODE.md` to make `belayer-talent/v1` the public contract
+   and demote `kind`/`ephemeral` to bridge compatibility mechanics.
+2. Update `docs/AGENT_ARCHITECTURE.md` to explain how current main/side bridge
+   mechanics map to future `resident`, `resumable`, and `ephemeral` lifecycle
+   behavior.
+3. Extend `docs/artifact-schemas/org-plan.schema.json` with top-level
+   `assignments` and task-level `expected_outputs`, `gates`, and `attempts`.
+4. Extend `docs/artifact-schemas/talent-evaluation.schema.json` with assignment
+   lifecycle evidence.
+5. Update the software-company and story-world proof org-plans so assignments,
+   tasks, and gates exercise the new contract.
+6. Update story catalog and generated-talent YAML so talent metadata uses
+   `role`, `domain`, `activation`, `runtime`, `contract`, `memory`, and
+   `retention`.
+7. Add agentlint regression tests that fail if proof examples omit lifecycle
+   assignments, task output/gate bindings, or evaluation lifecycle evidence.
+
+## Runtime Follow-Up
+
+The daemon follow-up should introduce assigned/dormant state as a runtime-owned
+concept:
+
+```text
+assigned talent != running process
+dormant resumable talent + direct mail -> spawn with prior Hermes session
+broadcast -> resident/live recipients only by default
+```
+
+The smallest runtime change should preserve existing supervisor + PM climbs,
+reuse `agent_runs.hermes_session_id`, and avoid a global scheduler or remote
+talent marketplace.
+
+## Validation
+
+Required checks for this PR:
+
+```bash
+jq empty docs/artifact-schemas/org-plan.schema.json docs/artifact-schemas/talent-evaluation.schema.json examples/org-proofs/relay-ide-software-company/org-plan.json examples/org-proofs/athenaeum-tavern-story/org-plan.json examples/org-proofs/relay-ide-software-company/talent-evaluation-backend-dev.json examples/org-proofs/athenaeum-tavern-story/talent-evaluation-storyteller.json examples/org-proofs/athenaeum-tavern-story/talent-evaluation-tavernkeep-mara.json
+go test ./internal/agentlint
+go test ./...
+git diff --check
+```
+

--- a/examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml
+++ b/examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml
@@ -6,7 +6,33 @@ origin:
   session_id: "example-athenaeum-tavern"
   first_artifact: "examples/org-proofs/athenaeum-tavern-story/three-act-story.md"
 role: "tavernkeep"
+domain: "story"
 summary: "Warm, watchful keeper of the Last Lantern who remembers debts, house rules, and rumors."
+capabilities:
+  - scene-role
+  - location-anchor
+  - rumor-delivery
+activation:
+  mode: generated
+runtime:
+  lifecycle: ephemeral
+  idle_after: task_done
+  resume: none
+contract:
+  accepts:
+    - scene-role
+  produces:
+    - character-beats
+  requires:
+    - scene-context
+authority:
+  tools: []
+  gates: []
+memory:
+  scope: project
+retention:
+  scope: crag
+  promotion: proposed
 personality_hooks:
   - "Practical hospitality with a steel edge"
   - "Treats magical danger as a customer-service problem until it breaks house rules"

--- a/examples/org-proofs/athenaeum-tavern-story/org-plan.json
+++ b/examples/org-proofs/athenaeum-tavern-story/org-plan.json
@@ -7,6 +7,100 @@
     "belayer-athenaeum/.design/characters.md",
     "belayer-athenaeum/examples/quest-tale.md"
   ],
+  "assignments": [
+    {
+      "talent": "storyteller",
+      "source": "catalog",
+      "reason": "Frame the scene, coordinate character pressure, and aggregate the story artifact.",
+      "activation": {
+        "mode": "climb_start"
+      },
+      "runtime": {
+        "lifecycle": "resident",
+        "idle_after": "session_complete",
+        "resume": "hermes_session"
+      },
+      "contract": {
+        "accepts": [
+          "story-premise",
+          "continuity-feedback"
+        ],
+        "produces": [
+          "org-plan",
+          "story-artifact",
+          "org-retro"
+        ],
+        "requires": [
+          "world-context"
+        ]
+      },
+      "task_ids": [
+        "scene-setup",
+        "npc-generation",
+        "continuity"
+      ]
+    },
+    {
+      "talent": "continuity-editor",
+      "source": "catalog",
+      "reason": "Continuity is a blocking session gate for story-world climbs.",
+      "activation": {
+        "mode": "gate_triggered",
+        "triggers": [
+          "gate:continuity"
+        ]
+      },
+      "runtime": {
+        "lifecycle": "resumable",
+        "idle_after": "gate_result_submitted",
+        "resume": "hermes_session"
+      },
+      "contract": {
+        "accepts": [
+          "gate-request",
+          "story-artifact",
+          "world-state"
+        ],
+        "produces": [
+          "continuity-report",
+          "gate-result"
+        ],
+        "requires": [
+          "world-context"
+        ]
+      },
+      "task_ids": [
+        "continuity"
+      ]
+    },
+    {
+      "talent": "mara-underbough",
+      "source": "generated",
+      "reason": "Scene-local tavernkeep created for this climb and proposed for future reuse.",
+      "activation": {
+        "mode": "generated"
+      },
+      "runtime": {
+        "lifecycle": "ephemeral",
+        "idle_after": "task_done",
+        "resume": "none"
+      },
+      "contract": {
+        "accepts": [
+          "scene-role"
+        ],
+        "produces": [
+          "character-beats"
+        ],
+        "requires": [
+          "scene-context"
+        ]
+      },
+      "task_ids": [
+        "npc-generation"
+      ]
+    }
+  ],
   "tasks": [
     {
       "id": "scene-setup",
@@ -18,6 +112,16 @@
         "Scene starts after a successful Athenaeum adventure",
         "At least three existing party characters appear with distinct voices"
       ],
+      "expected_outputs": [
+        "story-artifact"
+      ],
+      "gates": [
+        "continuity"
+      ],
+      "attempts": {
+        "max": 2,
+        "used": 0
+      },
       "output_artifacts": [
         "examples/org-proofs/athenaeum-tavern-story/three-act-story.md"
       ]
@@ -34,6 +138,16 @@
         "At least one tavern NPC affects the scene",
         "At least one NPC is persisted as compact generated team metadata"
       ],
+      "expected_outputs": [
+        "generated-talent"
+      ],
+      "gates": [
+        "continuity"
+      ],
+      "attempts": {
+        "max": 2,
+        "used": 0
+      },
       "output_artifacts": [
         "examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml"
       ]
@@ -51,6 +165,17 @@
         "Continuity report has a clear verdict",
         "World state records consequences, open hooks, and NPC persistence"
       ],
+      "expected_outputs": [
+        "continuity-report",
+        "world-state"
+      ],
+      "gates": [
+        "continuity"
+      ],
+      "attempts": {
+        "max": 1,
+        "used": 0
+      },
       "output_artifacts": [
         "examples/org-proofs/athenaeum-tavern-story/continuity-report.json",
         "examples/org-proofs/athenaeum-tavern-story/world-state.json"

--- a/examples/org-proofs/athenaeum-tavern-story/talent-evaluation-storyteller.json
+++ b/examples/org-proofs/athenaeum-tavern-story/talent-evaluation-storyteller.json
@@ -19,6 +19,16 @@
       "outcome": "completed"
     }
   ],
+  "assignment": {
+    "source": "catalog",
+    "reason": "Storyteller leads the climb, coordinates scene pressure, and aggregates the story artifact.",
+    "lifecycle": "resident",
+    "state": "running",
+    "task_ids": [
+      "scene-setup",
+      "npc-generation"
+    ]
+  },
   "produced_artifacts": [
     "examples/org-proofs/athenaeum-tavern-story/three-act-story.md",
     "examples/org-proofs/athenaeum-tavern-story/world-state.json"

--- a/examples/org-proofs/athenaeum-tavern-story/talent-evaluation-tavernkeep-mara.json
+++ b/examples/org-proofs/athenaeum-tavern-story/talent-evaluation-tavernkeep-mara.json
@@ -14,6 +14,15 @@
       "outcome": "completed"
     }
   ],
+  "assignment": {
+    "source": "generated",
+    "reason": "Mara was generated for a scene-local tavern role and proposed for recurring reuse.",
+    "lifecycle": "ephemeral",
+    "state": "spawned_new",
+    "task_ids": [
+      "npc-generation"
+    ]
+  },
   "produced_artifacts": [
     "examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml"
   ],

--- a/examples/org-proofs/relay-ide-software-company/org-plan.json
+++ b/examples/org-proofs/relay-ide-software-company/org-plan.json
@@ -213,8 +213,7 @@
         "code-changes"
       ],
       "gates": [
-        "code-review",
-        "runtime-qa"
+        "code-review"
       ],
       "attempts": {
         "max": 2,
@@ -260,6 +259,7 @@
       "stage": "task",
       "authority": "blocking",
       "input_artifacts": [
+        "artifacts/relay-ide/port-allocator-analysis.md",
         "artifacts/relay-ide/implementation-notes.md"
       ],
       "output_artifact": "gate-result",

--- a/examples/org-proofs/relay-ide-software-company/org-plan.json
+++ b/examples/org-proofs/relay-ide-software-company/org-plan.json
@@ -5,6 +5,171 @@
   "context_artifacts": [
     "https://github.com/donovan-yohan/relay-ide/issues/320"
   ],
+  "assignments": [
+    {
+      "talent": "supervisor",
+      "source": "project",
+      "reason": "Lead the climb, decompose the operator request, and request acceptance when evidence is ready.",
+      "activation": {
+        "mode": "climb_start"
+      },
+      "runtime": {
+        "lifecycle": "resident",
+        "idle_after": "session_complete",
+        "resume": "hermes_session"
+      },
+      "contract": {
+        "accepts": [
+          "operator-request",
+          "gate-result"
+        ],
+        "produces": [
+          "org-plan",
+          "org-retro"
+        ],
+        "requires": [
+          "repo-workspace"
+        ]
+      },
+      "task_ids": [
+        "task-1",
+        "task-2",
+        "task-3"
+      ]
+    },
+    {
+      "talent": "backend-dev",
+      "source": "catalog",
+      "reason": "PortAllocator path ownership and implementation are backend/runtime work.",
+      "activation": {
+        "mode": "on_demand",
+        "triggers": [
+          "direct_mail",
+          "task-assignment"
+        ]
+      },
+      "runtime": {
+        "lifecycle": "resumable",
+        "idle_after": "task_done",
+        "resume": "hermes_session"
+      },
+      "contract": {
+        "accepts": [
+          "task",
+          "direct-mail"
+        ],
+        "produces": [
+          "implementation-notes",
+          "code-changes"
+        ],
+        "requires": [
+          "repo-workspace"
+        ]
+      },
+      "task_ids": [
+        "task-1",
+        "task-2"
+      ]
+    },
+    {
+      "talent": "qa",
+      "source": "catalog",
+      "reason": "Runtime evidence is required before session acceptance.",
+      "activation": {
+        "mode": "gate_triggered",
+        "triggers": [
+          "gate:runtime-qa"
+        ]
+      },
+      "runtime": {
+        "lifecycle": "resumable",
+        "idle_after": "gate_result_submitted",
+        "resume": "hermes_session"
+      },
+      "contract": {
+        "accepts": [
+          "gate-request",
+          "artifact-review"
+        ],
+        "produces": [
+          "runtime-qa",
+          "gate-result"
+        ],
+        "requires": [
+          "repo-workspace"
+        ]
+      },
+      "task_ids": [
+        "task-3"
+      ]
+    },
+    {
+      "talent": "reviewer",
+      "source": "catalog",
+      "reason": "Code review is a blocking gate before final acceptance.",
+      "activation": {
+        "mode": "gate_triggered",
+        "triggers": [
+          "gate:code-review"
+        ]
+      },
+      "runtime": {
+        "lifecycle": "resumable",
+        "idle_after": "gate_result_submitted",
+        "resume": "hermes_session"
+      },
+      "contract": {
+        "accepts": [
+          "gate-request",
+          "artifact-review"
+        ],
+        "produces": [
+          "review-report",
+          "gate-result"
+        ],
+        "requires": [
+          "repo-workspace"
+        ]
+      },
+      "task_ids": [
+        "task-1",
+        "task-2"
+      ]
+    },
+    {
+      "talent": "pm",
+      "source": "project",
+      "reason": "The built-in acceptance gate remains the final session-level verifier.",
+      "activation": {
+        "mode": "gate_triggered",
+        "triggers": [
+          "completion_requested"
+        ]
+      },
+      "runtime": {
+        "lifecycle": "ephemeral",
+        "idle_after": "gate_result_submitted",
+        "resume": "none"
+      },
+      "contract": {
+        "accepts": [
+          "completion-request",
+          "org-plan",
+          "gate-result"
+        ],
+        "produces": [
+          "verification-report",
+          "gate-result"
+        ],
+        "requires": [
+          "repo-workspace"
+        ]
+      },
+      "task_ids": [
+        "task-3"
+      ]
+    }
+  ],
   "tasks": [
     {
       "id": "task-1",
@@ -16,6 +181,16 @@
         "Identify where configPath resolves to ./config.json in local dev",
         "Find tests covering port allocator path behavior"
       ],
+      "expected_outputs": [
+        "port-allocator-analysis"
+      ],
+      "gates": [
+        "code-review"
+      ],
+      "attempts": {
+        "max": 2,
+        "used": 0
+      },
       "output_artifacts": [
         "artifacts/relay-ide/port-allocator-analysis.md"
       ]
@@ -33,6 +208,18 @@
         "Path is keyed by repo or workspace identity",
         "Existing root file is migrated or safely ignored"
       ],
+      "expected_outputs": [
+        "implementation-notes",
+        "code-changes"
+      ],
+      "gates": [
+        "code-review",
+        "runtime-qa"
+      ],
+      "attempts": {
+        "max": 2,
+        "used": 0
+      },
       "output_artifacts": [
         "artifacts/relay-ide/implementation-notes.md"
       ]
@@ -50,6 +237,18 @@
         "Multiple worktrees do not collide",
         "Repo root does not receive port-assignments.json"
       ],
+      "expected_outputs": [
+        "runtime-qa",
+        "gate-result"
+      ],
+      "gates": [
+        "runtime-qa",
+        "acceptance"
+      ],
+      "attempts": {
+        "max": 2,
+        "used": 0
+      },
       "output_artifacts": [
         "artifacts/relay-ide/runtime-qa.md"
       ]

--- a/examples/org-proofs/relay-ide-software-company/talent-evaluation-backend-dev.json
+++ b/examples/org-proofs/relay-ide-software-company/talent-evaluation-backend-dev.json
@@ -19,6 +19,16 @@
       "outcome": "blocked"
     }
   ],
+  "assignment": {
+    "source": "catalog",
+    "reason": "Backend/runtime ownership matched the PortAllocator path task.",
+    "lifecycle": "resumable",
+    "state": "assigned",
+    "task_ids": [
+      "task-1",
+      "task-2"
+    ]
+  },
   "produced_artifacts": [
     "examples/org-proofs/relay-ide-software-company/org-plan.json"
   ],

--- a/examples/talent-catalog/story/continuity-editor/talent.yaml
+++ b/examples/talent-catalog/story/continuity-editor/talent.yaml
@@ -1,12 +1,40 @@
 schema_version: "belayer-talent/v1"
 name: continuity-editor
 category: story
-kind: side
 summary: "Gate talent for story continuity and tone"
+role: "continuity editor"
+domain: "story"
 capabilities:
   - continuity-check
   - tone-check
   - canon-review
+activation:
+  mode: gate_triggered
+  triggers:
+    - gate:continuity
+runtime:
+  lifecycle: resumable
+  idle_after: gate_result_submitted
+  resume: hermes_session
+contract:
+  accepts:
+    - gate-request
+    - story-artifact
+    - world-state
+  produces:
+    - continuity-report
+    - gate-result
+  requires:
+    - world-context
+authority:
+  tools: []
+  gates:
+    - continuity
+memory:
+  scope: crag
+retention:
+  scope: crag
+  promotion: proposed
 compatible_adapters:
   - hermes-plugin
 default_gates:

--- a/examples/talent-catalog/story/lorekeeper/talent.yaml
+++ b/examples/talent-catalog/story/lorekeeper/talent.yaml
@@ -1,11 +1,38 @@
 schema_version: "belayer-talent/v1"
 name: lorekeeper
 category: story
-kind: side
 summary: "Maintains durable world state and open story threads"
+role: "lorekeeper"
+domain: "worldbuilding"
 capabilities:
   - world-state
   - continuity-memory
+activation:
+  mode: on_demand
+  triggers:
+    - direct_mail
+    - task:world-state
+runtime:
+  lifecycle: resumable
+  idle_after: task_done
+  resume: hermes_session
+contract:
+  accepts:
+    - task
+    - world-state-update
+  produces:
+    - world-state
+    - continuity-notes
+  requires:
+    - world-context
+authority:
+  tools: []
+  gates: []
+memory:
+  scope: crag
+retention:
+  scope: crag
+  promotion: proposed
 compatible_adapters:
   - hermes-plugin
 default_gates: []

--- a/examples/talent-catalog/story/storyteller/talent.yaml
+++ b/examples/talent-catalog/story/storyteller/talent.yaml
@@ -1,12 +1,39 @@
 schema_version: "belayer-talent/v1"
 name: storyteller
 category: story
-kind: main
 summary: "Narrator and scene coordinator for story-world runs"
+role: "storyteller"
+domain: "story"
 capabilities:
   - scene-framing
   - character-coordination
   - story-artifacts
+activation:
+  mode: climb_start
+runtime:
+  lifecycle: resident
+  idle_after: session_complete
+  resume: hermes_session
+contract:
+  accepts:
+    - story-premise
+    - continuity-feedback
+  produces:
+    - org-plan
+    - story-artifact
+    - org-retro
+  requires:
+    - world-context
+authority:
+  tools:
+    - belayer_spawn_agent
+    - belayer_request_completion
+  gates: []
+memory:
+  scope: crag
+retention:
+  scope: crag
+  promotion: proposed
 compatible_adapters:
   - hermes-plugin
 default_gates:

--- a/internal/agentlint/proof_examples_test.go
+++ b/internal/agentlint/proof_examples_test.go
@@ -163,11 +163,13 @@ func TestOrgProofPlansCarryTalentLifecycleAssignments(t *testing.T) {
 				t.Fatalf("%s: assignment is %T, want object", path, item)
 			}
 			activation, ok := assignment["activation"].(map[string]any)
-			if !ok || activation["mode"] == "" {
+			mode, modeOK := activation["mode"].(string)
+			if !ok || !modeOK || strings.TrimSpace(mode) == "" {
 				t.Errorf("%s: assignment %v missing activation.mode", path, assignment["talent"])
 			}
 			runtime, ok := assignment["runtime"].(map[string]any)
-			if !ok || runtime["lifecycle"] == "" {
+			lifecycle, lifecycleOK := runtime["lifecycle"].(string)
+			if !ok || !lifecycleOK || strings.TrimSpace(lifecycle) == "" {
 				t.Errorf("%s: assignment %v missing runtime.lifecycle", path, assignment["talent"])
 			}
 			contract, ok := assignment["contract"].(map[string]any)
@@ -226,10 +228,12 @@ func TestTalentEvaluationsRecordAssignmentLifecycle(t *testing.T) {
 			t.Errorf("%s: missing assignment", path)
 			return nil
 		}
-		if assignment["lifecycle"] == "" {
+		lifecycle, lifecycleOK := assignment["lifecycle"].(string)
+		if !lifecycleOK || strings.TrimSpace(lifecycle) == "" {
 			t.Errorf("%s: missing assignment.lifecycle", path)
 		}
-		if assignment["state"] == "" {
+		state, stateOK := assignment["state"].(string)
+		if !stateOK || strings.TrimSpace(state) == "" {
 			t.Errorf("%s: missing assignment.state", path)
 		}
 		requireNonEmptyJSONArray(t, path, assignment, "task_ids")

--- a/internal/agentlint/proof_examples_test.go
+++ b/internal/agentlint/proof_examples_test.go
@@ -143,6 +143,107 @@ func TestOrgProofExamplesPersistGeneratedStoryTalent(t *testing.T) {
 	}
 }
 
+func TestOrgProofPlansCarryTalentLifecycleAssignments(t *testing.T) {
+	root := repoRoot(t)
+	proofRoot := filepath.Join(root, "examples", "org-proofs")
+	plans := []string{
+		filepath.Join(proofRoot, "relay-ide-software-company", "org-plan.json"),
+		filepath.Join(proofRoot, "athenaeum-tavern-story", "org-plan.json"),
+	}
+
+	for _, path := range plans {
+		plan := readJSONMap(t, path)
+		assignments, ok := plan["assignments"].([]any)
+		if !ok || len(assignments) == 0 {
+			t.Fatalf("%s: missing assignments", path)
+		}
+		for _, item := range assignments {
+			assignment, ok := item.(map[string]any)
+			if !ok {
+				t.Fatalf("%s: assignment is %T, want object", path, item)
+			}
+			activation, ok := assignment["activation"].(map[string]any)
+			if !ok || activation["mode"] == "" {
+				t.Errorf("%s: assignment %v missing activation.mode", path, assignment["talent"])
+			}
+			runtime, ok := assignment["runtime"].(map[string]any)
+			if !ok || runtime["lifecycle"] == "" {
+				t.Errorf("%s: assignment %v missing runtime.lifecycle", path, assignment["talent"])
+			}
+			contract, ok := assignment["contract"].(map[string]any)
+			if !ok {
+				t.Errorf("%s: assignment %v missing contract", path, assignment["talent"])
+				continue
+			}
+			requireNonEmptyJSONArray(t, path, contract, "accepts")
+			requireNonEmptyJSONArray(t, path, contract, "produces")
+		}
+	}
+}
+
+func TestOrgProofPlanTasksBindOutputsAndGates(t *testing.T) {
+	root := repoRoot(t)
+	proofRoot := filepath.Join(root, "examples", "org-proofs")
+	plans := []string{
+		filepath.Join(proofRoot, "relay-ide-software-company", "org-plan.json"),
+		filepath.Join(proofRoot, "athenaeum-tavern-story", "org-plan.json"),
+	}
+
+	for _, path := range plans {
+		plan := readJSONMap(t, path)
+		tasks, ok := plan["tasks"].([]any)
+		if !ok || len(tasks) == 0 {
+			t.Fatalf("%s: missing tasks", path)
+		}
+		for _, item := range tasks {
+			task, ok := item.(map[string]any)
+			if !ok {
+				t.Fatalf("%s: task is %T, want object", path, item)
+			}
+			requireNonEmptyJSONArray(t, path, task, "expected_outputs")
+			requireNonEmptyJSONArray(t, path, task, "gates")
+		}
+	}
+}
+
+func TestTalentEvaluationsRecordAssignmentLifecycle(t *testing.T) {
+	root := repoRoot(t)
+	proofRoot := filepath.Join(root, "examples", "org-proofs")
+
+	checked := 0
+	err := filepath.WalkDir(proofRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		base := filepath.Base(path)
+		if d.IsDir() || !strings.HasPrefix(base, "talent-evaluation-") || !strings.HasSuffix(base, ".json") {
+			return nil
+		}
+
+		evaluation := readJSONMap(t, path)
+		assignment, ok := evaluation["assignment"].(map[string]any)
+		if !ok {
+			t.Errorf("%s: missing assignment", path)
+			return nil
+		}
+		if assignment["lifecycle"] == "" {
+			t.Errorf("%s: missing assignment.lifecycle", path)
+		}
+		if assignment["state"] == "" {
+			t.Errorf("%s: missing assignment.state", path)
+		}
+		requireNonEmptyJSONArray(t, path, assignment, "task_ids")
+		checked++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", proofRoot, err)
+	}
+	if checked == 0 {
+		t.Fatalf("no talent evaluations checked under %s", proofRoot)
+	}
+}
+
 func TestOrgProofExamplesAllJSONHasSchemaVersion(t *testing.T) {
 	root := repoRoot(t)
 	proofRoot := filepath.Join(root, "examples", "org-proofs")
@@ -177,6 +278,14 @@ func readJSONMap(t *testing.T, path string) map[string]any {
 		t.Fatalf("%s: invalid JSON: %v", path, err)
 	}
 	return artifact
+}
+
+func requireNonEmptyJSONArray(t *testing.T, path string, object map[string]any, key string) {
+	t.Helper()
+	items, ok := object[key].([]any)
+	if !ok || len(items) == 0 {
+		t.Errorf("%s: missing non-empty %s", path, key)
+	}
 }
 
 func jsonObjectArrayContains(items []any, key, want string) bool {

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -105,6 +105,29 @@ func agentRunIsMain(run store.AgentRun) bool {
 	return !agentRunIsSide(run)
 }
 
+func agentRunStatusIsTerminal(status string) bool {
+	switch status {
+	case "complete", "blocked", "incomplete", "exited", "failed":
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *Daemon) markAgentRunRunningUnlessTerminal(sessionID, name string) (store.AgentRun, error) {
+	current, err := d.store.GetAgentRun(sessionID, name)
+	if err != nil {
+		return store.AgentRun{}, err
+	}
+	if agentRunStatusIsTerminal(current.Status) {
+		return current, nil
+	}
+	if err := d.store.UpdateAgentRunStatus(sessionID, name, "running"); err != nil {
+		return store.AgentRun{}, err
+	}
+	return d.store.GetAgentRun(sessionID, name)
+}
+
 func (d *Daemon) lockSpawnSession(sessionID string) func() {
 	d.spawnSessionMu.Lock()
 	mu := d.spawnSessionLocks[sessionID]
@@ -361,11 +384,7 @@ func (d *Daemon) handleSpawnAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := d.store.UpdateAgentRunStatus(sessionID, req.Name, "running"); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-	stored, err := d.store.GetAgentRun(sessionID, req.Name)
+	stored, err := d.markAgentRunRunningUnlessTerminal(sessionID, req.Name)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -1076,13 +1095,9 @@ func (d *Daemon) spawnAgentInternal(req agentSpawnRequest) (store.AgentRun, erro
 		}
 	}
 
-	if err := d.store.UpdateAgentRunStatus(req.SessionID, req.Name, "running"); err != nil {
-		return store.AgentRun{}, fmt.Errorf("update running status: %w", err)
-	}
-
-	stored, err := d.store.GetAgentRun(req.SessionID, req.Name)
+	stored, err := d.markAgentRunRunningUnlessTerminal(req.SessionID, req.Name)
 	if err != nil {
-		return store.AgentRun{}, fmt.Errorf("get agent run: %w", err)
+		return store.AgentRun{}, fmt.Errorf("update running status: %w", err)
 	}
 
 	if proc != nil {

--- a/internal/daemon/agents_resume_test.go
+++ b/internal/daemon/agents_resume_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -110,5 +111,49 @@ func TestSpawnAgent_FreshWhenNoPrior(t *testing.T) {
 	}
 	if seen[0] != "" {
 		t.Errorf("spawnBridgeAgent received HermesSessionID = %q, want empty (no resume)", seen[0])
+	}
+}
+
+func TestSpawnAgent_DoesNotOverwriteBridgeFinishedDuringStartup(t *testing.T) {
+	d := testDaemon(t)
+	rr := doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "fast-finish"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create session: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	sess := decodeJSON[sessionAPIResponse](t, rr)
+
+	d.spawnBridgeAgent = func(req agentSpawnRequest) (*bridge.Process, error) {
+		postBridgeEvent(t, d, req.SessionID, "bridge:finished", map[string]any{
+			"agent":          req.Name,
+			"final_response": "finished before spawn bookkeeping caught up",
+		})
+		return nil, nil
+	}
+
+	run, err := d.spawnAgentInternal(agentSpawnRequest{
+		SessionID: sess.ID,
+		Name:      "qa",
+		Role:      "qa",
+		Kind:      "side",
+		Profile:   "default",
+		Workdir:   t.TempDir(),
+		Message:   "quick check",
+	})
+	if err != nil {
+		t.Fatalf("spawnAgentInternal: %v", err)
+	}
+	if run.Status != "complete" {
+		t.Fatalf("spawnAgentInternal returned status %q, want complete", run.Status)
+	}
+
+	stored, err := d.store.GetAgentRun(sess.ID, "qa")
+	if err != nil {
+		t.Fatalf("GetAgentRun: %v", err)
+	}
+	if stored.Status != "complete" {
+		t.Fatalf("stored status = %q, want complete", stored.Status)
+	}
+	if stored.Outcome != "succeeded" {
+		t.Fatalf("stored outcome = %q, want succeeded", stored.Outcome)
 	}
 }

--- a/internal/daemon/messages.go
+++ b/internal/daemon/messages.go
@@ -75,9 +75,34 @@ func (d *Daemon) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Reject messages to agents that have exited the session.
+	// Reject messages to agents that have exited the session, except completed
+	// side agents with a Hermes session: those are dormant resumable talent and
+	// direct mail is the wake signal.
 	if target, err := d.store.GetAgentRun(id, req.To); err == nil {
-		if target.Status == "complete" || target.Status == "blocked" || target.Status == "incomplete" || target.Status == "exited" {
+		if agentRunStatusIsTerminal(target.Status) {
+			if agentRunIsWakeableDormantSide(target) {
+				msgID, from, wakeErr := d.wakeDormantSideFromMessage(id, target, req)
+				if wakeErr != nil {
+					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": wakeErr.Error()})
+					return
+				}
+				data := mustJSON(map[string]any{
+					"id":        msgID,
+					"to":        req.To,
+					"from":      from,
+					"content":   req.Content,
+					"type":      req.Type,
+					"interrupt": req.Interrupt,
+					"delivery":  "wake_spawn",
+					"sent_at":   time.Now().UTC().Format(time.RFC3339Nano),
+				})
+				if err := d.store.LogEvent(store.SessionEvent{SessionID: id, Type: "message_sent", Data: data}); err != nil {
+					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+					return
+				}
+				writeJSON(w, http.StatusCreated, map[string]string{"id": msgID})
+				return
+			}
 			writeJSON(w, http.StatusGone, map[string]string{
 				"error": "agent '" + req.To + "' has exited (status: " + target.Status + "). Use belayer_spawn_agent to re-spawn with conversation history.",
 			})
@@ -164,6 +189,36 @@ func (d *Daemon) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]string{"id": msgID})
+}
+
+func agentRunIsWakeableDormantSide(run store.AgentRun) bool {
+	return agentRunIsSide(run) && run.Status == "complete" && run.HermesSessionID != ""
+}
+
+func (d *Daemon) wakeDormantSideFromMessage(sessionID string, target store.AgentRun, req sendMessageRequest) (string, string, error) {
+	msgID := uuid.New().String()
+	from := req.From
+	if from == "" {
+		from = "operator"
+	}
+
+	wakeMessage := fmt.Sprintf("Resume from your prior Hermes conversation. New message from %s:\n\n%s", from, req.Content)
+	_, err := d.spawnAgentInternal(agentSpawnRequest{
+		SessionID:       sessionID,
+		Name:            target.Name,
+		Role:            target.Role,
+		Kind:            target.Kind,
+		Profile:         target.Profile,
+		Repo:            target.RepoScope,
+		Workdir:         target.Workdir,
+		Branch:          target.Branch,
+		HermesSessionID: target.HermesSessionID,
+		Message:         wakeMessage,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("wake dormant side %q: %w", target.Name, err)
+	}
+	return msgID, from, nil
 }
 
 func (d *Daemon) handleBroadcastMessage(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/messages_surface_test.go
+++ b/internal/daemon/messages_surface_test.go
@@ -3,8 +3,10 @@ package daemon
 import (
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/donovan-yohan/belayer/internal/bridge"
 	"github.com/donovan-yohan/belayer/internal/store"
 )
 
@@ -71,6 +73,72 @@ func TestSendMessageEnforcesMainAndSideSurfaces(t *testing.T) {
 	msgsRR := doRequest(t, d, "GET", "/sessions/"+created.ID+"/messages?for=pm", nil)
 	if msgsRR.Code != http.StatusBadRequest {
 		t.Fatalf("expected side inbox listing to be rejected, got %d: %s", msgsRR.Code, msgsRR.Body.String())
+	}
+}
+
+func TestSendMessageWakesCompletedSideWithHermesSession(t *testing.T) {
+	d := testDaemon(t)
+	created := decodeJSON[sessionAPIResponse](t, doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "wake-side"}))
+	workdir := t.TempDir()
+	if _, err := d.store.CreateAgentRun(store.AgentRun{
+		SessionID:       created.ID,
+		Name:            "qa",
+		Role:            "qa",
+		Kind:            "side",
+		Profile:         "default",
+		Workdir:         workdir,
+		Status:          "complete",
+		Outcome:         "succeeded",
+		Transport:       "bridge",
+		HermesSessionID: "hermes-qa-123",
+	}); err != nil {
+		t.Fatalf("CreateAgentRun qa: %v", err)
+	}
+
+	var mu sync.Mutex
+	var seen []agentSpawnRequest
+	d.spawnBridgeAgent = func(req agentSpawnRequest) (*bridge.Process, error) {
+		mu.Lock()
+		seen = append(seen, req)
+		mu.Unlock()
+		return nil, nil
+	}
+
+	rr := doRequest(t, d, "POST", "/sessions/"+created.ID+"/messages", sendMessageRequest{
+		From:    "supervisor",
+		To:      "qa",
+		Content: "Please re-check the latest implementation.",
+		Type:    "instruction",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected wake delivery to completed side, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != 1 {
+		t.Fatalf("spawnBridgeAgent call count = %d, want 1", len(seen))
+	}
+	req := seen[0]
+	if req.Name != "qa" || req.Kind != "side" || req.Role != "qa" || req.Profile != "default" {
+		t.Fatalf("unexpected wake spawn request identity fields: %#v", req)
+	}
+	if req.Workdir != workdir {
+		t.Fatalf("wake spawn workdir = %q, want %q", req.Workdir, workdir)
+	}
+	if req.HermesSessionID != "hermes-qa-123" {
+		t.Fatalf("wake spawn HermesSessionID = %q, want hermes-qa-123", req.HermesSessionID)
+	}
+	if !strings.Contains(req.Message, "supervisor") || !strings.Contains(req.Message, "Please re-check") {
+		t.Fatalf("wake spawn message did not preserve sender/content: %q", req.Message)
+	}
+
+	msgs, err := d.store.ListMessagesInSession(created.ID)
+	if err != nil {
+		t.Fatalf("ListMessagesInSession: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("wake delivery to a side should not create mailbox rows, got %#v", msgs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #119.

This PR formalizes the lazy talent lifecycle contract we discussed for Crag/OMC-style org runs:

- Defines the public talent metadata shape around role/domain, activation, runtime lifecycle, typed contract, authority, memory, and retention.
- Separates current bridge `kind`/`ephemeral` mechanics from the future `resident | resumable | ephemeral` talent lifecycle model.
- Extends org-plan and talent-evaluation schemas so assignments, task-scoped outputs/gates, and lifecycle evidence are durable artifacts.
- Updates software-company and story-world proof examples to exercise the contract, including generated talent retention.
- Adds agentlint regressions to keep proof examples from dropping lifecycle assignments or task bindings.

## Runtime follow-up

This is the docs/schema/proof-example step. The daemon wake-on-mail implementation remains the next runtime step: assigned dormant resumable talent plus direct mail should spawn with the prior Hermes session, while broadcasts stay scoped to live resident recipients by default.

## Verification

- `jq empty docs/artifact-schemas/org-plan.schema.json docs/artifact-schemas/talent-evaluation.schema.json examples/org-proofs/relay-ide-software-company/org-plan.json examples/org-proofs/athenaeum-tavern-story/org-plan.json examples/org-proofs/relay-ide-software-company/talent-evaluation-backend-dev.json examples/org-proofs/athenaeum-tavern-story/talent-evaluation-storyteller.json examples/org-proofs/athenaeum-tavern-story/talent-evaluation-tavernkeep-mara.json`
- `go test ./internal/agentlint`
- `go test ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised architecture, CRAG mode, and design docs adding a talent lifecycle taxonomy (resident/resumable/ephemeral), lifecycle guidance, and contract-oriented terminology.

* **New Features**
  * Talent metadata now includes role/domain, activation, runtime.lifecycle, contract, authority, memory/retention.
  * Org plans and schemas require assignments; tasks must declare expected_outputs, gates, and attempts.
  * Talent evaluations include assignment lifecycle, state, and task_ids.

* **Bug Fixes**
  * Message sends can wake eligible completed side runs (returns 201); daemon avoids overwriting terminal run states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->