### PR TITLE
docs: retroactively document OMC talent + crag work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,24 +40,24 @@ Agents coordinate through the daemon:
 
 ## Agent identity
 
-Agent identities resolve through four layers (highest precedence first), per `docs/CRAG_FILESYSTEM.md`:
+The daemon loader at `internal/daemon/agents.go:agentIdentityPaths` resolves identities through two layers today:
 
-1. `repo/.belayer/agents/<name>/` — project-local override (`belayer init` scaffolds)
-2. `~/.belayer/crags/<crag>/teams/` — linked crag (only when `.belayer/config.yaml` declares one)
-3. `~/.belayer/talent-catalog/<category>/<name>/` — local talent supply (`belayer team add` copies from here)
-4. `agents/<name>/` — shipped defaults, embedded in binary
+1. `repo/.belayer/agents/<name>/<file>` — project-local override, with walk-up so nested cwds (worktrees, climb workspaces) still see the project root copy
+2. `<belayerRoot>/agents/<name>/<file>` — shipped defaults, embedded in binary via `embed.go`
 
-The loader at `internal/daemon/agents.go` reads in this order. Each identity directory contains:
+The 4-tier precedence (repo → linked crag → talent-catalog → shipped) described in `docs/CRAG_FILESYSTEM.md` is the design contract; the crag and catalog tiers are not yet wired into the spawn-time loader. `belayer team add` copies catalog identities into `repo/.belayer/agents/` so they reach the daemon through tier 1.
+
+Each identity directory contains:
 - `agent.yaml` — `kind`, vendor, model, ephemeral flag, `belayer_tools` allowlist
 - `system-prompt.md` — the agent's soul
 - `agents.md` — operating instructions, tools, workflows
-- `talent.yaml` — optional `belayer-talent/v1` metadata (role, domain, activation, runtime.lifecycle, contract, authority, memory, retention)
+- `talent.yaml` — optional. Two distinct schemas: `belayer-talent/v1` for catalog talents (role, domain, activation, runtime.lifecycle, contract, authority, memory, retention) per `docs/CRAG_MODE.md`, and `belayer-generated-talent/v1` for runtime-scaffolded generated talents (id, domain, role, lifecycle, status, source_request, reason) per `internal/generatedtalent/`.
 
 Shipped default team:
 - **Mains:** `supervisor` (party lead), `backend-dev`, `web-dev`.
 - **Sides:** `pm` (completion gate), `qa`, `reviewer`.
 
-Customize in `.belayer/agents/` — see `agents/README.md` for worked examples. Reusable talent supply lives in `examples/talent-catalog/` (development + story categories) and copies via `belayer team add <category>`.
+Customize in `.belayer/agents/` — see `agents/README.md` for worked examples. `belayer team add <category>` copies team identities into `.belayer/agents/`. The `development` category is a CLI special-case that copies the embedded shipped team from `agents/`; other categories (e.g. `story`) live in `examples/talent-catalog/<category>/`.
 
 System prompts are loaded by the daemon at spawn time and injected via Hermes `ephemeral_system_prompt`. All agents use the `default` Hermes profile for now (see profile bootstrap TODO in AGENT_ARCHITECTURE.md).
 
@@ -65,11 +65,11 @@ The `hermes_bridge` Python package lives in the daemon's runtime dir (default `$
 
 ## Acceptance gate (PM is the default)
 
-When the supervisor calls `belayer finish`, the daemon intercepts and auto-spawns the PM side for adversarial spec-vs-reality verification. PM approves or rejects (up to 3 cycles). The PM gate is one preset of the generic `belayer-gate/v1` contract — crags can declare additional task-stage gates (code-review, runtime-qa, continuity, etc.) or replace the acceptance gate with a stricter one. See `docs/CRAG_MODE.md` for the gate contract and `docs/AGENT_ARCHITECTURE.md` for the daemon enforcement path.
+When the supervisor calls `belayer finish`, the daemon intercepts and auto-spawns the PM side for adversarial spec-vs-reality verification. PM approves or rejects (up to 3 cycles). PM is currently the only runtime-enforced gate. The generic `belayer-gate/v1` contract (`docs/CRAG_MODE.md`) describes additional gate kinds (code-review, runtime-qa, continuity, etc.) as documented contracts and proof examples; the daemon does not yet discover or execute crag-defined task-stage gates. See `docs/AGENT_ARCHITECTURE.md` for the daemon enforcement path.
 
 ## Crag mode
 
