### PR TITLE
feat: persist generated talent records

### DIFF
--- a/docs/ARTIFACT_SCHEMAS.md
+++ b/docs/ARTIFACT_SCHEMAS.md
@@ -28,6 +28,8 @@ The artifact file at `path` should then follow the schema for its `kind`.
 | Kind | Schema | Producer | Purpose |
 |------|--------|----------|---------|
 | `org-plan` | [`org-plan.schema.json`](artifact-schemas/org-plan.schema.json) | lead talent | Task graph, assignments, dependencies, and gate plan |
+| `talent-request` | [`talent-request.schema.json`](artifact-schemas/talent-request.schema.json) | coordinator talent | Mechanical request for a role/domain/lifecycle without domain-specific semantics |
+| `generated-talent` | [`generated-talent.schema.json`](artifact-schemas/generated-talent.schema.json) | coordinator talent or operator | Compact generated talent metadata selected for possible reuse |
 | `gate-result` | [`gate-result.schema.json`](artifact-schemas/gate-result.schema.json) | gate talent | Generic verdict from QA, reviewer, PM, continuity editor, or any custom gate |
 | `org-retro` | [`org-retro.schema.json`](artifact-schemas/org-retro.schema.json) | lead talent | Lessons, bottlenecks, and catalog/prompt follow-ups after a run |
 | `talent-evaluation` | [`talent-evaluation.schema.json`](artifact-schemas/talent-evaluation.schema.json) | lead or gate talent | Per-run performance evidence and growth recommendations for one talent |

--- a/docs/CRAG_FILESYSTEM.md
+++ b/docs/CRAG_FILESYSTEM.md
@@ -249,12 +249,14 @@ proposals stay auditable but do not alter crag state.
 
 ### `generated-talents/`
 
-Generated talents are short-lived workers or NPCs that were created during a
-climb and then selected for possible reuse.
+Generated talents are short-lived, bounded talents that were requested during a
+climb and then selected for possible reuse. Belayer stores them mechanically by
+domain, role, lifecycle, source request, and caller-provided metadata. Product
+meaning stays outside Belayer.
 
 ```text
 generated-talents/
-└── tavernkeep-mara/
+└── generated-reviewer-1/
     ├── talent.yaml
     └── notes.md
 ```
@@ -262,16 +264,18 @@ generated-talents/
 Minimal generated talent metadata:
 
 ```yaml
-schema_version: "belayer-generated-talent/v1"
-name: tavernkeep-mara
-category: story
-status: candidate
-origin:
-  session_id: "<session-id>"
-  first_artifact: "artifacts/stories/tavern-celebration.md"
-role: "tavernkeep"
-summary: "Warm, watchful innkeeper who remembers debts and rumors"
-reuse_policy: scene-local # options: scene-local | recurring | promoted
+schema_version: belayer-generated-talent/v1
+id: generated-reviewer-1
+domain: development
+role: reviewer
+lifecycle: ephemeral
+status: generated
+source_request: task-42
+reason: "The lead requested a bounded second opinion."
+metadata:
+  specialty: api-contracts
+promotion_evidence:
+  - artifacts/talent-evaluation-generated-reviewer-1.json
 ```
 
 Generated talents do not become full `.belayer/agents/` identities by default.

--- a/docs/CRAG_FILESYSTEM.md
+++ b/docs/CRAG_FILESYSTEM.md
@@ -258,7 +258,7 @@ meaning stays outside Belayer.
 generated-talents/
 └── generated-reviewer-1/
     ├── talent.yaml
