### PR TITLE
feat: scaffold generated talent identities

### DIFF
--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -75,6 +75,7 @@ interrupt (`--interrupt` writes to the side's stdin).
 | `belayer_broadcast`            | ✓           | ✓                 | ✗    |
 | `belayer_check_mail`           | ✓           | ✓                 | ✗    |
 | `belayer_spawn_agent`          | ✗           | ✓ (opt-in)        | ✗    |
+| `belayer_scaffold_generated_talent` | ✗      | ✓ (opt-in)        | ✗    |
 | `belayer_request_completion`   | ✗           | ✓ (opt-in)        | ✗    |
 | `belayer_escalate_to_human`    | ✗           | ✓ (opt-in)        | ✗    |
 | `belayer_approve_completion`   | ✗           | ✗                 | ✓ (PM only) |
@@ -82,7 +83,7 @@ interrupt (`--interrupt` writes to the side's stdin).
 
 The mail tools (`send_message`, `broadcast`, `check_mail`) are automatic for
 every `kind: main` and withheld from every `kind: side`. Role-specific tools
-(`spawn_agent`, completion-gate tools) are opt-in via
+(`spawn_agent`, generated-talent scaffolding, completion-gate tools) are opt-in via
 `agent.yaml#belayer_tools:` and enforced at registration time — an identity
 that does not declare a tool spawns without it.
 
@@ -170,15 +171,16 @@ flowchart TB
 | `belayer_check_mail` | — | Poll for queued messages and broadcasts (main only) |
 | `belayer_create_artifact` | `kind`, `path`, `summary?` | Register a durable output (contract, report, task-graph, etc.) |
 | `belayer_report_status` | `status` (working/blocked/done/needs-review), `detail?` | Publish lifecycle state to the session bus |
-| `belayer_spawn_agent` | `name`, `profile`, `message`, `branch?` | Dynamically spawn a specialist agent (supervisor only) |
-| `belayer_request_completion` | `summary`, `spec_artifact?` | Signal work is done, trigger PM verification (supervisor only) |
+| `belayer_spawn_agent` | `name`, `profile`, `message`, `branch?` | Dynamically spawn a specialist agent (party lead only) |
+| `belayer_scaffold_generated_talent` | `crag`, `id`, `domain`, `role`, `lifecycle`, `source_request`, `reason`, `metadata?` | Create a runnable project-local identity for a generated talent (party lead opt-in only) |
+| `belayer_request_completion` | `summary`, `spec_artifact?` | Signal work is done, trigger PM verification (party lead only) |
 | `belayer_approve_completion` | `verification_report` | Approve the climb after spec verification (PM only) |
 | `belayer_reject_completion` | `verification_report`, `gap_list` | Reject the climb with gaps for supervisor to fix (PM only) |
-| `belayer_escalate_to_human` | `reason` (string) | Halt the climb and flag for human review (supervisor only) |
+| `belayer_escalate_to_human` | `reason` (string) | Halt the climb and flag for human review (party lead only) |
 
 The base Hermes tools let an agent do work (read files, write code, run commands). The Belayer coordination tools let an agent coordinate (send messages, register outputs, report status, spawn teammates). The completion gate tools enforce spec verification before a climb can close.
 
-Each agent template declares role-specific tools via the `belayer_tools` field in `agent.yaml`. `report_status` and `create_artifact` are universal baseline tools registered on every agent. Mail tools (`send_message`, `broadcast`, `check_mail`) are registered only for `kind: main`. Role-specific tools are only available to identities that declare them. The supervisor can spawn agents, request completion, and escalate to human. Only the PM can approve or reject a climb. This is enforced at registration time — agents never see tools they aren't authorized to use.
+Each agent template declares role-specific tools via the `belayer_tools` field in `agent.yaml`. `report_status` and `create_artifact` are universal baseline tools registered on every agent. Mail tools (`send_message`, `broadcast`, `check_mail`) are registered only for `kind: main`. Role-specific tools are only available to identities that declare them. A party lead can spawn agents, scaffold generated talent identities, request completion, and escalate to human when its identity allows those tools. The shipped default team names that party lead `supervisor`, but the capability comes from the declared tool contract rather than the literal identity name. Only the PM can approve or reject a climb. This is enforced at registration time — agents never see tools they aren't authorized to use.
 
 Side agents do not receive mail tools; they receive their task in the spawn message and return via `final_response` plus artifacts.
 
@@ -877,10 +879,11 @@ Agents receive belayer tools in two layers:
 2. **Main-mail tools** — registered only for `kind: main`:
    `belayer_send_message`, `belayer_broadcast`, `belayer_check_mail`.
 3. **Role-specific tools** — opt-in via `agent.yaml#belayer_tools:`:
-   - `belayer_spawn_agent` — supervisor only
-   - `belayer_request_completion` — supervisor only
+   - `belayer_spawn_agent` — party lead only
+   - `belayer_scaffold_generated_talent` — party lead opt-in only
+   - `belayer_request_completion` — party lead only
    - `belayer_approve_completion`, `belayer_reject_completion` — PM only
-   - `belayer_escalate_to_human` — supervisor only (last-resort stop)
+   - `belayer_escalate_to_human` — party lead only (last-resort stop)
 
 Side agents (`kind: side`) do not receive mail tools. They receive their task in the spawn message and return via `final_response` plus artifacts.
 

--- a/docs/CRAG_FILESYSTEM.md
+++ b/docs/CRAG_FILESYSTEM.md
@@ -282,6 +282,22 @@ Generated talents do not become full `.belayer/agents/` identities by default.
 They start as compact metadata. A later reviewed promotion can turn one into a
 catalog talent or crag team member.
 
+When a coordinator needs to run a generated talent during the current climb,
+Belayer can scaffold a project-local identity from the same mechanical record:
+
+```text
+repo/.belayer/agents/<generated-talent-id>/
+├── agent.yaml
+├── system-prompt.md
+├── agents.md
+└── talent.yaml
+```
+
+This is not promotion. It creates a runnable local identity for the current
+project while preserving the generated talent as a bounded, auditable profile.
+Agents only receive the scaffolding tool when their identity explicitly declares
+`belayer_scaffold_generated_talent` in `agent.yaml#belayer_tools:`.
+
 ### `world-state/`
 
 Story crags may keep campaign or setting state here.

--- a/examples/talent-catalog/story/storyteller/agent.yaml
+++ b/examples/talent-catalog/story/storyteller/agent.yaml
@@ -9,5 +9,6 @@ ephemeral: false
 workspace: inherit
 belayer_tools:
   - belayer_spawn_agent
+  - belayer_scaffold_generated_talent
   - belayer_request_completion
   - belayer_escalate_to_human

--- a/internal/cli/org_talent_test.go
+++ b/internal/cli/org_talent_test.go
@@ -412,6 +412,77 @@ func TestTalentGeneratedPersistRejectsInvalidLifecycle(t *testing.T) {
 	}
 }
 
+func TestTalentGeneratedScaffoldCreatesRunnableIdentity(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	t.Setenv("BELAYER_HOME", home)
+
+	initCmd := newCragCmd()
+	initCmd.SetOut(&bytes.Buffer{})
+	initCmd.SetErr(&bytes.Buffer{})
+	initCmd.SetArgs([]string{"init", "last-lantern", "--kind", "story"})
+	if err := initCmd.Execute(); err != nil {
+		t.Fatalf("crag init: %v", err)
+	}
+
+	persistCmd := newTeamCmd()
+	persistCmd.SetOut(&bytes.Buffer{})
+	persistCmd.SetErr(&bytes.Buffer{})
+	persistCmd.SetArgs([]string{
+		"generated", "persist", "last-lantern", "mara-underbough",
+		"--domain", "story",
+		"--role", "tavernkeep",
+		"--lifecycle", "resumable",
+		"--source-request", "turn-0002",
+		"--reason", "scene needs a reusable local authority",
+		"--metadata", "voice=warm and watchful",
+	})
+	if err := persistCmd.Execute(); err != nil {
+		t.Fatalf("generated persist: %v", err)
+	}
+
+	scaffoldCmd := newTeamCmd()
+	scaffoldOut := &bytes.Buffer{}
+	scaffoldCmd.SetOut(scaffoldOut)
+	scaffoldCmd.SetErr(scaffoldOut)
+	scaffoldCmd.SetArgs([]string{"generated", "scaffold", "last-lantern", "mara-underbough", "--target", project})
+	if err := scaffoldCmd.Execute(); err != nil {
+		t.Fatalf("generated scaffold: %v\n%s", err, scaffoldOut.String())
+	}
+	if !strings.Contains(scaffoldOut.String(), "Scaffolded generated talent mara-underbough") {
+		t.Fatalf("unexpected scaffold output: %s", scaffoldOut.String())
+	}
+
+	identityDir := filepath.Join(project, ".belayer", "agents", "mara-underbough")
+	for _, rel := range []string{"agent.yaml", "system-prompt.md", "agents.md", "talent.yaml"} {
+		if _, err := os.Stat(filepath.Join(identityDir, rel)); err != nil {
+			t.Fatalf("expected scaffolded %s: %v", rel, err)
+		}
+	}
+	agentYAML, err := os.ReadFile(filepath.Join(identityDir, "agent.yaml"))
+	if err != nil {
+		t.Fatalf("read scaffolded agent.yaml: %v", err)
+	}
+	for _, want := range []string{
+		`kind: side`,
+		`ephemeral: false`,
+		`model: gpt-5.4`,
+	} {
+		if !strings.Contains(string(agentYAML), want) {
+			t.Fatalf("agent.yaml missing %q:\n%s", want, string(agentYAML))
+		}
+	}
+	systemPrompt, err := os.ReadFile(filepath.Join(identityDir, "system-prompt.md"))
+	if err != nil {
+		t.Fatalf("read scaffolded system prompt: %v", err)
+	}
+	for _, want := range []string{"domain: story", "role: tavernkeep", "source request: turn-0002", "voice: warm and watchful"} {
+		if !strings.Contains(string(systemPrompt), want) {
+			t.Fatalf("system-prompt.md missing %q:\n%s", want, string(systemPrompt))
+		}
+	}
+}
+
 func TestSetCragLinkBlockReplacesExistingBlocks(t *testing.T) {
 	raw := []byte("log_level: standard\norg:\n  name: old\nruntime:\n  max_concurrent_mains: 8\n")
 	got := string(setCragLinkBlock(raw, "new-crag", ""))

--- a/internal/cli/talent.go
+++ b/internal/cli/talent.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	belayer "github.com/donovan-yohan/belayer"
+	"github.com/donovan-yohan/belayer/internal/generatedtalent"
 	"github.com/spf13/cobra"
-	"go.yaml.in/yaml/v3"
 )
 
 type copySummary struct {
@@ -144,23 +144,8 @@ func newGeneratedTalentCmd() *cobra.Command {
 		Aliases: []string{"generated-talents"},
 		Short:   "Manage generated talent records in a crag-local pool",
 	}
-	cmd.AddCommand(newGeneratedTalentPersistCmd(), newGeneratedTalentListCmd())
+	cmd.AddCommand(newGeneratedTalentPersistCmd(), newGeneratedTalentListCmd(), newGeneratedTalentScaffoldCmd())
 	return cmd
-}
-
-type generatedTalentRecord struct {
-	SchemaVersion     string            `yaml:"schema_version"`
-	ID                string            `yaml:"id"`
-	Domain            string            `yaml:"domain"`
-	Role              string            `yaml:"role"`
-	Lifecycle         string            `yaml:"lifecycle"`
-	Status            string            `yaml:"status"`
-	SourceRequest     string            `yaml:"source_request"`
-	Reason            string            `yaml:"reason"`
-	Metadata          map[string]string `yaml:"metadata,omitempty"`
-	PromotionEvidence []string          `yaml:"promotion_evidence,omitempty"`
-	CreatedAt         string            `yaml:"created_at"`
-	UpdatedAt         string            `yaml:"updated_at"`
 }
 
 func newGeneratedTalentPersistCmd() *cobra.Command {
@@ -227,8 +212,8 @@ func newGeneratedTalentPersistCmd() *cobra.Command {
 			dir := filepath.Join(cragPath, "generated-talents", id)
 			talentPath := filepath.Join(dir, "talent.yaml")
 			now := time.Now().UTC().Format(time.RFC3339)
-			record := generatedTalentRecord{
-				SchemaVersion:     "belayer-generated-talent/v1",
+			record := generatedtalent.Record{
+				SchemaVersion:     generatedtalent.SchemaVersion,
 				ID:                id,
 				Domain:            domain,
 				Role:              role,
@@ -240,10 +225,6 @@ func newGeneratedTalentPersistCmd() *cobra.Command {
 				PromotionEvidence: promotionEvidence,
 				CreatedAt:         now,
 				UpdatedAt:         now,
-			}
-			raw, err := yaml.Marshal(record)
-			if err != nil {
-				return fmt.Errorf("marshal generated talent: %w", err)
 			}
 			if !force {
 				if _, err := os.Stat(talentPath); err == nil {
@@ -265,8 +246,8 @@ func newGeneratedTalentPersistCmd() *cobra.Command {
 					return fmt.Errorf("remove stale generated talent notes: %w", err)
 				}
 			}
-			if err := os.WriteFile(talentPath, raw, 0o644); err != nil {
-				return fmt.Errorf("write generated talent: %w", err)
+			if err := generatedtalent.WriteRecord(talentPath, record); err != nil {
+				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Persisted generated talent %s in crag %s\n", id, cragName)
 			return nil
@@ -324,16 +305,12 @@ func newGeneratedTalentListCmd() *cobra.Command {
 					continue
 				}
 				path := filepath.Join(root, entry.Name(), "talent.yaml")
-				raw, err := os.ReadFile(path)
+				record, err := generatedtalent.ReadRecord(path)
 				if err != nil {
 					if os.IsNotExist(err) {
 						continue
 					}
 					return fmt.Errorf("read %s: %w", path, err)
-				}
-				var record generatedTalentRecord
-				if err := yaml.Unmarshal(raw, &record); err != nil {
-					return fmt.Errorf("parse %s: %w", path, err)
 				}
 				if record.ID == "" {
 					record.ID = entry.Name()
@@ -343,6 +320,52 @@ func newGeneratedTalentListCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func newGeneratedTalentScaffoldCmd() *cobra.Command {
+	var target string
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "scaffold <crag> <id>",
+		Short: "Scaffold a runnable project-local identity from generated talent metadata",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cragName, id := args[0], args[1]
+			if err := validateName(cragName, "crag"); err != nil {
+				return err
+			}
+			if err := validateName(id, "generated talent"); err != nil {
+				return err
+			}
+			if target == "" {
+				var err error
+				target, err = os.Getwd()
+				if err != nil {
+					return err
+				}
+			}
+			recordPath, err := generatedTalentRecordPath(cragName, id)
+			if err != nil {
+				return err
+			}
+			record, err := generatedtalent.ReadRecord(recordPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("generated talent %q does not exist in crag %q", id, cragName)
+				}
+				return err
+			}
+			identityDir, err := generatedtalent.ScaffoldIdentity(target, record, force)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Scaffolded generated talent %s at %s\n", id, identityDir)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&target, "target", "", "Project directory (default cwd)")
+	cmd.Flags().BoolVar(&force, "force", false, "Overwrite an existing scaffolded identity")
+	return cmd
 }
 
 func parseTalentRef(ref string) (string, string, error) {
@@ -363,6 +386,22 @@ func parseTalentRef(ref string) (string, string, error) {
 		return parts[0], parts[1], nil
 	}
 	return "", "", fmt.Errorf("invalid team reference %q (use category or category/team)", ref)
+}
+
+func generatedTalentRecordPath(cragName, id string) (string, error) {
+	dir, err := generatedTalentDir(cragName, id)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "talent.yaml"), nil
+}
+
+func generatedTalentDir(cragName, id string) (string, error) {
+	dir, err := cragDir(cragName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "generated-talents", id), nil
 }
 
 func validateRequiredFlag(name, value string) error {

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -222,12 +222,28 @@ func (d *Daemon) handleSpawnAgent(w http.ResponseWriter, r *http.Request) {
 		req.Workdir = sess.WorkspaceDir
 	}
 
+	identityKind := ""
+	if kind == "" {
+		loaded := loadAgentIdentity(req.Workdir, d.config.BelayerRoot, req.identityKey(), req.Model)
+		if loaded.Kind != "" {
+			var kindErr error
+			identityKind, kindErr = validateAgentKind(loaded.Kind)
+			if kindErr != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "identity kind: " + kindErr.Error()})
+				return
+			}
+		}
+	}
+
 	// Check for a prior run of this agent in this session.
 	// If it exists, carry over its Hermes session ID for resume and update
 	// the existing row instead of creating a new one (UNIQUE constraint).
 	prior, priorErr := d.store.GetAgentRun(sessionID, req.Name)
 	if priorErr == nil && kind == "" {
 		kind, _ = validateAgentKind(prior.Kind)
+	}
+	if kind == "" && identityKind != "" {
+		kind = identityKind
 	}
 	if kind == "" {
 		kind = "main"
@@ -589,15 +605,6 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 	// Compute Landlock write roots for this agent (used when ConfineAgentWrites is true).
 	writeRoots := computeWriteRoots(req, repoWorkdir, worktreePath, runDir, d.config.AgentSharedWritePaths)
 
-	// Resolve ephemeral flag: explicit request > role-based default.
-	// Supervisors stay alive by default; all other roles exit on task completion.
-	ephemeral := true
-	if req.Ephemeral != nil {
-		ephemeral = *req.Ephemeral
-	} else if req.Role == "supervisor" {
-		ephemeral = false
-	}
-
 	// Load system prompt + agent.yaml settings from the agent's identity dir.
 	// Project-local <workdir>/.belayer/agents/<identity>/ overrides shipped
 	// <BelayerRoot>/agents/<identity>/. Identity defaults to Name when unset.
@@ -613,6 +620,17 @@ func (d *Daemon) bridgeLaunchAgent(req agentSpawnRequest) (*bridge.Process, erro
 	}
 	if loaded.YAMLPath != "" {
 		log.Printf("Loaded agent.yaml from %s for agent %s (identity=%s): model=%q tools=%v toolsets=%v", loaded.YAMLPath, req.Name, identity, agentModel, belayerTools, enabledToolsets)
+	}
+	// Resolve ephemeral flag: explicit request > identity config > role-based
+	// default. Supervisors stay alive by default; all other roles exit on task
+	// completion unless their identity says otherwise.
+	ephemeral := true
+	if req.Ephemeral != nil {
+		ephemeral = *req.Ephemeral
+	} else if loaded.Ephemeral != nil {
+		ephemeral = *loaded.Ephemeral
+	} else if req.Role == "supervisor" {
+		ephemeral = false
 	}
 
 	// Set up stdin pipe for daemon→agent communication.
@@ -982,11 +1000,25 @@ func (d *Daemon) spawnAgentInternal(req agentSpawnRequest) (store.AgentRun, erro
 			return store.AgentRun{}, kindErr
 		}
 	}
+	identityKind := ""
+	if kind == "" {
+		loaded := loadAgentIdentity(req.Workdir, d.config.BelayerRoot, req.identityKey(), req.Model)
+		if loaded.Kind != "" {
+			var kindErr error
+			identityKind, kindErr = validateAgentKind(loaded.Kind)
+			if kindErr != nil {
+				return store.AgentRun{}, fmt.Errorf("identity kind: %w", kindErr)
+			}
+		}
+	}
 
 	// Check for prior run (resume support).
 	prior, priorErr := d.store.GetAgentRun(req.SessionID, req.Name)
 	if priorErr == nil && kind == "" {
 		kind, _ = validateAgentKind(prior.Kind)
+	}
+	if kind == "" && identityKind != "" {
+		kind = identityKind
 	}
 	if kind == "" {
 		kind = "main"
@@ -1350,6 +1382,8 @@ type agentIdentity struct {
 	EnabledToolsets  []string
 	Model            string
 	MaxTurns         int
+	Kind             string
+	Ephemeral        *bool
 	YAMLPath         string
 }
 
@@ -1386,6 +1420,21 @@ func loadAgentIdentity(workdir, belayerRoot, identity, modelOverride string) age
 			trimmed := strings.TrimSpace(line)
 			if strings.HasPrefix(trimmed, "model:") && out.Model == "" {
 				out.Model = strings.TrimSpace(strings.TrimPrefix(trimmed, "model:"))
+				inTools = false
+				inToolsets = false
+				continue
+			}
+			if strings.HasPrefix(trimmed, "kind:") && out.Kind == "" {
+				out.Kind = strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, "kind:")), `"'`)
+				inTools = false
+				inToolsets = false
+				continue
+			}
+			if strings.HasPrefix(trimmed, "ephemeral:") && out.Ephemeral == nil {
+				raw := strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, "ephemeral:")), `"'`)
+				if parsed, convErr := strconv.ParseBool(raw); convErr == nil {
+					out.Ephemeral = &parsed
+				}
 				inTools = false
 				inToolsets = false
 				continue

--- a/internal/daemon/agents_identity_test.go
+++ b/internal/daemon/agents_identity_test.go
@@ -66,6 +66,24 @@ func TestLoadAgentIdentity_FallsBackToShipped(t *testing.T) {
 	}
 }
 