-Crags are durable cross-project operating contexts (software company, story world, research group) at `~/.belayer/crags/<name>/`. They store reusable teams, gate presets, evaluations, promotions, and generated talent metadata. A repo opts in by `belayer crag link <name>`, writing the link into `.belayer/config.yaml`. See `docs/CRAG_MODE.md` and `docs/CRAG_FILESYSTEM.md`.
+Crags are durable cross-project operating contexts (software company, story world, research group) at `~/.belayer/crags/<name>/`. They store reusable teams, gates, evaluations, promotions, and generated talent metadata as documented contracts. A repo opts in by `belayer crag link <name>`, writing the link into `.belayer/config.yaml`. The CLI surfaces (`belayer crag init/list/link`, `belayer team add/remove`) and filesystem layout have shipped; runtime crag enforcement (gate discovery, identity precedence) is still in flight. See `docs/CRAG_MODE.md` and `docs/CRAG_FILESYSTEM.md`.
 
 ## CLI surface highlights
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,16 @@
 # CLAUDE.md
 
-Belayer v7 — run-local agent control plane for Nightshift.
+Belayer v7 — climb-local agent control plane for Nightshift.
 
 ## What Belayer is
 
-> The **agent control plane** inside a single Nightshift worker run.
+> The **agent control plane** inside a single Nightshift worker climb.
 
-One worker, one request, one Belayer session. Belayer coordinates supervisor + specialist agents via the Hermes bridge.
+One worker, one request, one Belayer session. Belayer coordinates supervisor + specialist agents via the Hermes bridge. Crag mode (`docs/CRAG_MODE.md`) layers durable cross-project knowledge on top of the same primitives.
 
 ## What Belayer is not
 
-Not a cluster scheduler, autoscaler, hypervisor, or hosted identity service. It manages one run.
+Not a cluster scheduler, autoscaler, hypervisor, or hosted identity service. It manages one climb at a time.
 
 ## Architecture
 
@@ -38,43 +38,55 @@ Agents coordinate through the daemon:
 - **events** — machine-readable state transitions
 - **artifacts** — durable outputs registered in the session
 
-## CLI surface
-
-Run `belayer --help` and `belayer <cmd> --help` for current commands and
-flags. Default config schema (including `exit_conditions`) is generated
-from `internal/cli/init.go`. Agent tool surface (baseline + role-specific)
-is defined by the Hermes plugin at `plugins/belayer/tools.py` and gated
-by `plugins/belayer/__init__.py:register()` based on agent kind +
-`BELAYER_TOOLS` allowlist.
-
 ## Agent identity
 
-Agent identities live in `agents/<name>/` (shipped defaults, embedded in the binary)
-and `.belayer/agents/<name>/` (project-local override; `belayer init` scaffolds it).
-The loader at `internal/daemon/agents.go` reads project-local first, falls back to shipped.
-Each directory contains:
+Agent identities resolve through four layers (highest precedence first), per `docs/CRAG_FILESYSTEM.md`:
+
+1. `repo/.belayer/agents/<name>/` — project-local override (`belayer init` scaffolds)
+2. `~/.belayer/crags/<crag>/teams/` — linked crag (only when `.belayer/config.yaml` declares one)
+3. `~/.belayer/talent-catalog/<category>/<name>/` — local talent supply (`belayer team add` copies from here)
+4. `agents/<name>/` — shipped defaults, embedded in binary
+
+The loader at `internal/daemon/agents.go` reads in this order. Each identity directory contains:
 - `agent.yaml` — `kind`, vendor, model, ephemeral flag, `belayer_tools` allowlist
 - `system-prompt.md` — the agent's soul
 - `agents.md` — operating instructions, tools, workflows
+- `talent.yaml` — optional `belayer-talent/v1` metadata (role, domain, activation, runtime.lifecycle, contract, authority, memory, retention)
 
 Shipped default team:
 - **Mains:** `supervisor` (party lead), `backend-dev`, `web-dev`.
 - **Sides:** `pm` (completion gate), `qa`, `reviewer`.
 