-    └── notes.md
+    └── notes.md   # optional
 ```
 
 Minimal generated talent metadata:

--- a/docs/artifact-schemas/generated-talent.schema.json
+++ b/docs/artifact-schemas/generated-talent.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/donovan-yohan/belayer/docs/artifact-schemas/generated-talent.schema.json",
+  "title": "Belayer Generated Talent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "domain", "role", "lifecycle", "status", "source_request", "reason"],
+  "properties": {
+    "schema_version": {
+      "const": "belayer-generated-talent/v1"
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "domain": {
+      "type": "string",
+      "minLength": 1
+    },
+    "role": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lifecycle": {
+      "enum": ["resident", "resumable", "ephemeral"]
+    },
+    "status": {
+      "enum": ["generated", "promoted", "retired", "discarded"]
+    },
+    "source_request": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "promotion_evidence": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/docs/artifact-schemas/generated-talent.schema.json
+++ b/docs/artifact-schemas/generated-talent.schema.json
@@ -5,6 +5,26 @@
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "id", "domain", "role", "lifecycle", "status", "source_request", "reason"],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "promoted"
+          }
+        },
+        "required": ["status"]
+      },
+      "then": {
+        "required": ["promotion_evidence"],
+        "properties": {
+          "promotion_evidence": {
+            "minItems": 1
+          }
+        }
+      }
+    }
+  ],
   "properties": {
     "schema_version": {
       "const": "belayer-generated-talent/v1"

--- a/docs/artifact-schemas/talent-request.schema.json
+++ b/docs/artifact-schemas/talent-request.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/donovan-yohan/belayer/docs/artifact-schemas/talent-request.schema.json",
+  "title": "Belayer Talent Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "request_id", "requester", "domain", "role", "lifecycle", "reason", "expected_outputs"],
+  "properties": {
+    "schema_version": {
+      "const": "belayer-talent-request/v1"
+    },
+    "request_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "requester": {
+      "type": "string",
+      "minLength": 1
+    },
+    "domain": {
+      "type": "string",
+      "minLength": 1
+    },
+    "role": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lifecycle": {
+      "enum": ["resident", "resumable", "ephemeral"]
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "context_artifacts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "expected_outputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "constraints": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml
+++ b/examples/org-proofs/athenaeum-tavern-story/generated-talents/tavernkeep-mara/talent.yaml
@@ -1,51 +1,16 @@
-schema_version: "belayer-generated-talent/v1"
-name: mara-underbough
-category: story
-status: candidate
-origin:
-  session_id: "example-athenaeum-tavern"
-  first_artifact: "examples/org-proofs/athenaeum-tavern-story/three-act-story.md"
-role: "tavernkeep"
-domain: "story"
-summary: "Warm, watchful keeper of the Last Lantern who remembers debts, house rules, and rumors."
-capabilities:
-  - scene-role
-  - location-anchor
-  - rumor-delivery
-activation:
-  mode: generated
-runtime:
-  lifecycle: ephemeral
-  idle_after: task_done
-  resume: none
-contract:
-  accepts:
-    - scene-role
-  produces:
-    - character-beats
-  requires:
-    - scene-context
-authority:
-  tools: []
-  gates: []
-memory:
-  scope: project
-retention:
-  scope: crag
-  promotion: proposed
-personality_hooks:
-  - "Practical hospitality with a steel edge"
-  - "Treats magical danger as a customer-service problem until it breaks house rules"
-  - "Knows more family history than she admits at first"
-voice_notes:
-  - "Plainspoken"
-  - "Dry humor"
-  - "Uses house rules as moral philosophy"
-relationships:
-  - "Respects Zara's diplomacy"
-  - "Wary of Thorne's instinct to solve mysteries with refusal"
-continuity_constraints:
-  - "Owns or manages the Last Lantern"
-  - "The tavern is built from archive stone"
-  - "The Last Lantern keeps an Athenaeum door"
-reuse_policy: "recurring"
+schema_version: belayer-generated-talent/v1
+id: tavernkeep-mara
+domain: story
+role: tavernkeep
+lifecycle: ephemeral
+status: generated
+source_request: story-task-2
+reason: "The storyteller needed a bounded location authority for the Athenaeum tavern scene."
+metadata:
+  voice: "plainspoken, dry humor"
+  knowledge_boundary: "knows only facts established in the scene artifacts"
+  reuse_hint: "possible recurring location anchor"
+promotion_evidence:
+  - examples/org-proofs/athenaeum-tavern-story/talent-evaluation-tavernkeep-mara.json
+created_at: "2026-05-01T00:00:00Z"
+updated_at: "2026-05-01T00:00:00Z"

--- a/internal/agentlint/docs_test.go
+++ b/internal/agentlint/docs_test.go
@@ -140,3 +140,42 @@ func TestCragFilesystemContractCoversRequiredScopes(t *testing.T) {
 		}
 	}
 }
+
+func TestGeneratedTalentContractsStayGeneric(t *testing.T) {
+	root := repoRoot(t)
+	for _, rel := range []string{
+		filepath.Join("docs", "artifact-schemas", "talent-request.schema.json"),
+		filepath.Join("docs", "artifact-schemas", "generated-talent.schema.json"),
+	} {
+		path := filepath.Join(root, rel)
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		text := string(raw)
+		for _, forbidden := range []string{"NPC", "npc", "tavern", "DND", "D&D", "quest system"} {
+			if strings.Contains(text, forbidden) {
+				t.Fatalf("%s contains story-specific term %q", path, forbidden)
+			}
+		}
+	}
+
+	docPath := filepath.Join(root, "docs", "CRAG_FILESYSTEM.md")
+	raw, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", docPath, err)
+	}
+	text := string(raw)
+	for _, want := range []string{
+		"belayer-generated-talent/v1",
+		"domain:",
+		"role:",
+		"lifecycle:",
+		"source_request:",
+		"promotion_evidence:",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("%s missing generated talent contract marker %q", docPath, want)
+		}
+	}
+}

--- a/internal/agentlint/proof_examples_test.go
+++ b/internal/agentlint/proof_examples_test.go
@@ -124,22 +124,25 @@ func TestOrgProofExamplesPersistGeneratedStoryTalent(t *testing.T) {
 	if got := talent["schema_version"]; got != "belayer-generated-talent/v1" {
 		t.Errorf("%s: schema_version = %v, want belayer-generated-talent/v1", path, got)
 	}
-	if got := talent["name"]; got != "mara-underbough" {
-		t.Errorf("%s: name = %v, want mara-underbough", path, got)
+	if got := talent["id"]; got != "tavernkeep-mara" {
+		t.Errorf("%s: id = %v, want tavernkeep-mara", path, got)
 	}
-	origin, ok := talent["origin"].(map[string]any)
-	if !ok {
-		t.Fatalf("%s: missing origin object", path)
+	for _, key := range []string{"name", "category", "origin", "continuity_constraints"} {
+		if _, ok := talent[key]; ok {
+			t.Errorf("%s: legacy generated talent field %q should not be present", path, key)
+		}
 	}
-	if got := origin["session_id"]; got != "example-athenaeum-tavern" {
-		t.Errorf("%s: origin.session_id = %v, want example-athenaeum-tavern", path, got)
+	for _, key := range []string{"domain", "role", "lifecycle", "status", "source_request", "reason"} {
+		if value, ok := talent[key].(string); !ok || strings.TrimSpace(value) == "" {
+			t.Errorf("%s: %s = %v, want non-empty string", path, key, talent[key])
+		}
 	}
-	firstArtifact, ok := origin["first_artifact"].(string)
-	if !ok || !strings.Contains(firstArtifact, "athenaeum-tavern-story/three-act-story.md") {
-		t.Errorf("%s: origin.first_artifact = %v, want tavern story artifact", path, origin["first_artifact"])
+	evidence, ok := talent["promotion_evidence"].([]any)
+	if !ok || len(evidence) == 0 {
+		t.Fatalf("%s: promotion_evidence = %v, want non-empty list", path, talent["promotion_evidence"])
 	}
-	if _, ok := talent["continuity_constraints"]; !ok {
-		t.Errorf("%s: missing continuity_constraints", path)
+	if first, ok := evidence[0].(string); !ok || !strings.Contains(first, "talent-evaluation-tavernkeep-mara.json") {
+		t.Errorf("%s: promotion_evidence[0] = %v, want talent evaluation path", path, evidence[0])
 	}
 }
 

--- a/internal/cli/org_talent_test.go
+++ b/internal/cli/org_talent_test.go
@@ -214,6 +214,113 @@ func TestCragInitRejectsInvalidKind(t *testing.T) {
 	}
 }
 
+func TestTalentGeneratedPersistAndList(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BELAYER_HOME", home)
+
+	initCmd := newCragCmd()
+	initCmd.SetOut(&bytes.Buffer{})
+	initCmd.SetErr(&bytes.Buffer{})
+	initCmd.SetArgs([]string{"init", "last-lantern", "--kind", "story"})
+	if err := initCmd.Execute(); err != nil {
+		t.Fatalf("crag init: %v", err)
+	}
+
+	persistCmd := newTeamCmd()
+	persistOut := &bytes.Buffer{}
+	persistCmd.SetOut(persistOut)
+	persistCmd.SetErr(persistOut)
+	persistCmd.SetArgs([]string{
+		"generated", "persist", "last-lantern", "mara-underbough",
+		"--domain", "story",
+		"--role", "tavernkeep",
+		"--lifecycle", "resumable",
+		"--status", "generated",
+		"--source-request", "turn-0002",
+		"--reason", "scene needs a local authority who remembers rumors",
+		"--metadata", "voice=warm and watchful",
+		"--metadata", "constraint=does not know who sent the sealed letter",
+		"--promotion-evidence", "artifacts/talent-evaluation-mara.json",
+		"--note", "First appeared when the player asked about old roads.",
+	})
+	if err := persistCmd.Execute(); err != nil {
+		t.Fatalf("generated persist: %v\n%s", err, persistOut.String())
+	}
+	if !strings.Contains(persistOut.String(), "Persisted generated talent mara-underbough") {
+		t.Fatalf("unexpected persist output: %s", persistOut.String())
+	}
+
+	talentPath := filepath.Join(home, "crags", "last-lantern", "generated-talents", "mara-underbough", "talent.yaml")
+	raw, err := os.ReadFile(talentPath)
+	if err != nil {
+		t.Fatalf("read generated talent: %v", err)
+	}
+	for _, want := range []string{
+		`schema_version: belayer-generated-talent/v1`,
+		`id: mara-underbough`,
+		`domain: story`,
+		`role: tavernkeep`,
+		`lifecycle: resumable`,
+		`status: generated`,
+		`source_request: turn-0002`,
+		`voice: warm and watchful`,
+		`constraint: does not know who sent the sealed letter`,
+		`artifacts/talent-evaluation-mara.json`,
+	} {
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("generated talent missing %q:\n%s", want, string(raw))
+		}
+	}
+	notesPath := filepath.Join(home, "crags", "last-lantern", "generated-talents", "mara-underbough", "notes.md")
+	notes, err := os.ReadFile(notesPath)
+	if err != nil {
+		t.Fatalf("read generated talent notes: %v", err)
+	}
+	if !strings.Contains(string(notes), "First appeared") {
+		t.Fatalf("notes missing first appearance:\n%s", string(notes))
+	}
+
+	listCmd := newTeamCmd()
+	listOut := &bytes.Buffer{}
+	listCmd.SetOut(listOut)
+	listCmd.SetErr(listOut)
+	listCmd.SetArgs([]string{"generated", "list", "last-lantern"})
+	if err := listCmd.Execute(); err != nil {
+		t.Fatalf("generated list: %v", err)
+	}
+	if !strings.Contains(listOut.String(), "mara-underbough\tstory\ttavernkeep\tresumable\tgenerated") {
+		t.Fatalf("generated list missing persisted talent:\n%s", listOut.String())
+	}
+}
+
+func TestTalentGeneratedPersistRejectsInvalidLifecycle(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BELAYER_HOME", home)
+
+	initCmd := newCragCmd()
+	initCmd.SetOut(&bytes.Buffer{})
+	initCmd.SetErr(&bytes.Buffer{})
+	initCmd.SetArgs([]string{"init", "last-lantern"})
+	if err := initCmd.Execute(); err != nil {
+		t.Fatalf("crag init: %v", err)
+	}
+
+	cmd := newTeamCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"generated", "persist", "last-lantern", "mara-underbough",
+		"--domain", "story",
+		"--role", "tavernkeep",
+		"--lifecycle", "sidequest",
+		"--source-request", "turn-0002",
+		"--reason", "scene needs a local authority",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected invalid lifecycle to fail")
+	}
+}
+
 func TestSetCragLinkBlockReplacesExistingBlocks(t *testing.T) {
 	raw := []byte("log_level: standard\norg:\n  name: old\nruntime:\n  max_concurrent_mains: 8\n")
 	got := string(setCragLinkBlock(raw, "new-crag", ""))

--- a/internal/cli/org_talent_test.go
+++ b/internal/cli/org_talent_test.go
@@ -266,6 +266,8 @@ func TestTalentGeneratedPersistAndList(t *testing.T) {
 		`voice: warm and watchful`,
 		`constraint: does not know who sent the sealed letter`,
 		`artifacts/talent-evaluation-mara.json`,
+		`created_at:`,
+		`updated_at:`,
 	} {
 		if !strings.Contains(string(raw), want) {
 			t.Fatalf("generated talent missing %q:\n%s", want, string(raw))
@@ -288,8 +290,97 @@ func TestTalentGeneratedPersistAndList(t *testing.T) {
 	if err := listCmd.Execute(); err != nil {
 		t.Fatalf("generated list: %v", err)
 	}
-	if !strings.Contains(listOut.String(), "mara-underbough\tstory\ttavernkeep\tresumable\tgenerated") {
-		t.Fatalf("generated list missing persisted talent:\n%s", listOut.String())
+	if got := strings.Fields(listOut.String()); len(got) < 5 ||
+		got[0] != "mara-underbough" ||
+		got[1] != "story" ||
+		got[2] != "tavernkeep" ||
+		got[3] != "resumable" ||
+		got[4] != "generated" {
+		t.Fatalf("generated list missing persisted talent fields:\n%s", listOut.String())
+	}
+}
+
+func TestTalentGeneratedPersistRejectsPromotedWithoutEvidence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BELAYER_HOME", home)
+
+	initCmd := newCragCmd()
+	initCmd.SetOut(&bytes.Buffer{})
+	initCmd.SetErr(&bytes.Buffer{})
+	initCmd.SetArgs([]string{"init", "last-lantern"})
+	if err := initCmd.Execute(); err != nil {
+		t.Fatalf("crag init: %v", err)
+	}
+
+	cmd := newTeamCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"generated", "persist", "last-lantern", "mara-underbough",
+		"--domain", "story",
+		"--role", "tavernkeep",
+		"--status", "promoted",
+		"--source-request", "turn-0002",
+		"--reason", "scene needs a local authority",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected promoted status without evidence to fail")
+	}
+}
+
+func TestTalentGeneratedPersistRejectsEmptyPromotionEvidence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BELAYER_HOME", home)
+
+	initCmd := newCragCmd()
+	initCmd.SetOut(&bytes.Buffer{})
+	initCmd.SetErr(&bytes.Buffer{})
+	initCmd.SetArgs([]string{"init", "last-lantern"})
+	if err := initCmd.Execute(); err != nil {
+		t.Fatalf("crag init: %v", err)
+	}
+
+	cmd := newTeamCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"generated", "persist", "last-lantern", "mara-underbough",
+		"--domain", "story",
+		"--role", "tavernkeep",
+		"--source-request", "turn-0002",
+		"--reason", "scene needs a local authority",
+		"--promotion-evidence", " ",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected empty promotion evidence to fail")
+	}
+}
+
+func TestTalentGeneratedListSkipsDanglingDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BELAYER_HOME", home)
+
+	initCmd := newCragCmd()
+	initCmd.SetOut(&bytes.Buffer{})
+	initCmd.SetErr(&bytes.Buffer{})
+	initCmd.SetArgs([]string{"init", "last-lantern"})
+	if err := initCmd.Execute(); err != nil {
+		t.Fatalf("crag init: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "crags", "last-lantern", "generated-talents", "dangling"), 0o755); err != nil {
+		t.Fatalf("mkdir dangling generated talent: %v", err)
+	}
+
+	cmd := newTeamCmd()
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"generated", "list", "last-lantern"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("generated list: %v\n%s", err, out.String())
+	}
+	if out.String() != "" {
+		t.Fatalf("expected dangling dir to be skipped, got:\n%s", out.String())
 	}
 }
 

--- a/internal/cli/talent.go
+++ b/internal/cli/talent.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"text/tabwriter"
+	"time"
 
 	belayer "github.com/donovan-yohan/belayer"
 	"github.com/spf13/cobra"
@@ -22,7 +24,7 @@ func newTeamCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "team",
 		Aliases: []string{"teams", "talent"},
-		Short:   "List, add, and remove local team identities",
+		Short:   "Manage local team identities and generated talent records",
 	}
 	cmd.AddCommand(newTeamListCmd(), newTeamAddCmd(), newTeamRemoveCmd(), newGeneratedTalentCmd())
 	return cmd
@@ -157,6 +159,8 @@ type generatedTalentRecord struct {
 	Reason            string            `yaml:"reason"`
 	Metadata          map[string]string `yaml:"metadata,omitempty"`
 	PromotionEvidence []string          `yaml:"promotion_evidence,omitempty"`
+	CreatedAt         string            `yaml:"created_at"`
+	UpdatedAt         string            `yaml:"updated_at"`
 }
 
 func newGeneratedTalentPersistCmd() *cobra.Command {
@@ -204,19 +208,25 @@ func newGeneratedTalentPersistCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			dir, err := generatedTalentDir(cragName, id)
+			if err := validateNonEmptyValues("promotion-evidence", promotionEvidence); err != nil {
+				return err
+			}
+			if status == "promoted" && len(promotionEvidence) == 0 {
+				return fmt.Errorf("--promotion-evidence is required when --status=promoted")
+			}
+			cragPath, err := cragDir(cragName)
 			if err != nil {
 				return err
 			}
-			if _, err := os.Stat(filepath.Join(filepath.Dir(filepath.Dir(dir)), "crag.yaml")); err != nil {
+			if _, err := os.Stat(filepath.Join(cragPath, "crag.yaml")); err != nil {
 				if os.IsNotExist(err) {
 					return fmt.Errorf("crag %q does not exist", cragName)
 				}
 				return fmt.Errorf("stat crag.yaml: %w", err)
 			}
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				return fmt.Errorf("mkdir generated talent: %w", err)
-			}
+			dir := filepath.Join(cragPath, "generated-talents", id)
+			talentPath := filepath.Join(dir, "talent.yaml")
+			now := time.Now().UTC().Format(time.RFC3339)
 			record := generatedTalentRecord{
 				SchemaVersion:     "belayer-generated-talent/v1",
 				ID:                id,
@@ -228,12 +238,13 @@ func newGeneratedTalentPersistCmd() *cobra.Command {
 				Reason:            reason,
 				Metadata:          parsedMetadata,
 				PromotionEvidence: promotionEvidence,
+				CreatedAt:         now,
+				UpdatedAt:         now,
 			}
 			raw, err := yaml.Marshal(record)
 			if err != nil {
 				return fmt.Errorf("marshal generated talent: %w", err)
 			}
-			talentPath := filepath.Join(dir, "talent.yaml")
 			if !force {
 				if _, err := os.Stat(talentPath); err == nil {
 					return fmt.Errorf("generated talent %q already exists in crag %q (use --force to overwrite)", id, cragName)
@@ -241,13 +252,21 @@ func newGeneratedTalentPersistCmd() *cobra.Command {
 					return fmt.Errorf("stat generated talent: %w", err)
 				}
 			}
-			if err := os.WriteFile(talentPath, raw, 0o644); err != nil {
-				return fmt.Errorf("write generated talent: %w", err)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("mkdir generated talent: %w", err)
 			}
+			notesPath := filepath.Join(dir, "notes.md")
 			if note != "" {
-				if err := os.WriteFile(filepath.Join(dir, "notes.md"), []byte(note+"\n"), 0o644); err != nil {
+				if err := os.WriteFile(notesPath, []byte(note+"\n"), 0o644); err != nil {
 					return fmt.Errorf("write generated talent notes: %w", err)
 				}
+			} else if force {
+				if err := os.Remove(notesPath); err != nil && !os.IsNotExist(err) {
+					return fmt.Errorf("remove stale generated talent notes: %w", err)
+				}
+			}
+			if err := os.WriteFile(talentPath, raw, 0o644); err != nil {
+				return fmt.Errorf("write generated talent: %w", err)
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Persisted generated talent %s in crag %s\n", id, cragName)
 			return nil
@@ -263,6 +282,10 @@ func newGeneratedTalentPersistCmd() *cobra.Command {
 	cmd.Flags().StringArrayVar(&promotionEvidence, "promotion-evidence", nil, "Evidence path supporting promotion or reuse; repeatable")
 	cmd.Flags().StringVar(&note, "note", "", "Optional human-readable notes.md content")
 	cmd.Flags().BoolVar(&force, "force", false, "Overwrite an existing generated talent record")
+	_ = cmd.MarkFlagRequired("domain")
+	_ = cmd.MarkFlagRequired("role")
+	_ = cmd.MarkFlagRequired("source-request")
+	_ = cmd.MarkFlagRequired("reason")
 	return cmd
 }
 
@@ -294,6 +317,8 @@ func newGeneratedTalentListCmd() *cobra.Command {
 				}
 				return fmt.Errorf("read generated talents: %w", err)
 			}
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			defer w.Flush()
 			for _, entry := range entries {
 				if !entry.IsDir() {
 					continue
@@ -301,6 +326,9 @@ func newGeneratedTalentListCmd() *cobra.Command {
 				path := filepath.Join(root, entry.Name(), "talent.yaml")
 				raw, err := os.ReadFile(path)
 				if err != nil {
+					if os.IsNotExist(err) {
+						continue
+					}
 					return fmt.Errorf("read %s: %w", path, err)
 				}
 				var record generatedTalentRecord
@@ -310,7 +338,7 @@ func newGeneratedTalentListCmd() *cobra.Command {
 				if record.ID == "" {
 					record.ID = entry.Name()
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%s\t%s\n", record.ID, record.Domain, record.Role, record.Lifecycle, record.Status)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", record.ID, record.Domain, record.Role, record.Lifecycle, record.Status)
 			}
 			return nil
 		},
@@ -348,6 +376,15 @@ func generatedTalentDir(cragName, id string) (string, error) {
 func validateRequiredFlag(name, value string) error {
 	if strings.TrimSpace(value) == "" {
 		return fmt.Errorf("--%s is required", name)
+	}
+	return nil
+}
+
+func validateNonEmptyValues(name string, values []string) error {
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("--%s values must be non-empty", name)
+		}
 	}
 	return nil
 }

--- a/internal/cli/talent.go
+++ b/internal/cli/talent.go
@@ -10,6 +10,7 @@ import (
 
 	belayer "github.com/donovan-yohan/belayer"
 	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v3"
 )
 
 type copySummary struct {
@@ -23,7 +24,7 @@ func newTeamCmd() *cobra.Command {
 		Aliases: []string{"teams", "talent"},
 		Short:   "List, add, and remove local team identities",
 	}
-	cmd.AddCommand(newTeamListCmd(), newTeamAddCmd(), newTeamRemoveCmd())
+	cmd.AddCommand(newTeamListCmd(), newTeamAddCmd(), newTeamRemoveCmd(), newGeneratedTalentCmd())
 	return cmd
 }
 
@@ -135,6 +136,187 @@ func newTeamRemoveCmd() *cobra.Command {
 	return cmd
 }
 
+func newGeneratedTalentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "generated",
+		Aliases: []string{"generated-talents"},
+		Short:   "Manage generated talent records in a crag-local pool",
+	}
+	cmd.AddCommand(newGeneratedTalentPersistCmd(), newGeneratedTalentListCmd())
+	return cmd
+}
+
+type generatedTalentRecord struct {
+	SchemaVersion     string            `yaml:"schema_version"`
+	ID                string            `yaml:"id"`
+	Domain            string            `yaml:"domain"`
+	Role              string            `yaml:"role"`
+	Lifecycle         string            `yaml:"lifecycle"`
+	Status            string            `yaml:"status"`
+	SourceRequest     string            `yaml:"source_request"`
+	Reason            string            `yaml:"reason"`
+	Metadata          map[string]string `yaml:"metadata,omitempty"`
+	PromotionEvidence []string          `yaml:"promotion_evidence,omitempty"`
+}
+
+func newGeneratedTalentPersistCmd() *cobra.Command {
+	var domain, role, lifecycle, status, sourceRequest, reason, note string
+	var metadata []string
+	var promotionEvidence []string
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "persist <crag> <id>",
+		Short: "Persist compact generated talent metadata into a crag pool",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cragName, id := args[0], args[1]
+			if err := validateName(cragName, "crag"); err != nil {
+				return err
+			}
+			if err := validateName(id, "generated talent"); err != nil {
+				return err
+			}
+			if err := validateRequiredFlag("domain", domain); err != nil {
+				return err
+			}
+			if err := validateRequiredFlag("role", role); err != nil {
+				return err
+			}
+			if err := validateRequiredFlag("source-request", sourceRequest); err != nil {
+				return err
+			}
+			if err := validateRequiredFlag("reason", reason); err != nil {
+				return err
+			}
+			if lifecycle == "" {
+				lifecycle = "ephemeral"
+			}
+			if status == "" {
+				status = "generated"
+			}
+			if err := validateTalentLifecycle(lifecycle); err != nil {
+				return err
+			}
+			if err := validateGeneratedTalentStatus(status); err != nil {
+				return err
+			}
+			parsedMetadata, err := parseKeyValueFlags(metadata)
+			if err != nil {
+				return err
+			}
+			dir, err := generatedTalentDir(cragName, id)
+			if err != nil {
+				return err
+			}
+			if _, err := os.Stat(filepath.Join(filepath.Dir(filepath.Dir(dir)), "crag.yaml")); err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("crag %q does not exist", cragName)
+				}
+				return fmt.Errorf("stat crag.yaml: %w", err)
+			}
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("mkdir generated talent: %w", err)
+			}
+			record := generatedTalentRecord{
+				SchemaVersion:     "belayer-generated-talent/v1",
+				ID:                id,
+				Domain:            domain,
+				Role:              role,
+				Lifecycle:         lifecycle,
+				Status:            status,
+				SourceRequest:     sourceRequest,
+				Reason:            reason,
+				Metadata:          parsedMetadata,
+				PromotionEvidence: promotionEvidence,
+			}
+			raw, err := yaml.Marshal(record)
+			if err != nil {
+				return fmt.Errorf("marshal generated talent: %w", err)
+			}
+			talentPath := filepath.Join(dir, "talent.yaml")
+			if !force {
+				if _, err := os.Stat(talentPath); err == nil {
+					return fmt.Errorf("generated talent %q already exists in crag %q (use --force to overwrite)", id, cragName)
+				} else if !os.IsNotExist(err) {
+					return fmt.Errorf("stat generated talent: %w", err)
+				}
+			}
+			if err := os.WriteFile(talentPath, raw, 0o644); err != nil {
+				return fmt.Errorf("write generated talent: %w", err)
+			}
+			if note != "" {
+				if err := os.WriteFile(filepath.Join(dir, "notes.md"), []byte(note+"\n"), 0o644); err != nil {
+					return fmt.Errorf("write generated talent notes: %w", err)
+				}
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Persisted generated talent %s in crag %s\n", id, cragName)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&domain, "domain", "", "Prompt-visible domain metadata")
+	cmd.Flags().StringVar(&role, "role", "", "Prompt-visible role metadata")
+	cmd.Flags().StringVar(&lifecycle, "lifecycle", "ephemeral", "Runtime lifecycle: resident, resumable, or ephemeral")
+	cmd.Flags().StringVar(&status, "status", "generated", "Generated talent status: generated, promoted, retired, or discarded")
+	cmd.Flags().StringVar(&sourceRequest, "source-request", "", "Request, task, or turn identifier that caused generation")
+	cmd.Flags().StringVar(&reason, "reason", "", "Why this generated talent was needed")
+	cmd.Flags().StringArrayVar(&metadata, "metadata", nil, "Caller-provided key=value metadata; repeatable")
+	cmd.Flags().StringArrayVar(&promotionEvidence, "promotion-evidence", nil, "Evidence path supporting promotion or reuse; repeatable")
+	cmd.Flags().StringVar(&note, "note", "", "Optional human-readable notes.md content")
+	cmd.Flags().BoolVar(&force, "force", false, "Overwrite an existing generated talent record")
+	return cmd
+}
+
+func newGeneratedTalentListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list <crag>",
+		Short: "List generated talent records for a crag",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cragName := args[0]
+			if err := validateName(cragName, "crag"); err != nil {
+				return err
+			}
+			dir, err := cragDir(cragName)
+			if err != nil {
+				return err
+			}
+			if _, err := os.Stat(filepath.Join(dir, "crag.yaml")); err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("crag %q does not exist", cragName)
+				}
+				return fmt.Errorf("stat crag.yaml: %w", err)
+			}
+			root := filepath.Join(dir, "generated-talents")
+			entries, err := os.ReadDir(root)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return fmt.Errorf("read generated talents: %w", err)
+			}
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
+				path := filepath.Join(root, entry.Name(), "talent.yaml")
+				raw, err := os.ReadFile(path)
+				if err != nil {
+					return fmt.Errorf("read %s: %w", path, err)
+				}
+				var record generatedTalentRecord
+				if err := yaml.Unmarshal(raw, &record); err != nil {
+					return fmt.Errorf("parse %s: %w", path, err)
+				}
+				if record.ID == "" {
+					record.ID = entry.Name()
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%s\t%s\n", record.ID, record.Domain, record.Role, record.Lifecycle, record.Status)
+			}
+			return nil
+		},
+	}
+}
+
 func parseTalentRef(ref string) (string, string, error) {
 	parts := strings.Split(ref, "/")
 	if len(parts) == 1 {
@@ -153,6 +335,58 @@ func parseTalentRef(ref string) (string, string, error) {
 		return parts[0], parts[1], nil
 	}
 	return "", "", fmt.Errorf("invalid team reference %q (use category or category/team)", ref)
+}
+
+func generatedTalentDir(cragName, id string) (string, error) {
+	dir, err := cragDir(cragName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "generated-talents", id), nil
+}
+
+func validateRequiredFlag(name, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("--%s is required", name)
+	}
+	return nil
+}
+
+func validateTalentLifecycle(lifecycle string) error {
+	switch lifecycle {
+	case "resident", "resumable", "ephemeral":
+		return nil
+	default:
+		return fmt.Errorf("invalid lifecycle %q: must be resident, resumable, or ephemeral", lifecycle)
+	}
+}
+
+func validateGeneratedTalentStatus(status string) error {
+	switch status {
+	case "generated", "promoted", "retired", "discarded":
+		return nil
+	default:
+		return fmt.Errorf("invalid generated talent status %q: must be generated, promoted, retired, or discarded", status)
+	}
+}
+
+func parseKeyValueFlags(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(values))
+	for _, value := range values {
+		key, val, ok := strings.Cut(value, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid metadata %q: use key=value", value)
+		}
+		key = strings.TrimSpace(key)
+		if err := validateName(key, "metadata key"); err != nil {
+			return nil, err
+		}
+		out[key] = strings.TrimSpace(val)
+	}
+	return out, nil
 }
 
 func validateName(name, label string) error {

--- a/internal/cli/talent.go
+++ b/internal/cli/talent.go
@@ -365,14 +365,6 @@ func parseTalentRef(ref string) (string, string, error) {
 	return "", "", fmt.Errorf("invalid team reference %q (use category or category/team)", ref)
 }
 
-func generatedTalentDir(cragName, id string) (string, error) {
-	dir, err := cragDir(cragName)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "generated-talents", id), nil
-}
-
 func validateRequiredFlag(name, value string) error {
 	if strings.TrimSpace(value) == "" {
 		return fmt.Errorf("--%s is required", name)


### PR DESCRIPTION
## Summary

Implements the generic generated talent persistence primitive for #120. Belayer stays mechanical: generated talents are stored by domain, role, lifecycle, status, source request, reason, metadata, and promotion evidence under the crag-local `generated-talents/` pool.

Adds:
- `belayer talent generated persist <crag> <id>`
- `belayer talent generated list <crag>`
- `talent-request` and `generated-talent` artifact schemas
- docs/tests that keep the contract generic rather than story-specific

Parley validation is in donovan-yohan/parley#1 and uses the new CLI for the Last Lantern smoke.

Refs #120.

## Verification

- `go test ./internal/cli -run 'TestTalentGenerated'`\n- `go test ./internal/agentlint -run 'TestGeneratedTalentContractsStayGeneric|TestArtifactSchemaDocsReferenceEverySchema|TestArtifactSchemasAreValidJSON'`\n- `go test ./...`\n- `go build -o /tmp/belayer-issue-120 ./cmd/belayer`\n- Parley smoke: `BELAYER_BIN=/tmp/belayer-issue-120 ./scripts/smoke-last-lantern.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `team generated persist` to create/manage generated talent records with metadata, promotion evidence, and validation
  * Added `team generated list` to view generated talents in a crag

* **Documentation**
  * Added talent-request and generated-talent artifact schemas and updated generated-talent storage/metadata guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->