+func TestLoadAgentIdentity_ReadsRuntimeKindAndEphemeral(t *testing.T) {
+	root := t.TempDir()
+	belayerRoot := filepath.Join(root, "shipped")
+	mustWrite(t, filepath.Join(belayerRoot, "agents", "mara-underbough", "agent.yaml"),
+		"kind: side\nephemeral: false\n")
+
+	got := loadAgentIdentity("", belayerRoot, "mara-underbough", "")
+	if got.Kind != "side" {
+		t.Errorf("Kind = %q, want side", got.Kind)
+	}
+	if got.Ephemeral == nil {
+		t.Fatal("Ephemeral = nil, want false pointer")
+	}
+	if *got.Ephemeral {
+		t.Errorf("Ephemeral = true, want false")
+	}
+}
+
 // TestLoadAgentIdentity_ModelOverrideWins verifies that an explicit spawn
 // request model takes precedence over the model: line in agent.yaml. The
 // supervisor can force a specialist onto a specific model for a task.

--- a/internal/daemon/agents_spawn_test.go
+++ b/internal/daemon/agents_spawn_test.go
@@ -161,6 +161,41 @@ func TestSpawnAgent_BridgeHeartbeatsQuickly(t *testing.T) {
 	}
 }
 
+func TestHandleSpawnAgentUsesIdentityKindFromAgentYAML(t *testing.T) {
+	d := testDaemon(t)
+	workspace := t.TempDir()
+	mustWrite(t, filepath.Join(workspace, ".belayer", "agents", "mara-underbough", "agent.yaml"), "kind: side\n")
+
+	sessRR := doRequest(t, d, "POST", "/sessions", createSessionRequest{Name: "identity-kind-test", WorkspaceDir: workspace})
+	if sessRR.Code != http.StatusCreated {
+		t.Fatalf("create session: %d %s", sessRR.Code, sessRR.Body.String())
+	}
+	sess := decodeJSON[sessionAPIResponse](t, sessRR)
+
+	var capturedKind string
+	d.spawnBridgeAgent = func(req agentSpawnRequest) (*bridge.Process, error) {
+		capturedKind = req.Kind
+		return nil, nil
+	}
+
+	rr := doRequest(t, d, "POST", "/sessions/"+sess.ID+"/agents", agentSpawnRequest{
+		Name:     "mara-underbough",
+		Identity: "mara-underbough",
+		Role:     "tavernkeep",
+		Profile:  "default",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("spawn generated identity: got %d body=%s", rr.Code, rr.Body.String())
+	}
+	run := decodeJSON[agentRunResponse](t, rr)
+	if run.Kind != "side" {
+		t.Fatalf("run.Kind = %q, want side", run.Kind)
+	}
+	if capturedKind != "side" {
+		t.Fatalf("spawn request kind = %q, want side", capturedKind)
+	}
+}
+
 // --- Test: Bridge takes >500ms → spawn returns success (timeout path) ---
 
 // TestSpawnAgent_SlowStartAssumedOK verifies that when neither an event nor a

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -346,6 +346,7 @@ func New(cfg Config) (*Daemon, error) {
 	mux.HandleFunc("POST /sessions/{id}/agents", d.handleSpawnAgent)
 	mux.HandleFunc("GET /sessions/{id}/agents", d.handleListAgents)
 	mux.HandleFunc("POST /sessions/{id}/agents/{name}/finish", d.handleFinishAgent)
+	mux.HandleFunc("POST /sessions/{id}/generated-talents/scaffold", d.handleScaffoldGeneratedTalent)
 	mux.HandleFunc("GET /sessions/{id}/bridges", d.handleListBridges)
 	mux.HandleFunc("GET /sessions/{id}/bridges/{agent}/stdout", d.handleBridgeStdout)
 	mux.HandleFunc("POST /sessions/{id}/artifacts", d.handleCreateArtifact)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -73,6 +73,7 @@ func testDaemon(t *testing.T) *Daemon {
 	mux.HandleFunc("POST /sessions/{id}/agents", d.handleSpawnAgent)
 	mux.HandleFunc("GET /sessions/{id}/agents", d.handleListAgents)
 	mux.HandleFunc("POST /sessions/{id}/agents/{name}/finish", d.handleFinishAgent)
+	mux.HandleFunc("POST /sessions/{id}/generated-talents/scaffold", d.handleScaffoldGeneratedTalent)
 	mux.HandleFunc("GET /sessions/{id}/bridges", d.handleListBridges)
 	mux.HandleFunc("GET /sessions/{id}/bridges/{agent}/stdout", d.handleBridgeStdout)
 	mux.HandleFunc("POST /sessions/{id}/artifacts", d.handleCreateArtifact)

--- a/internal/daemon/generated_talent.go
+++ b/internal/daemon/generated_talent.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+
+	"github.com/donovan-yohan/belayer/internal/generatedtalent"
+	"github.com/donovan-yohan/belayer/internal/store"
+)
+
+type generatedTalentScaffoldRequest struct {
+	Crag          string            `json:"crag"`
+	ID            string            `json:"id"`
+	Domain        string            `json:"domain"`
+	Role          string            `json:"role"`
+	Lifecycle     string            `json:"lifecycle"`
+	SourceRequest string            `json:"source_request"`
+	Reason        string            `json:"reason"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	Force         bool              `json:"force,omitempty"`
+}
+
+func (d *Daemon) handleScaffoldGeneratedTalent(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	sess, err := d.store.GetSession(sessionID)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "session not found"})
+		return
+	}
+	if sess.WorkspaceDir == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "session has no workspace_dir"})
+		return
+	}
+
+	var req generatedTalentScaffoldRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	record := generatedtalent.Record{
+		SchemaVersion: generatedtalent.SchemaVersion,
+		ID:            req.ID,
+		Domain:        req.Domain,
+		Role:          req.Role,
+		Lifecycle:     req.Lifecycle,
+		SourceRequest: req.SourceRequest,
+		Reason:        req.Reason,
+		Metadata:      req.Metadata,
+	}
+	identityDir, err := generatedtalent.ScaffoldIdentity(sess.WorkspaceDir, record, req.Force)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if generatedtalent.IsInputError(err) {
+			status = http.StatusBadRequest
+		}
+		writeJSON(w, status, map[string]string{"error": err.Error()})
+		return
+	}
+	responsePath := filepath.ToSlash(identityDir)
+	_ = d.store.LogEvent(store.SessionEvent{SessionID: sessionID, Type: "org:generated_talent_scaffolded", Data: mustJSON(map[string]string{
+		"crag":     req.Crag,
+		"identity": req.ID,
+		"path":     responsePath,
+	})})
+	writeJSON(w, http.StatusCreated, map[string]string{
+		"identity": req.ID,
+		"path":     responsePath,
+	})
+}

--- a/internal/daemon/generated_talent_test.go
+++ b/internal/daemon/generated_talent_test.go
@@ -1,0 +1,161 @@
+package daemon
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/donovan-yohan/belayer/internal/store"
+)
+
+func TestScaffoldGeneratedTalentEndpointCreatesRunnableIdentity(t *testing.T) {
+	d := testDaemon(t)
+	workspace := t.TempDir()
+	sessionID, err := d.store.CreateSession(store.Session{Name: "story-smoke", WorkspaceDir: workspace})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	rr := doRequest(t, d, "POST", "/sessions/"+sessionID+"/generated-talents/scaffold", generatedTalentScaffoldRequest{
+		Crag:          "last-lantern",
+		ID:            "mara-underbough",
+		Domain:        "story",
+		Role:          "tavernkeep",
+		Lifecycle:     "resumable",
+		SourceRequest: "turn-0002",
+		Reason:        "scene needs a reusable local authority",
+		Metadata: map[string]string{
+			"voice": "warm and watchful",
+		},
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("scaffold generated talent: got %d, body=%s", rr.Code, rr.Body.String())
+	}
+	resp := decodeJSON[map[string]string](t, rr)
+	if resp["identity"] != "mara-underbough" {
+		t.Fatalf("identity = %q, want mara-underbough", resp["identity"])
+	}
+	if resp["path"] != filepath.ToSlash(filepath.Join(workspace, ".belayer", "agents", "mara-underbough")) {
+		t.Fatalf("path = %q, want slash-normalized identity path", resp["path"])
+	}
+
+	identityDir := filepath.Join(workspace, ".belayer", "agents", "mara-underbough")
+	for _, rel := range []string{"agent.yaml", "system-prompt.md", "agents.md", "talent.yaml"} {
+		if _, err := os.Stat(filepath.Join(identityDir, rel)); err != nil {
+			t.Fatalf("expected scaffolded %s: %v", rel, err)
+		}
+	}
+	systemPrompt, err := os.ReadFile(filepath.Join(identityDir, "system-prompt.md"))
+	if err != nil {
+		t.Fatalf("read system prompt: %v", err)
+	}
+	for _, want := range []string{"domain: story", "role: tavernkeep", "source request: turn-0002"} {
+		if !strings.Contains(string(systemPrompt), want) {
+			t.Fatalf("system prompt missing %q:\n%s", want, string(systemPrompt))
+		}
+	}
+}
+
+func TestScaffoldGeneratedTalentEndpointIgnoresPersistenceOnlyFields(t *testing.T) {
+	d := testDaemon(t)
+	workspace := t.TempDir()
+	sessionID, err := d.store.CreateSession(store.Session{Name: "story-smoke", WorkspaceDir: workspace})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	rr := doRequest(t, d, "POST", "/sessions/"+sessionID+"/generated-talents/scaffold", map[string]any{
+		"crag":               "last-lantern",
+		"id":                 "mara-underbough",
+		"domain":             "story",
+		"role":               "tavernkeep",
+		"lifecycle":          "resumable",
+		"status":             "promoted",
+		"source_request":     "turn-0002",
+		"reason":             "scene needs a reusable local authority",
+		"promotion_evidence": []string{"artifacts/talent-evaluation-mara.json"},
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("scaffold generated talent: got %d, body=%s", rr.Code, rr.Body.String())
+	}
+
+	record, err := os.ReadFile(filepath.Join(workspace, ".belayer", "agents", "mara-underbough", "talent.yaml"))
+	if err != nil {
+		t.Fatalf("read talent.yaml: %v", err)
+	}
+	if strings.Contains(string(record), "promoted") || strings.Contains(string(record), "promotion_evidence") {
+		t.Fatalf("daemon scaffold should ignore persistence-only fields:\n%s", string(record))
+	}
+	if !strings.Contains(string(record), "status: generated") {
+		t.Fatalf("daemon scaffold should retain generated default status:\n%s", string(record))
+	}
+}
+
+func TestScaffoldGeneratedTalentEndpointRequiresWorkspace(t *testing.T) {
+	d := testDaemon(t)
+	sessionID, err := d.store.CreateSession(store.Session{Name: "no-workspace"})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	rr := doRequest(t, d, "POST", "/sessions/"+sessionID+"/generated-talents/scaffold", generatedTalentScaffoldRequest{
+		Crag:          "last-lantern",
+		ID:            "mara-underbough",
+		Domain:        "story",
+		Role:          "tavernkeep",
+		Lifecycle:     "resumable",
+		SourceRequest: "turn-0002",
+		Reason:        "scene needs a reusable local authority",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing workspace, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestScaffoldGeneratedTalentEndpointRejectsTraversalID(t *testing.T) {
+	d := testDaemon(t)
+	sessionID, err := d.store.CreateSession(store.Session{Name: "story-smoke", WorkspaceDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	rr := doRequest(t, d, "POST", "/sessions/"+sessionID+"/generated-talents/scaffold", generatedTalentScaffoldRequest{
+		Crag:          "last-lantern",
+		ID:            "../escape",
+		Domain:        "story",
+		Role:          "tavernkeep",
+		Lifecycle:     "resumable",
+		SourceRequest: "turn-0002",
+		Reason:        "scene needs a reusable local authority",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for traversal id, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestScaffoldGeneratedTalentEndpointReturnsInternalErrorForFilesystemFailure(t *testing.T) {
+	d := testDaemon(t)
+	workspaceFile := filepath.Join(t.TempDir(), "workspace-file")
+	if err := os.WriteFile(workspaceFile, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write workspace file: %v", err)
+	}
+	sessionID, err := d.store.CreateSession(store.Session{Name: "story-smoke", WorkspaceDir: workspaceFile})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	rr := doRequest(t, d, "POST", "/sessions/"+sessionID+"/generated-talents/scaffold", generatedTalentScaffoldRequest{
+		Crag:          "last-lantern",
+		ID:            "mara-underbough",
+		Domain:        "story",
+		Role:          "tavernkeep",
+		Lifecycle:     "resumable",
+		SourceRequest: "turn-0002",
+		Reason:        "scene needs a reusable local authority",
+	})
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for filesystem failure, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/generatedtalent/generatedtalent.go
+++ b/internal/generatedtalent/generatedtalent.go
@@ -1,0 +1,272 @@
+package generatedtalent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+const SchemaVersion = "belayer-generated-talent/v1"
+
+type Record struct {
+	SchemaVersion     string            `json:"schema_version" yaml:"schema_version"`
+	ID                string            `json:"id" yaml:"id"`
+	Domain            string            `json:"domain" yaml:"domain"`
+	Role              string            `json:"role" yaml:"role"`
+	Lifecycle         string            `json:"lifecycle" yaml:"lifecycle"`
+	Status            string            `json:"status" yaml:"status"`
+	SourceRequest     string            `json:"source_request" yaml:"source_request"`
+	Reason            string            `json:"reason" yaml:"reason"`
+	Metadata          map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	PromotionEvidence []string          `json:"promotion_evidence,omitempty" yaml:"promotion_evidence,omitempty"`
+	CreatedAt         string            `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt         string            `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+}
+
+type InputError struct {
+	Err error
+}
+
+func (e InputError) Error() string {
+	if e.Err == nil {
+		return ""
+	}
+	return e.Err.Error()
+}
+
+func (e InputError) Unwrap() error {
+	return e.Err
+}
+
+func inputErrorf(format string, args ...any) error {
+	return InputError{Err: fmt.Errorf(format, args...)}
+}
+
+func IsInputError(err error) bool {
+	var inputErr InputError
+	return errors.As(err, &inputErr)
+}
+
+func Normalize(record Record) Record {
+	if record.SchemaVersion == "" {
+		record.SchemaVersion = SchemaVersion
+	}
+	if record.Lifecycle == "" {
+		record.Lifecycle = "ephemeral"
+	}
+	if record.Status == "" {
+		record.Status = "generated"
+	}
+	return record
+}
+
+func ValidateRecord(record Record) error {
+	record = Normalize(record)
+	required := []struct {
+		label string
+		value string
+	}{
+		{label: "id", value: record.ID},
+		{label: "domain", value: record.Domain},
+		{label: "role", value: record.Role},
+		{label: "source_request", value: record.SourceRequest},
+		{label: "reason", value: record.Reason},
+	}
+	for _, field := range required {
+		if strings.TrimSpace(field.value) == "" {
+			return inputErrorf("%s is required", field.label)
+		}
+	}
+	if err := validateIdentifier(record.ID, "id"); err != nil {
+		return err
+	}
+	switch record.Lifecycle {
+	case "resident", "resumable", "ephemeral":
+	default:
+		return inputErrorf("invalid lifecycle %q: must be resident, resumable, or ephemeral", record.Lifecycle)
+	}
+	switch record.Status {
+	case "generated", "promoted", "retired", "discarded":
+	default:
+		return inputErrorf("invalid generated talent status %q: must be generated, promoted, retired, or discarded", record.Status)
+	}
+	for _, evidence := range record.PromotionEvidence {
+		if strings.TrimSpace(evidence) == "" {
+			return inputErrorf("promotion_evidence values must be non-empty")
+		}
+	}
+	if record.Status == "promoted" && len(record.PromotionEvidence) == 0 {
+		return inputErrorf("promotion_evidence is required when status is promoted")
+	}
+	return nil
+}
+
+func validateIdentifier(value, label string) error {
+	switch value {
+	case ".", "..":
+		return inputErrorf("%s %q is reserved", label, value)
+	}
+	if strings.ContainsAny(value, `/\`) {
+		return inputErrorf("%s %q must not contain path separators", label, value)
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return inputErrorf("%s %q must contain only letters, numbers, dash, underscore, or dot", label, value)
+	}
+	return nil
+}
+
+func WriteRecord(path string, record Record) error {
+	record = Normalize(record)
+	if err := ValidateRecord(record); err != nil {
+		return err
+	}
+	raw, err := yaml.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal generated talent: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir generated talent: %w", err)
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		return fmt.Errorf("write generated talent: %w", err)
+	}
+	return nil
+}
+
+func ReadRecord(path string) (Record, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Record{}, err
+	}
+	var record Record
+	if err := yaml.Unmarshal(raw, &record); err != nil {
+		return Record{}, fmt.Errorf("parse generated talent: %w", err)
+	}
+	record = Normalize(record)
+	if strings.TrimSpace(record.ID) == "" {
+		record.ID = filepath.Base(filepath.Dir(path))
+	}
+	if err := ValidateRecord(record); err != nil {
+		return Record{}, err
+	}
+	return record, nil
+}
+
+func ScaffoldIdentity(projectRoot string, record Record, force bool) (string, error) {
+	record = Normalize(record)
+	if err := ValidateRecord(record); err != nil {
+		return "", err
+	}
+	identityDir := filepath.Join(projectRoot, ".belayer", "agents", record.ID)
+	if !force {
+		if _, err := os.Stat(identityDir); err == nil {
+			return "", inputErrorf("generated talent identity %q already exists (use --force to overwrite)", record.ID)
+		} else if !os.IsNotExist(err) {
+			return "", fmt.Errorf("stat generated talent identity: %w", err)
+		}
+	}
+	if err := os.MkdirAll(identityDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir generated talent identity: %w", err)
+	}
+	agentConfig, err := agentYAML(record)
+	if err != nil {
+		return "", err
+	}
+	files := map[string]string{
+		"agent.yaml":       agentConfig,
+		"system-prompt.md": systemPrompt(record),
+		"agents.md":        agentsMD(record),
+	}
+	for rel, content := range files {
+		if err := os.WriteFile(filepath.Join(identityDir, rel), []byte(content), 0o644); err != nil {
+			return "", fmt.Errorf("write %s: %w", rel, err)
+		}
+	}
+	if err := WriteRecord(filepath.Join(identityDir, "talent.yaml"), record); err != nil {
+		return "", err
+	}
+	return identityDir, nil
+}
+
+func agentYAML(record Record) (string, error) {
+	kind := "side"
+	maxTurns := 40
+	if record.Lifecycle == "resident" {
+		kind = "main"
+		maxTurns = 80
+	}
+	ephemeral := record.Lifecycle == "ephemeral"
+	raw, err := yaml.Marshal(struct {
+		SchemaVersion string   `yaml:"schema_version"`
+		Description   string   `yaml:"description"`
+		Kind          string   `yaml:"kind"`
+		Vendor        string   `yaml:"vendor"`
+		Model         string   `yaml:"model"`
+		MaxTurns      int      `yaml:"max_turns"`
+		MaxDuration   string   `yaml:"max_duration"`
+		Ephemeral     bool     `yaml:"ephemeral"`
+		Workspace     string   `yaml:"workspace"`
+		BelayerTools  []string `yaml:"belayer_tools"`
+	}{
+		SchemaVersion: "1",
+		Description:   fmt.Sprintf("Generated talent %s (%s/%s)", record.ID, record.Domain, record.Role),
+		Kind:          kind,
+		Vendor:        "codex",
+		Model:         "gpt-5.4",
+		MaxTurns:      maxTurns,
+		MaxDuration:   "45m",
+		Ephemeral:     ephemeral,
+		Workspace:     "inherit",
+		BelayerTools:  []string{},
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal generated talent agent config: %w", err)
+	}
+	return string(raw), nil
+}
+
+func systemPrompt(record Record) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "You are generated talent `%s`.\n\n", record.ID)
+	b.WriteString("Mechanical contract:\n")
+	fmt.Fprintf(&b, "- domain: %s\n", record.Domain)
+	fmt.Fprintf(&b, "- role: %s\n", record.Role)
+	fmt.Fprintf(&b, "- lifecycle: %s\n", record.Lifecycle)
+	fmt.Fprintf(&b, "- source request: %s\n", record.SourceRequest)
+	fmt.Fprintf(&b, "- reason: %s\n", record.Reason)
+	if len(record.Metadata) > 0 {
+		b.WriteString("\nCaller-provided metadata:\n")
+		keys := make([]string, 0, len(record.Metadata))
+		for key := range record.Metadata {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			fmt.Fprintf(&b, "- %s: %s\n", key, record.Metadata[key])
+		}
+	}
+	b.WriteString("\nStay inside the assignment context you receive. Produce bounded output for the coordinator and do not silently mutate global crag or catalog state.\n")
+	return b.String()
+}
+
+func agentsMD(record Record) string {
+	return fmt.Sprintf(
+		"# Generated Talent: %s\n\n"+
+			"This identity was scaffolded from a generated talent record.\n\n"+
+			"- Domain: `%s`\n"+
+			"- Role: `%s`\n"+
+			"- Lifecycle: `%s`\n"+
+			"- Source request: `%s`\n\n"+
+			"Use normal Belayer mail and artifact tools granted to this identity. Promotion\n"+
+			"into a durable catalog talent is a separate reviewed step.\n",
+		record.ID, record.Domain, record.Role, record.Lifecycle, record.SourceRequest,
+	)
+}

--- a/internal/generatedtalent/generatedtalent_test.go
+++ b/internal/generatedtalent/generatedtalent_test.go
@@ -1,0 +1,83 @@
+package generatedtalent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadRecordFallsBackToDirectoryID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "generated-talents", "mara-underbough", "talent.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir record dir: %v", err)
+	}
+	raw := []byte(`schema_version: belayer-generated-talent/v1
+domain: story
+role: tavernkeep
+lifecycle: resumable
+status: generated
+source_request: turn-0002
+reason: scene needs a reusable local authority
+`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write record: %v", err)
+	}
+
+	record, err := ReadRecord(path)
+	if err != nil {
+		t.Fatalf("read record: %v", err)
+	}
+	if record.ID != "mara-underbough" {
+		t.Fatalf("record.ID = %q, want mara-underbough", record.ID)
+	}
+}
+
+func TestValidateRecordReturnsDeterministicInputErrors(t *testing.T) {
+	err := ValidateRecord(Record{})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !IsInputError(err) {
+		t.Fatalf("expected input error, got %T %[1]v", err)
+	}
+	if got, want := err.Error(), "id is required"; got != want {
+		t.Fatalf("validation error = %q, want %q", got, want)
+	}
+}
+
+func TestValidateRecordRequiresPromotionEvidenceForPromotedStatus(t *testing.T) {
+	record := Record{
+		ID:            "mara-underbough",
+		Domain:        "story",
+		Role:          "tavernkeep",
+		Lifecycle:     "resumable",
+		Status:        "promoted",
+		SourceRequest: "turn-0002",
+		Reason:        "scene needs a reusable local authority",
+	}
+	err := ValidateRecord(record)
+	if err == nil {
+		t.Fatal("expected promoted record without evidence to fail")
+	}
+	if !IsInputError(err) {
+		t.Fatalf("expected input error, got %T %[1]v", err)
+	}
+	if !strings.Contains(err.Error(), "promotion_evidence is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInputErrorClassificationSurvivesWrapping(t *testing.T) {
+	err := fmt.Errorf("wrap: %w", ValidateRecord(Record{
+		ID:            "../escape",
+		Domain:        "story",
+		Role:          "tavernkeep",
+		SourceRequest: "turn-0002",
+		Reason:        "scene needs a reusable local authority",
+	}))
+	if !IsInputError(err) {
+		t.Fatalf("expected wrapped validation error to classify as input: %v", err)
+	}
+}

--- a/plugins/belayer/plugin.yaml
+++ b/plugins/belayer/plugin.yaml
@@ -10,6 +10,7 @@ provides_tools:
   - belayer_report_status
   - belayer_create_artifact
   - belayer_spawn_agent
+  - belayer_scaffold_generated_talent
   - belayer_request_completion
   - belayer_approve_completion
   - belayer_reject_completion

--- a/plugins/belayer/tests/test_plugin_register.py
+++ b/plugins/belayer/tests/test_plugin_register.py
@@ -306,6 +306,46 @@ def test_spawn_agent_forwards_repo_and_branch(monkeypatch):
     assert payload["identity"] == "web-dev"
 
 
+def test_scaffold_generated_talent_is_allowlisted_tool(monkeypatch):
+    plugin = _make_plugin_with_env(
+        monkeypatch,
+        kind="main",
+        tools="belayer_scaffold_generated_talent",
+    )
+    ctx = _FakeCtx()
+    plugin.register(ctx)
+    names = {t["name"] for t in ctx.tools}
+    assert "belayer_scaffold_generated_talent" in names
+
+
+def test_scaffold_generated_talent_posts_to_daemon(monkeypatch):
+    plugin = _make_plugin_with_env(
+        monkeypatch,
+        kind="main",
+        tools="belayer_scaffold_generated_talent",
+    )
+    seen: list[tuple] = []
+    monkeypatch.setattr(plugin.tools, "unix_post", lambda *a: (seen.append(a), (201, "{\"identity\":\"mara-underbough\"}"))[1])
+
+    tool = _register_and_get(plugin, "belayer_scaffold_generated_talent")
+    result = tool["handler"]({
+        "crag": "last-lantern",
+        "id": "mara-underbough",
+        "domain": "story",
+        "role": "tavernkeep",
+        "lifecycle": "resumable",
+        "source_request": "turn-0002",
+        "reason": "scene needs a reusable local authority",
+        "metadata": {"voice": "warm and watchful"},
+    })
+    assert "mara-underbough" in result
+    assert seen[0][1] == "/sessions/sess-1/generated-talents/scaffold"
+    payload = seen[0][2]
+    assert payload["crag"] == "last-lantern"
+    assert payload["id"] == "mara-underbough"
+    assert payload["metadata"]["voice"] == "warm and watchful"
+
+
 def test_request_completion_posts_event(monkeypatch):
     plugin = _make_plugin_with_env(
         monkeypatch,

--- a/plugins/belayer/tools.py
+++ b/plugins/belayer/tools.py
@@ -465,6 +465,72 @@ SPAWN_AGENT_SCHEMA = {
     },
 }
 
+SCAFFOLD_GENERATED_TALENT_SCHEMA = {
+    "name": "belayer_scaffold_generated_talent",
+    "description": (
+        "Create a runnable project-local identity for a generated talent. Use this when a "
+        "party lead needs a bounded talent and no suitable .belayer/agents identity exists. "
+        "The daemon writes .belayer/agents/<id>/agent.yaml, system-prompt.md, agents.md, and "
+        "talent.yaml from generic mechanical fields. This tool does not promote the talent "
+        "into a global catalog and does not add domain-specific semantics to Belayer.\n\n"
+        "WHEN TO USE belayer_scaffold_generated_talent:\n"
+        "- You need to spawn a new role but no suitable project-local identity exists yet\n"
+        "- The role can be described by domain, role, lifecycle, source request, reason, and "
+        "caller-provided metadata\n"
+        "- You plan to follow up with belayer_spawn_agent using the same id as identity\n\n"
+        "WHEN NOT TO USE:\n"
+        "- A suitable identity already exists under .belayer/agents/ -> use belayer_spawn_agent\n"
+        "- You are only recording a reusable candidate -> create/persist a generated-talent "
+        "artifact instead\n"
+        "- You want to permanently promote a talent into a catalog -> use a reviewed promotion "
+        "flow outside this tool"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "crag": {
+                "type": "string",
+                "description": "Crag or operating context name associated with the generated talent.",
+            },
+            "id": {
+                "type": "string",
+                "description": "Directory-safe generated talent id and future spawn identity.",
+            },
+            "domain": {
+                "type": "string",
+                "description": "Prompt-visible domain metadata. Belayer treats this as a string.",
+            },
+            "role": {
+                "type": "string",
+                "description": "Prompt-visible role metadata. Belayer treats this as a string.",
+            },
+            "lifecycle": {
+                "type": "string",
+                "enum": ["resident", "resumable", "ephemeral"],
+                "description": "Runtime lifecycle for the generated identity.",
+            },
+            "source_request": {
+                "type": "string",
+                "description": "Request, task, or turn id that caused this generated talent to be needed.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Why this generated talent is needed for the current climb.",
+            },
+            "metadata": {
+                "type": "object",
+                "description": "Caller-provided compact key/value metadata for the generated prompt.",
+                "additionalProperties": {"type": "string"},
+            },
+            "force": {
+                "type": "boolean",
+                "description": "Overwrite an existing project-local identity with the same id.",
+            },
+        },
+        "required": ["crag", "id", "domain", "role", "lifecycle", "source_request", "reason"],
+    },
+}
+
 REQUEST_COMPLETION_SCHEMA = {
     "name": "belayer_request_completion",
     "description": (
@@ -875,6 +941,40 @@ def make_spawn_agent_handler(agent_id: str, session_id: str, socket_path: str) -
     return handler
 
 
+def make_scaffold_generated_talent_handler(agent_id: str, session_id: str, socket_path: str) -> Callable:
+    def handler(args: Optional[Dict[str, Any]] = None, **_kwargs: Any) -> str:
+        args = args or {}
+        payload = {
+            "crag": args.get("crag", ""),
+            "id": args.get("id", ""),
+            "domain": args.get("domain", ""),
+            "role": args.get("role", ""),
+            "lifecycle": args.get("lifecycle", ""),
+            "source_request": args.get("source_request", ""),
+            "reason": args.get("reason", ""),
+            "metadata": args.get("metadata", {}) or {},
+            "force": bool(args.get("force", False)),
+        }
+        status, body = unix_post(
+            socket_path,
+            f"/sessions/{session_id}/generated-talents/scaffold",
+            payload,
+        )
+        if status == 201:
+            identity = payload["id"]
+            try:
+                parsed = json.loads(body) if body else {}
+                if isinstance(parsed, dict):
+                    identity = parsed.get("identity", identity)
+            except json.JSONDecodeError:
+                pass
+            return f"Generated talent identity '{identity}' scaffolded. You can now spawn it with belayer_spawn_agent."
+        logger.warning("scaffold_generated_talent %s failed (%d): %s", payload["id"], status, body[:200])
+        return f"[System] Failed to scaffold generated talent '{payload['id']}'. Error: {body[:200]}"
+
+    return handler
+
+
 def make_request_completion_handler(agent_id: str, session_id: str, socket_path: str) -> Callable:
     def handler(args: Optional[Dict[str, Any]] = None, **_kwargs: Any) -> str:
         args = args or {}
@@ -1013,6 +1113,7 @@ TOOL_SPECS: Dict[str, tuple] = {
     "belayer_report_status": (REPORT_STATUS_SCHEMA, make_report_status_handler),
     "belayer_create_artifact": (CREATE_ARTIFACT_SCHEMA, make_create_artifact_handler),
     "belayer_spawn_agent": (SPAWN_AGENT_SCHEMA, make_spawn_agent_handler),
+    "belayer_scaffold_generated_talent": (SCAFFOLD_GENERATED_TALENT_SCHEMA, make_scaffold_generated_talent_handler),
     "belayer_request_completion": (REQUEST_COMPLETION_SCHEMA, make_request_completion_handler),
     "belayer_approve_completion": (APPROVE_COMPLETION_SCHEMA, make_approve_completion_handler),
     "belayer_reject_completion": (REJECT_COMPLETION_SCHEMA, make_reject_completion_handler),


### PR DESCRIPTION
## Why

This is the next stacked slice for #120, on top of #128. Generated talent records are useful as compact metadata, but coordinators also need an explicitly permitted way to turn one into a runnable project-local identity during a climb.

## What changed

- Added shared generated-talent record/scaffold helpers used by both CLI and daemon paths.
- Added `belayer talent generated scaffold <crag> <id> --target <project>` to create `.belayer/agents/<id>/agent.yaml`, `system-prompt.md`, `agents.md`, and `talent.yaml`.
- Added `POST /sessions/{id}/generated-talents/scaffold` for session-workspace scaffolding with validation for missing workspace and unsafe IDs.
- Added the opt-in Hermes tool `belayer_scaffold_generated_talent`, gated by `agent.yaml#belayer_tools`, and wired the story storyteller example to request it.
- Updated daemon spawn resolution so generated identity runtime metadata is honored: `kind: side` is applied to the roster/spawn request and `ephemeral: false` is passed through to the bridge.
- Updated architecture/filesystem docs to keep this generic: scaffolding creates a local runnable identity, not a catalog promotion or story-specific workflow.

## Verification

- `go test ./internal/cli -run 'TestTalentGeneratedScaffoldCreatesRunnableIdentity|TestTalentGeneratedPersistAndList'`
- `go test ./internal/daemon -run 'TestScaffoldGeneratedTalentEndpoint|TestLoadAgentIdentity_ReadsRuntimeKindAndEphemeral|TestHandleSpawnAgentUsesIdentityKindFromAgentYAML'`
- `go test ./...`
- `pytest plugins/belayer/tests hermes_bridge/tests`
- `go build -o /tmp/belayer-issue-120-scaffold ./cmd/belayer`
- CLI smoke: initialized `last-lantern`, persisted `mara-underbough`, scaffolded into a temp project, and verified generated identity files plus `kind: side`, `ephemeral: false`, `model: gpt-5.4`, source request, and metadata in the prompt.
- Parley E2E smoke against a temp copy of `donovan-yohan/parley`:
  - ran `examples/last-lantern` smoke with this Belayer binary
  - started a real Belayer daemon with Parley as workspace
  - created a story session through the daemon API
  - scaffolded `mara-underbough` through `POST /sessions/{id}/generated-talents/scaffold`
  - spawned `mara-underbough` through normal `belayer spawn --identity mara-underbough --profile default`
  - verified roster `kind=side`, status `running`, a stored Hermes session id, and a `bridge:started` event with `kind=side` and `ephemeral=false` in bridge logs

Stacked on #128.