-Customize in `.belayer/agents/` — see `agents/README.md` for worked examples.
+Customize in `.belayer/agents/` — see `agents/README.md` for worked examples. Reusable talent supply lives in `examples/talent-catalog/` (development + story categories) and copies via `belayer team add <category>`.
 
 System prompts are loaded by the daemon at spawn time and injected via Hermes `ephemeral_system_prompt`. All agents use the `default` Hermes profile for now (see profile bootstrap TODO in AGENT_ARCHITECTURE.md).
 
 The `hermes_bridge` Python package lives in the daemon's runtime dir (default `$XDG_STATE_HOME/belayer/runtime`), not inside any workspace. This protects the module from workspace agent cleanup (`rm -rf .belayer/`).
 
-## PM completion gate
+## Acceptance gate (PM is the default)
 
-When the supervisor calls `belayer finish`, the daemon intercepts and auto-spawns a PM agent for adversarial spec-vs-reality verification. The PM approves or rejects (up to 3 cycles). See `docs/AGENT_ARCHITECTURE.md` for full details.
+When the supervisor calls `belayer finish`, the daemon intercepts and auto-spawns the PM side for adversarial spec-vs-reality verification. PM approves or rejects (up to 3 cycles). The PM gate is one preset of the generic `belayer-gate/v1` contract — crags can declare additional task-stage gates (code-review, runtime-qa, continuity, etc.) or replace the acceptance gate with a stricter one. See `docs/CRAG_MODE.md` for the gate contract and `docs/AGENT_ARCHITECTURE.md` for the daemon enforcement path.
+
+## Crag mode
+
+Crags are durable cross-project operating contexts (software company, story world, research group) at `~/.belayer/crags/<name>/`. They store reusable teams, gate presets, evaluations, promotions, and generated talent metadata. A repo opts in by `belayer crag link <name>`, writing the link into `.belayer/config.yaml`. See `docs/CRAG_MODE.md` and `docs/CRAG_FILESYSTEM.md`.
+
+## CLI surface highlights
+
+- `belayer climb start` (alias `run`) — start a climb
+- `belayer crag init|list|link` — manage local crags
+- `belayer team list|add|remove` — manage talent catalog rosters
+- Full surface: `belayer --help` and `belayer <cmd> --help`
+
+Default config schema (including `exit_conditions`) is generated from `internal/cli/init.go`. Agent tool surface (baseline + role-specific) is defined by the Hermes plugin at `plugins/belayer/tools.py` and gated by `plugins/belayer/__init__.py:register()` based on agent kind + `BELAYER_TOOLS` allowlist.
 
 ## Docs
 
 - `docs/PHILOSOPHY.md` — the six runtime interfaces (conceptual, not implementation-specific)
-- `docs/AGENT_ARCHITECTURE.md` — how agents communicate, coordinate, and resume
+- `docs/AGENT_ARCHITECTURE.md` — agent kinds, tools, mail, spawn, PM/acceptance gate, lifecycle modes
+- `docs/CRAG_MODE.md` — talent contract, team catalogs, gate contracts, crag events, proof climbs
+- `docs/CRAG_FILESYSTEM.md` — repo, talent catalog, and crag directory contracts; resolution precedence
+- `docs/ARTIFACT_SCHEMAS.md` — content schemas for `org-plan`, `gate-result`, `talent-evaluation`, `org-retro`, `world-state`, `continuity-report`, `generated-talent`, `talent-request`
 - `docs/DEPLOYMENT.md` — deployment topologies, trust model, credentials, ports/sockets
 - `docs/LOG_FORMAT.md` — event schema, SSE, archive format, aggregates, HTTP API contract
 - `docs/OBSERVABILITY.md` — operator guide: tier selection, recipes, dashboard integration

