### PR TITLE
feat(profiles): Phase 1 — belayer auth + base profile scaffold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Shipped default team:
 
 Customize in `.belayer/agents/` — see `agents/README.md` for worked examples. `belayer team add <category>` copies team identities into `.belayer/agents/`. The `development` category is a CLI special-case that copies the embedded shipped team from `agents/`; other categories (e.g. `story`) live in `examples/talent-catalog/<category>/`.
 
-System prompts are loaded by the daemon at spawn time and injected via Hermes `ephemeral_system_prompt`. All agents use the `default` Hermes profile for now (see profile bootstrap TODO in AGENT_ARCHITECTURE.md).
+System prompts are loaded by the daemon at spawn time and injected via Hermes `ephemeral_system_prompt`. The daemon defaults to the `belayer` Hermes profile (`~/.hermes/profiles/belayer/`); run `belayer auth ensure` once to scaffold it. Per-talent profile forks (`belayer-<crag>-<instance>/`) are coming in Phase 2 (#135). See `docs/design-docs/2026-05-03-belayer-hermes-profiles-spec.md` for the full plan.
 
 The `hermes_bridge` Python package lives in the daemon's runtime dir (default `$XDG_STATE_HOME/belayer/runtime`), not inside any workspace. This protects the module from workspace agent cleanup (`rm -rf .belayer/`).
 
@@ -74,6 +74,7 @@ Crags are durable cross-project operating contexts (software company, story worl
 ## CLI surface highlights
 
 - `belayer climb start` (alias `run`) — start a climb
+- `belayer auth ensure|status` — scaffold/inspect the base `belayer` Hermes profile
 - `belayer crag init|list|link` — manage local crags
 - `belayer team list|add|remove` — manage talent catalog rosters
 - Full surface: `belayer --help` and `belayer <cmd> --help`

--- a/docs/design-docs/2026-05-03-belayer-hermes-profiles-spec.md
+++ b/docs/design-docs/2026-05-03-belayer-hermes-profiles-spec.md
@@ -1,0 +1,241 @@
+# Belayer Hermes Profiles Spec
+
+**Date:** 2026-05-03
+**Status:** Forward-looking, not implemented
+**Epic:** #131
+**Pattern harvest:** #132
+
+## Goal
+
+Move Belayer's runtime backing for talents from a single shared `default` Hermes profile to per-talent-instance profiles forked from a shared `belayer` base. Lean on Hermes's existing profile primitive (`hermes_cli/profiles.py`) for filesystem layout, auth, skills, memories, and sessions. Keep Belayer's identity contract (talents, crags, gates, evaluations) declarative and git-tracked; let runtime state live where Hermes already manages it.
+
+## Why
+
+Current state: every Belayer agent runs on the `default` Hermes profile. All talents share auth, memories, skills, and `state.db`. This blocks:
+
+- Multi-vendor talent teams (different providers per talent)
+- Per-crag isolation (software-personal vs software-work vs parley NPCs sharing one memory bank)
+- Talent-specific learned context (each talent's accumulated MEMORY.md drowns in the shared default)
+- Operator separation of concerns between projects
+
+Hermes already solves the per-instance isolation problem with profiles. Belayer should adopt the primitive instead of working around it.
+
+## Architecture
+
+Two stacks, parallel coordination, distinct ownership:
+
+```
+.belayer/                    Belayer-owned, declarative, git-tracked.
+                             Identity templates, crag config, climb artifacts.
+
+~/.belayer/                  Belayer-owned, cross-project knowledge.
+                             Talent catalog, crag SOPs, evaluations, promotions.
+
+~/.hermes/profiles/          Hermes-owned, runtime instance state.
+                             Per-talent-instance profile dirs.
+```
+
+Belayer reads/writes Hermes profiles via the existing `hermes_cli.profiles` API (or equivalent Go-native logic).
+
+## Profile naming
+
+```
+~/.hermes/profiles/
+├── belayer/                                 ← base, single source of auth + plugin reg
+├── belayer-<cragSlug>-<instanceID>/         ← per-talent-instance, forked from base
+```
+
+`instanceID` resolution:
+- Singleton talent: `<talentName>` (e.g. `supervisor`)
+- Parallel mains: `<talentName>-<short8hex>` (e.g. `backend-dev-a3f9c2d1`)
+- Generated talent: `<generatedTalentID>` (e.g. `generated-reviewer-1`)
+
+Char budget: `belayer-` (8) + crag (≤20) + `-` (1) + instance (≤35) ≤ 64 chars (Hermes regex `^[a-z0-9][a-z0-9_-]{0,63}$`). Validate at `belayer crag init`.
+
+## Forward materialization (.belayer → profile)
+
+Spawn sequence:
+
+1. Resolve identity through 4-layer precedence (already shipped, `internal/daemon/agents.go`).
+2. Resolve crag context from `.belayer/config.yaml#crag.name` or explicit flag.
+3. Compute profile name: `belayer-<crag>-<instanceID>`.
+4. If profile dir missing:
+   - Fork from `belayer` base with config + skills + memory seed copied.
+   - Auth: see "Auth fork strategy" below.
+5. Render `system-prompt.md` template → write `<profile>/SOUL.md`.
+6. Materialize `talent.yaml`-derived config:
+   - `memory.scope` → profile teardown rule (climb / crag / talent).
+   - `retention.scope` → archive rule.
+   - `authority.tools` → `BELAYER_TOOLS` env (existing wiring).
+   - `model` → `config.yaml` model field or `BELAYER_MODEL` env.
+7. Set `HERMES_HOME=~/.hermes/profiles/belayer-<crag>-<instance>` and spawn bridge subprocess via existing path.
+
+## Backward sync (profile → .belayer)
+
+Evidence-driven only. No silent copy of profile state back to `.belayer/`. Per `docs/CRAG_FILESYSTEM.md` privacy contract.
+
+| Trigger | Action |
+|---|---|
+| Climb end (memory.scope == "climb") | Daemon reads profile MEMORY.md → writes `talent-evaluation` artifact → tears down profile dir. |
+| Climb end (memory.scope == "crag") | Same evaluation artifact written; profile preserved across climbs. |
+| Operator retire (`belayer prune`) | Snapshot final SOUL.md, MEMORY.md, USER.md → archive in `~/.belayer/crags/<crag>/evaluations/<talent>/<date>.json`; delete profile. |
+| Operator promote (`belayer promote <eval>`) | Apply diff to catalog `talent.yaml` (maturity bump) or crag `sops/`, `gates/`. Profile untouched. |
+
+## Lifecycle binding
+
+`talent.yaml#runtime.lifecycle` (per #119) maps directly to profile retention:
+
+| Lifecycle | Profile retention | Sessions | Memory persists |
+|---|---|---|---|
+| `resident` | until climb end | active throughout | yes during climb |
+| `resumable` | until crag retire or explicit prune | dormant after run; mail wake (#118) reuses | yes |
+| `ephemeral` | tear down after `final_response` | discarded | no (unless evaluation extracts) |
+
+No new contract fields required.
+
+## Auth fork strategy
+
+**Resolved by Phase 0 spike (#133).** Symlink `auth.json` from each fork to base `belayer/auth.json`. Hermes's `utils.atomic_replace` (utils.py:61-82) preserves symlinks via `os.path.realpath` per #16743 upstream — token rotation in base propagates to all forks transparently.
+
+Same pattern extends to `plugins/` and `skills/` subdirs (plugin discovery walks symlinks). Per-fork dir holds only mutable state: `memories/`, `sessions/`, `state.db`, `SOUL.md`, `config.yaml`.
+
+## CLI surface
+
+```
+belayer auth                            # creates ~/.hermes/profiles/belayer/, runs hermes auth login
+belayer auth status                     # base profile auth state, refresh time
+
+belayer doctor                          # profile health: orphans, mismatched agent_runs/profiles, auth staleness
+belayer doctor --crag <slug>            # scoped to one crag
+
+belayer prune                           # interactive: list orphan profiles, remove
+belayer prune --crag <slug>             # scoped
+
+belayer uninstall --crag <slug>         # remove all belayer-<slug>-* + .belayer/crags/<slug>/
+belayer uninstall                       # global: remove all belayer-* + base + ~/.belayer/
+```
+
+## Why not Hermes Kanban
+
+Hermes ships a durable multi-agent task board (`~/.hermes/kanban.db`) with overlapping primitives: dispatcher-driven worker spawn, structured handoff, crash reclaim, retry rows, dashboard. We choose not to migrate Belayer's coordination plane to Kanban for two reasons:
+
+1. **Maintenance burden**: Kanban evolves on Hermes's gateway-universal axis; Belayer needs per-instance unique scoping. Riding both stacks creates compounding drift.
+2. **Architectural fit**: Kanban is board-global, dispatcher-driven, designed for many profiles sharing one queue. Belayer is climb-scoped, supervisor-LLM-driven, with mainline peer-to-peer mailbox semantics. Real-time mainline coordination doesn't fit kanban's task-thread model.
+
+Patterns worth porting independently (crash reclaim, idempotency keys, max-runtime, per-attempt rows, structured handoff schema) are tracked separately — see issue [TBD: kanban-pattern-harvest].
+
+The meeting point between Hermes and Belayer is the profile primitive, not the coordination plane.
+
+## Phases
+
+Each phase is a separate GitHub issue with blocking dependencies on prior phases.
+
+### Phase 0 — spike (#133) — COMPLETE 2026-05-03
+
+Findings (all four investigations resolved without runtime experiments — answered by hermes-agent source inspection):
+
+**1. Auth fork mechanism: symlink confirmed viable.**
+
+`hermes-agent/utils.py:61-82` defines `atomic_replace(tmp, target)` that explicitly preserves symlinks:
+
+> When *target* is a symlink, the symlink itself is replaced with a regular file — silently detaching managed deployments that symlink config.yaml / SOUL.md / auth.json etc. from ~/.hermes/ to a git-tracked profile package or dotfiles repo (GitHub #16743).
+>
+> This helper resolves the symlink first so os.replace writes to the real file in-place while the symlink survives.
+
+```python
+real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
+os.replace(str(tmp_path), real_path)
+```
+
+`_save_auth_store` (auth.py:853-886) uses `atomic_replace`. Token rotation in base `belayer/auth.json` propagates to every symlinked fork. Decision: **Option 1 (symlink) selected**. Drop Options 2 (watch+sync) and 3 (lazy copy).
+
+**2. Plugin/skill discovery from symlinked profile dirs: walks symlinks correctly.**
+
+`PluginManager._scan_directory_level` (plugins.py:781-835) uses `Path.iterdir()`, `Path.is_dir()`, and `Path.exists()` — all follow symlinks per Python stdlib. Symlinking `<profile>/plugins/belayer → <base>/plugins/belayer` works without special handling. Skills directory uses identical iteration shape.
+
+Belayer plugin currently lives at `~/.hermes/plugins/belayer/` (`kind: standalone`, version 0.2.0). Per-profile install via symlink from base profile, with `plugins.enabled` listing belayer in profile config.yaml.
+
+**3. SQLite WAL contention: not a concern.**
+
+`DEFAULT_DB_PATH = get_hermes_home() / "state.db"` (hermes_state.py:34). Each profile owns its own state.db. WAL is per-file, so isolation is automatic. Hermes's documented contention concerns (hermes_state.py:167-180) are about multiple processes sharing one DB — not multiple profiles.
+
+**Bug surfaced for Phase 2:** `hermes_bridge/__main__.py:410` hardcodes `~/.hermes/state.db` ignoring HERMES_HOME. Bridge must read `<HERMES_HOME>/state.db` when constructing `SessionDB`. Add to Phase 2 task list.
+
+**4. Upstream Hermes engagement: filed.**
+
+NousResearch/hermes-agent#19436 — proposing `hermes profile create --link-auth <base>` CLI flag plus docs for the symlink fork pattern. Optional companion flags `--link-skills` / `--link-plugins`. Belayer can implement the pattern locally in the meantime; upstream adoption only affects DX.
+
+**Storage growth:** With shared symlinked `auth.json` + `plugins/` + `skills/` from base, per-fork dir holds only `memories/`, `sessions/`, `state.db`, `SOUL.md`, `config.yaml` — likely under 5MB per dormant fork. Storage growth concern from spec (~2.5GB for 25 talents) is mitigated.
+
+### Phase 0 — output
+
+- All four spike questions resolved.
+- Auth fork mechanism: symlink (Option 1).
+- Plugin/skill discovery: symlinks supported.
+- WAL contention: non-issue with per-profile DBs.
+- New blocker for Phase 2: bridge state.db path bug.
+- Upstream issue: NousResearch/hermes-agent#19436.
+
+Estimate vs actual: 1 day budget; resolved in single session via source reading. No runtime experiments needed because Hermes already documents the symlink-preserving pattern in source.
+
+### Phase 1 — base belayer profile + `belayer auth` (#134, blocked by #133)
+
+- `belayer auth` command scaffolds `~/.hermes/profiles/belayer/`.
+- Plugin install path: `~/.hermes/profiles/belayer/plugins/belayer/` (symlink or copy).
+- Daemon defaults to `belayer` profile (was `default`).
+- Backwards-compat: `--profile default` still works.
+
+### Phase 2 — talent → profile materialization (#135, blocked by #134)
+
+- New module: `internal/daemon/profiles.go` — fork base, render SOUL, lifecycle binding.
+- Hook into existing spawn path in `internal/daemon/agents.go`.
+- Profile name resolution + crag context wiring.
+- Tests: parallel mains get distinct profiles; generated talents get scoped names; crag context resolved.
+
+Depends on: Phase 1.
+
+### Phase 3 — lifecycle wiring (#136, blocked by #135)
+
+- Tear-down on climb end honors `memory.scope`.
+- Resumable mains get profile preserved across runs.
+- Mail wake (#118) reuses profile for resume.
+- `talent-evaluation` artifact extraction at tear-down.
+
+Depends on: Phase 2.
+
+### Phase 4 — devex (doctor / prune / uninstall) (#137, blocked by #136)
+
+- `belayer doctor [--crag <slug>]` — orphan detection, auth staleness check.
+- `belayer prune [--crag <slug>]` — interactive removal.
+- `belayer uninstall [--crag <slug>]` — scoped or global.
+- `agent_runs` ↔ profile dir reconciliation logic.
+
+Depends on: Phase 3.
+
+### Phase 5 — Parley library shape
+
+- Talent management Go SDK or stable CLI subcommands for downstream embed (Parley).
+- Defer until Phase 4 ships and Parley language picked.
+
+Depends on: Phase 4.
+
+## Open questions
+
+1. ~~Auth fork mechanism~~ — **resolved**: symlink (Phase 0).
+2. Profile dir creation: shell to `hermes profile create` vs Go-native write? Single-source-of-truth vs Python dependency tradeoff. **Recommendation**: shell out for now (avoids drift); revisit if startup latency hurts.
+3. `agent_runs.hermes_session_id` retention when profile torn down — does session ID become invalid if `state.db` gone? **Likely yes** per Hermes session model. Phase 3 must reconcile by either (a) preserving state.db for resumable lifecycle, or (b) clearing stale `hermes_session_id` on teardown.
+4. Crag context resolution at spawn — `.belayer/config.yaml#crag.name` already shipped (#113); needs plumbing to spawn path. **Phase 2 task.**
+5. ~~Storage growth~~ — **resolved**: symlink-shared `skills/` + `plugins/` + `auth.json` from base. Per-fork ~5MB.
+6. **NEW from Phase 0**: `hermes_bridge/__main__.py:410` hardcodes `~/.hermes/state.db` ignoring HERMES_HOME. **Phase 2 task** — read `<HERMES_HOME>/state.db` instead.
+
+## Validation
+
+Required for each phase PR:
+
+```bash
+go build ./cmd/belayer
+go test ./...
+go test ./internal/daemon
+go test ./internal/agentlint
+git diff --check
+```

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -6,6 +6,7 @@ claims from a design note.
 
 ## Current Or Recently Implemented Designs
 
+- [Belayer Hermes profiles spec](2026-05-03-belayer-hermes-profiles-spec.md) — Forward-looking. Per-talent-instance Hermes profile materialization replacing the shared `default` profile. Epic #131; phase issues #133–#137; pattern-harvest sibling #132.
 - [Org Mode Nightshift plan](2026-04-30-org-mode-nightshift-plan.md) — Stack plan for crag-mode rollout: filesystem contract, CLI, proof examples. Shipped via PRs #117–#129. Prefer `docs/CRAG_MODE.md` and `docs/CRAG_FILESYSTEM.md` for current behavior.
 - [Talent lifecycle contract plan](2026-05-01-talent-lifecycle-contract-plan.md) — Defines `belayer-talent/v1` contract: `role`/`domain`, `activation`, `runtime.lifecycle`, typed `contract`, gate bindings, and lifecycle evidence in evaluations. Docs+schema step shipped; daemon wake-on-mail follow-up tracked separately.
 - [Observability log tiers and API design](2026-04-19-observability-log-tiers-and-api-design.md) — Tiered logging, consolidated CLI+HTTP API, SSE with digests, per-agent spill files, Nightshift-friendly archives.

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -1,0 +1,214 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// belayerProfileName is the canonical Hermes profile name that holds shared
+// auth, plugin registration, and skill catalog for all per-talent forks.
+// Per-talent profiles in Phase 2 will be named belayer-<crag>-<instance>
+// and symlink auth.json + plugins/ + skills/ from this base profile.
+const belayerProfileName = "belayer"
+
+// hermesProfileDirs mirrors hermes_cli/profiles.py#_PROFILE_DIRS so a profile
+// scaffolded by belayer matches one created by `hermes profile create` in shape.
+// Subprocess HOME isolation (the `home/` subdir) is intentional — see Hermes
+// hermes_constants.get_subprocess_home() for details.
+var hermesProfileDirs = []string{
+	"memories",
+	"sessions",
+	"skills",
+	"skins",
+	"logs",
+	"plans",
+	"workspace",
+	"cron",
+	"home",
+}
+
+func newAuthCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Manage the base belayer Hermes profile (auth, plugin install)",
+		Long: `Manage the base belayer Hermes profile.
+
+The base profile lives at ~/.hermes/profiles/belayer/ and holds shared auth
+credentials, the belayer Hermes plugin, and skill catalog. Per-talent forks
+created during a climb symlink auth.json + plugins/ + skills/ from this base,
+so a single 'belayer auth' login propagates to every spawned talent.`,
+	}
+	cmd.AddCommand(newAuthEnsureCmd(), newAuthStatusCmd())
+	return cmd
+}
+
+func newAuthEnsureCmd() *cobra.Command {
+	var skipLogin bool
+	cmd := &cobra.Command{
+		Use:   "ensure",
+		Short: "Scaffold ~/.hermes/profiles/belayer/, install belayer plugin, run hermes auth login",
+		Long: `Idempotent setup of the base belayer profile.
+
+Creates the profile directory tree (matching Hermes's profile schema), extracts
+the embedded belayer plugin into <profile>/plugins/belayer/, ensures the plugin
+is enabled in <profile>/config.yaml, and finally runs 'hermes auth login' with
+HERMES_HOME pointed at the profile.
+
+Safe to re-run; existing files are preserved and only stale plugin files are
+pruned. Use --skip-login for headless setup or test environments.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profileDir, err := belayerProfileDir()
+			if err != nil {
+				return err
+			}
+			created, err := scaffoldBelayerProfile(profileDir)
+			if err != nil {
+				return fmt.Errorf("scaffold profile: %w", err)
+			}
+			if created {
+				fmt.Fprintf(cmd.OutOrStdout(), "Created belayer profile at %s\n", profileDir)
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "Belayer profile present at %s\n", profileDir)
+			}
+			if err := extractPluginsToHermesHome(profileDir); err != nil {
+				return fmt.Errorf("install belayer plugin: %w", err)
+			}
+			if changed, err := ensureHermesPluginEnabled(profileDir, "belayer"); err != nil {
+				return fmt.Errorf("enable belayer plugin: %w", err)
+			} else if changed {
+				fmt.Fprintln(cmd.OutOrStdout(), "Enabled belayer plugin in profile config.yaml")
+			}
+			if skipLogin {
+				fmt.Fprintln(cmd.OutOrStdout(), "Skipped 'hermes auth login' (--skip-login)")
+				return nil
+			}
+			return runHermesAuthLogin(profileDir, cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+	cmd.Flags().BoolVar(&skipLogin, "skip-login", false, "Skip running 'hermes auth login' (for headless setup or tests)")
+	return cmd
+}
+
+func newAuthStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Report base belayer profile state (path, auth.json mtime, plugin presence)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profileDir, err := belayerProfileDir()
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Profile: %s\n", profileDir)
+			info, err := os.Stat(profileDir)
+			if err != nil {
+				if os.IsNotExist(err) {
+					fmt.Fprintln(out, "  Status: not created (run `belayer auth ensure`)")
+					return nil
+				}
+				return fmt.Errorf("stat profile: %w", err)
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("profile path %q exists but is not a directory", profileDir)
+			}
+			fmt.Fprintln(out, "  Status: present")
+
+			authPath := filepath.Join(profileDir, "auth.json")
+			if authInfo, err := os.Stat(authPath); err == nil {
+				age := time.Since(authInfo.ModTime()).Round(time.Second)
+				fmt.Fprintf(out, "  auth.json: %s (modified %s ago)\n", authInfo.ModTime().Format(time.RFC3339), age)
+			} else if os.IsNotExist(err) {
+				fmt.Fprintln(out, "  auth.json: missing (run `hermes auth login` with HERMES_HOME=" + profileDir + ")")
+			} else {
+				return fmt.Errorf("stat auth.json: %w", err)
+			}
+
+			pluginPath := filepath.Join(profileDir, "plugins", "belayer", "plugin.yaml")
+			if _, err := os.Stat(pluginPath); err == nil {
+				fmt.Fprintln(out, "  belayer plugin: installed")
+			} else {
+				fmt.Fprintln(out, "  belayer plugin: missing (run `belayer auth ensure`)")
+			}
+			return nil
+		},
+	}
+}
+
+// belayerProfileDir returns the absolute path to the base belayer Hermes
+// profile. Honours HERMES_HOME's parent layout: when HERMES_HOME is set we
+// place profiles under HERMES_HOME/../profiles/belayer if HERMES_HOME ends
+// in /profiles/<name>, otherwise HERMES_HOME/profiles/belayer.
+//
+// Today's only caller is the auth command, which always wants the canonical
+// home location. We keep the env-aware logic so test fixtures can redirect
+// the whole tree by setting HERMES_HOME=<tmpdir>.
+func belayerProfileDir() (string, error) {
+	if env := os.Getenv("HERMES_HOME"); env != "" {
+		// If HERMES_HOME already points at a profile dir, the parent profiles/
+		// is the canonical location. Detect by checking if parent is named
+		// "profiles". Otherwise treat HERMES_HOME as the root and nest profiles
+		// underneath.
+		parent := filepath.Base(filepath.Dir(env))
+		if parent == "profiles" {
+			return filepath.Join(filepath.Dir(env), belayerProfileName), nil
+		}
+		return filepath.Join(env, "profiles", belayerProfileName), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, ".hermes", "profiles", belayerProfileName), nil
+}
+
+// scaffoldBelayerProfile creates the profile dir and the standard Hermes
+// subdirectory layout (matching hermes_cli/profiles.py#_PROFILE_DIRS).
+// Returns (createdNewProfile, error). Idempotent: re-running on an existing
+// profile is a no-op.
+func scaffoldBelayerProfile(profileDir string) (bool, error) {
+	created := false
+	if _, err := os.Stat(profileDir); errors.Is(err, os.ErrNotExist) {
+		created = true
+	} else if err != nil {
+		return false, fmt.Errorf("stat profile dir: %w", err)
+	}
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		return false, fmt.Errorf("mkdir profile root: %w", err)
+	}
+	for _, sub := range hermesProfileDirs {
+		if err := os.MkdirAll(filepath.Join(profileDir, sub), 0o755); err != nil {
+			return false, fmt.Errorf("mkdir profile %s: %w", sub, err)
+		}
+	}
+	return created, nil
+}
+
+// runHermesAuthLogin invokes `hermes auth login` against the given profile
+// dir. The hermes binary must be on PATH; if missing we print an actionable
+// error directing the operator to install hermes-agent first.
+//
+// Stdin/stdout/stderr are wired through so OAuth device-flow URLs and any
+// interactive prompts surface to the user's terminal as if they ran
+// `hermes auth login` themselves.
+func runHermesAuthLogin(profileDir string, stdout, stderr io.Writer) error {
+	bin, err := exec.LookPath("hermes")
+	if err != nil {
+		return fmt.Errorf("'hermes' binary not found on PATH; install hermes-agent first (https://github.com/NousResearch/hermes-agent): %w", err)
+	}
+	cmd := exec.Command(bin, "auth", "login")
+	cmd.Env = append(os.Environ(), "HERMES_HOME="+profileDir)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("hermes auth login failed: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestScaffoldBelayerProfile_FreshCreatesAllDirs verifies that a fresh
+// scaffold call creates the full Hermes profile directory tree. The set
+// must match hermes_cli/profiles.py#_PROFILE_DIRS so a profile we create
+// is indistinguishable from one created by `hermes profile create`.
+func TestScaffoldBelayerProfile_FreshCreatesAllDirs(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "belayer-profile")
+
+	created, err := scaffoldBelayerProfile(dir)
+	if err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+	if !created {
+		t.Errorf("expected created=true on fresh scaffold, got false")
+	}
+
+	for _, sub := range hermesProfileDirs {
+		path := filepath.Join(dir, sub)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("expected %s to exist: %v", path, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("expected %s to be a directory", path)
+		}
+	}
+}
+
+// TestScaffoldBelayerProfile_Idempotent verifies that re-scaffolding an
+// existing profile is a no-op and reports created=false. Operators may
+// re-run `belayer auth ensure` after every Hermes upgrade to refresh the
+// plugin; existing memories/sessions must not be touched.
+func TestScaffoldBelayerProfile_Idempotent(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "belayer-profile")
+
+	if _, err := scaffoldBelayerProfile(dir); err != nil {
+		t.Fatalf("first scaffold: %v", err)
+	}
+	// Plant a sentinel file in memories/ so we can confirm re-scaffold doesn't
+	// nuke user state.
+	sentinel := filepath.Join(dir, "memories", "MEMORY.md")
+	if err := os.WriteFile(sentinel, []byte("user data"), 0o644); err != nil {
+		t.Fatalf("plant sentinel: %v", err)
+	}
+
+	created, err := scaffoldBelayerProfile(dir)
+	if err != nil {
+		t.Fatalf("second scaffold: %v", err)
+	}
+	if created {
+		t.Errorf("expected created=false on second scaffold, got true")
+	}
+	data, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("sentinel disappeared: %v", err)
+	}
+	if string(data) != "user data" {
+		t.Errorf("sentinel was modified: got %q", string(data))
+	}
+}
+
+// TestBelayerProfileDir_HermesHomeOverride verifies the env-aware path
+// resolution: HERMES_HOME under .hermes/profiles/<name>/ should anchor
+// belayer at the same parent profiles/ dir; HERMES_HOME at a custom root
+// should nest profiles/ underneath. This lets test fixtures redirect the
+// whole layout to a tmpdir without touching the real ~/.hermes.
+func TestBelayerProfileDir_HermesHomeOverride(t *testing.T) {
+	tests := []struct {
+		name       string
+		hermesHome string
+		want       string
+	}{
+		{
+			name:       "profile-style HERMES_HOME",
+			hermesHome: "/tmp/hermes/profiles/coder",
+			want:       "/tmp/hermes/profiles/belayer",
+		},
+		{
+			name:       "root-style HERMES_HOME",
+			hermesHome: "/tmp/custom-hermes",
+			want:       "/tmp/custom-hermes/profiles/belayer",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HERMES_HOME", tc.hermesHome)
+			got, err := belayerProfileDir()
+			if err != nil {
+				t.Fatalf("belayerProfileDir: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("belayerProfileDir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBelayerProfileDir_NoEnvFallsBackToHome verifies the default path
+// when HERMES_HOME is unset: ~/.hermes/profiles/belayer.
+func TestBelayerProfileDir_NoEnvFallsBackToHome(t *testing.T) {
+	t.Setenv("HERMES_HOME", "")
+	got, err := belayerProfileDir()
+	if err != nil {
+		t.Fatalf("belayerProfileDir: %v", err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	want := filepath.Join(home, ".hermes", "profiles", "belayer")
+	if got != want {
+		t.Errorf("belayerProfileDir() = %q, want %q", got, want)
+	}
+}
+
+// TestAuthEnsure_SkipLogin_ScaffoldsAndInstallsPlugin verifies the
+// end-to-end ensure flow with --skip-login: profile dirs created, plugin
+// extracted, plugin enabled in config.yaml. The login step is skipped so
+// the test runs without an interactive terminal or the hermes binary
+// installed.
+func TestAuthEnsure_SkipLogin_ScaffoldsAndInstallsPlugin(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HERMES_HOME", filepath.Join(tmp, "fake-hermes-home"))
+
+	cmd := newAuthEnsureCmd()
+	cmd.SetArgs([]string{"--skip-login"})
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("ensure --skip-login: %v\nstderr: %s", err, stderr.String())
+	}
+
+	profileDir := filepath.Join(tmp, "fake-hermes-home", "profiles", "belayer")
+
+	for _, sub := range hermesProfileDirs {
+		if _, err := os.Stat(filepath.Join(profileDir, sub)); err != nil {
+			t.Errorf("expected %s to exist: %v", sub, err)
+		}
+	}
+
+	manifest := filepath.Join(profileDir, "plugins", "belayer", "plugin.yaml")
+	if _, err := os.Stat(manifest); err != nil {
+		t.Errorf("plugin manifest missing: %v", err)
+	}
+
+	cfg, err := os.ReadFile(filepath.Join(profileDir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	if !strings.Contains(string(cfg), "belayer") {
+		t.Errorf("config.yaml does not list belayer plugin:\n%s", string(cfg))
+	}
+
+	if !strings.Contains(stdout.String(), "Created belayer profile at") {
+		t.Errorf("expected creation log line, got: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Skipped 'hermes auth login'") {
+		t.Errorf("expected skip-login log line, got: %q", stdout.String())
+	}
+}
+
+// TestAuthStatus_ReportsMissingProfile verifies that `belayer auth status`
+// gracefully reports an unscaffolded profile without erroring. Operators
+// running it pre-setup should get a clear next-step hint, not a stack trace.
+func TestAuthStatus_ReportsMissingProfile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HERMES_HOME", filepath.Join(tmp, "empty-hermes"))
+
+	cmd := newAuthStatusCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "not created") {
+		t.Errorf("expected 'not created' hint, got: %q", out)
+	}
+	if !strings.Contains(out, "belayer auth ensure") {
+		t.Errorf("expected next-step hint to mention `belayer auth ensure`, got: %q", out)
+	}
+}
+
+// TestAuthStatus_ReportsScaffoldedProfile verifies that after a successful
+// ensure, status reports the plugin as installed and the auth.json as
+// missing (since --skip-login was used).
+func TestAuthStatus_ReportsScaffoldedProfile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HERMES_HOME", filepath.Join(tmp, "fake-hermes"))
+
+	ensure := newAuthEnsureCmd()
+	ensure.SetArgs([]string{"--skip-login"})
+	ensure.SetOut(&bytes.Buffer{})
+	ensure.SetErr(&bytes.Buffer{})
+	if err := ensure.Execute(); err != nil {
+		t.Fatalf("ensure prep: %v", err)
+	}
+
+	status := newAuthStatusCmd()
+	var out bytes.Buffer
+	status.SetOut(&out)
+	status.SetErr(&bytes.Buffer{})
+	if err := status.Execute(); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Status: present") {
+		t.Errorf("expected 'Status: present', got: %q", got)
+	}
+	if !strings.Contains(got, "belayer plugin: installed") {
+		t.Errorf("expected plugin-installed line, got: %q", got)
+	}
+	if !strings.Contains(got, "auth.json: missing") {
+		t.Errorf("expected auth.json missing hint after --skip-login, got: %q", got)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -56,6 +56,7 @@ over SQLite.`,
 		newTeamCmd(),
 		newCragCmd(),
 		newInitCmd(),
+		newAuthCmd(),
 		newArchiveCmd(),
 		newBridgesCmd(),
 	)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -87,7 +87,7 @@ func newRunStartCmd() *cobra.Command {
 			}
 
 			if strings.TrimSpace(supervisorProfile) == "" {
-				supervisorProfile = "default"
+				supervisorProfile = belayerProfileName
 			}
 
 			// Parse repos.
@@ -173,7 +173,7 @@ func newRunStartCmd() *cobra.Command {
 	cmd.Flags().StringVar(&socket, "socket", "", "Daemon socket path")
 	cmd.Flags().StringVar(&name, "name", "", "Climb/session name")
 	cmd.Flags().StringVar(&task, "task", "", "Initial task text for the supervisor")
-	cmd.Flags().StringVar(&supervisorProfile, "supervisor-profile", "default", "Hermes profile for the supervisor")
+	cmd.Flags().StringVar(&supervisorProfile, "supervisor-profile", belayerProfileName, "Hermes profile for the supervisor (default: belayer; run `belayer auth ensure` first)")
 	cmd.Flags().StringVar(&workdir, "workdir", "", "Working directory (defaults to cwd)")
 	cmd.Flags().StringVar(&reposFlag, "repos", "", "Repos to include: name=path,name=path (e.g. frontend=../fe,backend=../be)")
 	cmd.Flags().StringArrayVar(&exitConditions, "exit-condition", nil, "Override .belayer/config.yaml#exit_conditions for this climb. Repeatable. When present, these replace the file's list entirely.")


### PR DESCRIPTION
## Summary

- Adds `belayer auth ensure` / `belayer auth status` commands for one-time setup of the base `belayer` Hermes profile at `~/.hermes/profiles/belayer/`.
- Daemon now defaults supervisor spawns to the `belayer` profile (was `default`). Backwards-compat preserved: explicit `--supervisor-profile default` still works.
- Profile dir layout matches `hermes_cli/profiles.py#_PROFILE_DIRS` so the output is indistinguishable from `hermes profile create`.
- Includes the design doc that anchors the full epic (#131) and a sibling kanban-pattern-harvest issue (#132).

## Phase 0 spike (#133) findings folded in

- Hermes `utils.atomic_replace` preserves symlinks (utils.py:61-82, upstream #16743) — per-fork auth.json symlink to base survives OAuth refresh. Symlink fork mechanism confirmed viable.
- Plugin/skill discovery walks symlinks (plugins.py:756-835). Per-fork plugin install via symlink works.
- WAL contention non-issue with per-profile `state.db` files.
- Bug surfaced for Phase 2: `hermes_bridge/__main__.py:410` hardcodes `~/.hermes/state.db` ignoring HERMES_HOME. Tracked in #135.
- Upstream issue filed: NousResearch/hermes-agent#19436 (proposing `hermes profile create --link-auth <base>`).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — 783 passed in 20 packages
- [x] New tests in `internal/cli/auth_test.go`:
  - scaffold creates all `_PROFILE_DIRS` subdirs
  - scaffold idempotent + preserves user state in `memories/`
  - `belayerProfileDir()` honors HERMES_HOME profile-style + root-style paths
  - `belayer auth ensure --skip-login` extracts plugin + enables it in config.yaml
  - `belayer auth status` reports missing profile gracefully
  - `belayer auth status` reports installed plugin + missing auth.json after `--skip-login`
- [x] `go run ./cmd/belayer auth --help` surfaces both subcommands

## Operator setup

```bash
go build -o ~/.local/bin/belayer ./cmd/belayer
belayer auth ensure              # scaffolds + plugin install + hermes auth login
belayer auth status              # confirm
```

## Stack

- Closes #134
- Refs #131 (epic), #133 (Phase 0 — closed)
- Phase 2 (#135) will stack on this branch

## Design

- `docs/design-docs/2026-05-03-belayer-hermes-profiles-spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)