--- a/README.md
+++ b/README.md
@@ -115,8 +115,16 @@ belayer climb start --task "Pick up this backlog item end to end"
 ```
 
 A crag stores reusable teams, playbooks, gates, evaluations, promotions, and
-generated team metadata under `~/.belayer/crags/<name>/`. Story worlds use the
+generated talent metadata under `~/.belayer/crags/<name>/`. Story worlds use the
 same shape with `--kind story`, story teams, continuity gates, and world state.
+
+Talent metadata (`talent.yaml`, schema `belayer-talent/v1`) describes intent
+beyond the bridge mechanics: `runtime.lifecycle: resident | resumable | ephemeral`,
+`activation.mode`, typed `contract.accepts/produces/requires`, gate authority,
+and `memory.scope`. Gates are reusable `belayer-gate/v1` presets — PM is the
+default acceptance gate; crags can declare additional task-stage gates
+(code-review, runtime-qa, continuity, etc.) or replace acceptance with a
+stricter one. See `docs/CRAG_MODE.md` and `docs/CRAG_FILESYSTEM.md`.
 
 ## How a climb flows
 

--- a/README.md
+++ b/README.md
@@ -114,17 +114,19 @@ belayer team add development
 belayer climb start --task "Pick up this backlog item end to end"
 ```
 
-A crag stores reusable teams, playbooks, gates, evaluations, promotions, and
+A crag stores reusable teams, gates, evaluations, promotions, and
 generated talent metadata under `~/.belayer/crags/<name>/`. Story worlds use the
 same shape with `--kind story`, story teams, continuity gates, and world state.
 
-Talent metadata (`talent.yaml`, schema `belayer-talent/v1`) describes intent
-beyond the bridge mechanics: `runtime.lifecycle: resident | resumable | ephemeral`,
+Catalog talent metadata (`talent.yaml`, schema `belayer-talent/v1`) describes
+intent beyond the bridge mechanics: `runtime.lifecycle: resident | resumable | ephemeral`,
 `activation.mode`, typed `contract.accepts/produces/requires`, gate authority,
-and `memory.scope`. Gates are reusable `belayer-gate/v1` presets — PM is the
-default acceptance gate; crags can declare additional task-stage gates
-(code-review, runtime-qa, continuity, etc.) or replace acceptance with a
-stricter one. See `docs/CRAG_MODE.md` and `docs/CRAG_FILESYSTEM.md`.
+and `memory.scope`. Generated talents use a separate `belayer-generated-talent/v1`
+schema for runtime-scaffolded records. Gates follow the `belayer-gate/v1` shape;
+PM is the only gate the daemon enforces today (the session-level acceptance
+gate). Additional crag-defined gates (code-review, runtime-qa, continuity, etc.)
+are documented contracts and proof examples — the daemon does not yet discover
+or execute them. See `docs/CRAG_MODE.md` and `docs/CRAG_FILESYSTEM.md`.
 
 ## How a climb flows
 

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -6,9 +6,11 @@ claims from a design note.
 
 ## Current Or Recently Implemented Designs
 
+- [Org Mode Nightshift plan](2026-04-30-org-mode-nightshift-plan.md) — Stack plan for crag-mode rollout: filesystem contract, CLI, proof examples. Shipped via PRs #117–#129. Prefer `docs/CRAG_MODE.md` and `docs/CRAG_FILESYSTEM.md` for current behavior.
+- [Talent lifecycle contract plan](2026-05-01-talent-lifecycle-contract-plan.md) — Defines `belayer-talent/v1` contract: `role`/`domain`, `activation`, `runtime.lifecycle`, typed `contract`, gate bindings, and lifecycle evidence in evaluations. Docs+schema step shipped; daemon wake-on-mail follow-up tracked separately.
 - [Observability log tiers and API design](2026-04-19-observability-log-tiers-and-api-design.md) — Tiered logging, consolidated CLI+HTTP API, SSE with digests, per-agent spill files, Nightshift-friendly archives.
 - [Template-team exit conditions, prompt discipline, and CI lint](2026-04-20-template-team-exit-conditions-and-prompt-discipline.md) — Implemented prompt/tool/doc-drift cleanup. This file already carries implementation deviations; check shipped prompts and current docs before copying examples.
-- [Belayer-in-clamshell](2026-04-17-belayer-in-clamshell-design.md) — Current direction for container-per-run sandboxing, but not the organization-mode execution adapter boundary.
+- [Belayer-in-clamshell](2026-04-17-belayer-in-clamshell-design.md) — Current direction for container-per-climb sandboxing, but not the organization-mode execution adapter boundary.
 - [Embed hermes_bridge + deployment docs](2026-04-17-embed-hermes-bridge-design.md) — Historical design behind embedded bridge distribution and deployment docs.
 
 ## Historical Or Superseded Designs


### PR DESCRIPTION
## Summary

Sync top-level entry-point docs (CLAUDE.md, README.md, design-docs/index.md) to reflect organization-mode work shipped via PRs #117–#129 (talent contract, crag filesystem, generated talents, acceptance gate, talent lifecycle).

The implementation-side docs (`AGENT_ARCHITECTURE.md`, `CRAG_MODE.md`, `CRAG_FILESYSTEM.md`, `ARTIFACT_SCHEMAS.md`) were updated alongside their shipping PRs. This commit catches up the entry-point map files that lagged.

## Changes

**CLAUDE.md** (89 → 101 lines, still under 120):
- Vocabulary: "run-local" → "climb-local" (matches `root.go:33` and every other current doc)
- Agent identity section: replace flat layer with 4-tier resolution precedence from `CRAG_FILESYSTEM.md` (repo > linked crag > talent-catalog > shipped binary)
- Add `talent.yaml` / `belayer-talent/v1` to identity directory contents
- "PM completion gate" → "Acceptance gate" framing, generalized to `belayer-gate/v1`
- New "Crag mode" section pointing at `CRAG_MODE.md` / `CRAG_FILESYSTEM.md`
- New "CLI surface highlights" listing `climb` / `crag` / `team` commands
- Add `CRAG_MODE.md`, `CRAG_FILESYSTEM.md`, `ARTIFACT_SCHEMAS.md` to docs index
- Drop redundant "CLI surface" stub (folded into highlights)

**README.md**:
- Extend "Climbs and Crags" section with talent metadata fields (`runtime.lifecycle`, `activation.mode`, `contract`, `memory.scope`) and gate generalization (`belayer-gate/v1`, PM as default acceptance preset)

**docs/design-docs/index.md**:
- Add `2026-04-30-org-mode-nightshift-plan.md` (the stack plan for PRs #117–#129)
- Add `2026-05-01-talent-lifecycle-contract-plan.md` (talent contract docs/schema step)
- Update clamshell entry to use "climb" vocabulary

## Documentation health

| File | Status | Details |
|------|--------|---------|
| README.md | Updated | Added talent metadata + gate generalization in Crags section |
| CLAUDE.md | Updated | Vocabulary, 4-tier identity precedence, crag mode, CLI surface, doc links |
| docs/README.md | Current | Already references CRAG_MODE/CRAG_FILESYSTEM/ARTIFACT_SCHEMAS |
| docs/AGENT_ARCHITECTURE.md | Current | Updated in #119/#120 PRs (lifecycle modes, generated-talent tool) |
| docs/CRAG_MODE.md | Current | Shipped in #117/#119 |
| docs/CRAG_FILESYSTEM.md | Current | Shipped in #121 |
| docs/ARTIFACT_SCHEMAS.md | Current | Shipped alongside org-mode work |
| docs/PHILOSOPHY.md | Current | Evergreen, no changes needed |
| docs/design-docs/index.md | Updated | Added 2 missing entries |
| agents/README.md | Current | No drift |
| hermes_bridge/README.md | Current | Already mentions Hermes 0.12 plugin |
| docs/DEPLOYMENT.md | Current | Updated to "climb" vocabulary in earlier PR |
| CHANGELOG.md / VERSION / TODOS.md | N/A | Project does not use these files |

## Test plan

- [ ] Read updated CLAUDE.md top-to-bottom — should make sense to a fresh reader
- [ ] Verify all doc links resolve (`docs/CRAG_MODE.md`, etc.)
- [ ] Confirm CLAUDE.md stays under 120 lines (currently 101)
- [ ] No code changes — `go test ./...` not required, but does not regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified agent identity resolution with explicit precedence order across agent directories and talent catalogs
  * Enhanced crag mode documentation with clearer opt-in and capability details
  * Expanded talent metadata schema documentation including lifecycle, contract details, and gate authority specifications
  * Added new design documentation entries for Org Mode Nightshift rollout and talent lifecycle contract planning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->