### PR TITLE
feat(profiles): Phase 5 — stable cross-climb profile naming

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -22,8 +22,10 @@ const doctorAuthStaleDefaultDays = 30
 type doctorProfileStatus string
 
 const (
-	doctorProfileActive doctorProfileStatus = "active"
-	doctorProfileOrphan doctorProfileStatus = "orphan"
+	doctorProfileActive          doctorProfileStatus = "active"
+	doctorProfileOrphan          doctorProfileStatus = "orphan"
+	doctorProfilePreservedCrag   doctorProfileStatus = "preserved-crag"
+	doctorProfilePreservedTalent doctorProfileStatus = "preserved-talent"
 )
 
 // doctorProfileEntry holds display data for one belayer-* profile.
@@ -68,6 +70,7 @@ func newDoctorCmd() *cobra.Command {
 	var cragFilter string
 	var jsonOut bool
 	var dbPath string
+	var includeScoped bool
 
 	cmd := &cobra.Command{
 		Use:   "doctor",
@@ -79,6 +82,10 @@ Lists all belayer-* Hermes profiles, groups them by crag slug, and checks:
   - Orphaned agent_runs rows (profile dir gone).
   - Base belayer profile presence and auth.json staleness.
   - Disk usage per crag.
+
+Profiles with memory.scope=crag or memory.scope=talent are intentionally
+preserved across climbs and are shown as [preserved-crag] or [preserved-talent]
+rather than [orphan]. Use --include-scoped to treat them as orphans too.
 
 Use --crag to filter to a single crag. Use --json to emit structured JSON
 for tooling (e.g. jq).
@@ -104,7 +111,7 @@ Read-only: doctor never modifies any state.`,
 				}
 			}
 
-			report, err := buildDoctorReport(resolvedDB, cragFilter, staleDays)
+			report, err := buildDoctorReport(resolvedDB, cragFilter, staleDays, includeScoped)
 			if err != nil {
 				return fmt.Errorf("doctor: %w", err)
 			}
@@ -120,11 +127,14 @@ Read-only: doctor never modifies any state.`,
 	cmd.Flags().StringVar(&cragFilter, "crag", "", "Filter to one crag slug")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit JSON instead of human-readable text")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database path (default ~/.belayer/belayer.db)")
+	cmd.Flags().BoolVar(&includeScoped, "include-scoped", false, "Treat crag/talent-scoped profiles as orphans (override preservation safety)")
 	return cmd
 }
 
 // buildDoctorReport assembles a doctorReport from the profile dirs and store.
-func buildDoctorReport(dbPath, cragFilter string, staleDays int) (doctorReport, error) {
+// includeScoped controls whether crag/talent-scoped profiles without a live run
+// are classified as orphans (true) or preserved (false, the safe default).
+func buildDoctorReport(dbPath, cragFilter string, staleDays int, includeScoped bool) (doctorReport, error) {
 	var report doctorReport
 
 	// 1. Resolve ProfilesRoot and stat base profile.
@@ -173,8 +183,24 @@ func buildDoctorReport(dbPath, cragFilter string, staleDays int) (doctorReport, 
 		status := doctorProfileActive
 		reason := ""
 		if !knownProfiles[profileName] {
-			status = doctorProfileOrphan
-			reason = "no matching agent_run"
+			// Determine the memory scope to decide if this is a true orphan or a
+			// preserved cross-climb profile.
+			scope := doctorReadMemoryScope(filepath.Join(profilesRoot, profileName), profileName)
+			switch {
+			case includeScoped || scope == "climb" || scope == "":
+				status = doctorProfileOrphan
+				reason = "no matching agent_run"
+			case scope == "crag":
+				status = doctorProfilePreservedCrag
+				reason = "memory.scope=crag (preserved across climbs)"
+			case scope == "talent":
+				status = doctorProfilePreservedTalent
+				reason = "memory.scope=talent (preserved across climbs)"
+			default:
+				// Unknown scope — treat conservatively as orphan.
+				status = doctorProfileOrphan
+				reason = "no matching agent_run"
+			}
 		}
 
 		diskBytes := pruneDirSize(filepath.Join(profilesRoot, profileName))
@@ -370,6 +396,26 @@ func doctorReadCragSlug(profileDir, profileName string) (cragSlug, talentName st
 	return doctorSplitProfileName(profileName)
 }
 
+// doctorReadMemoryScope reads the memory_scope field from a profile's
+// .belayer-talent.yaml. Returns "climb" as the safe default if the file is
+// missing or unreadable (ephemeral by default).
+func doctorReadMemoryScope(profileDir, profileName string) string {
+	data, err := os.ReadFile(filepath.Join(profileDir, ".belayer-talent.yaml"))
+	if err != nil {
+		return "climb"
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "memory_scope:") {
+			scope := strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "memory_scope:")), `"'`)
+			if scope != "" {
+				return scope
+			}
+		}
+	}
+	return "climb"
+}
+
 // doctorSplitProfileName extracts (cragSlug, talentName) from a profile name
 // of the form "belayer-<crag>-<talent>". Best-effort single-segment split.
 func doctorSplitProfileName(profileName string) (cragSlug, talentName string) {
@@ -451,13 +497,24 @@ func printDoctorText(cmd *cobra.Command, report doctorReport, staleDays int) {
 		}
 		fmt.Fprintf(out, "Crag: %s (%d profile(s))\n", slug, len(crag.Profiles))
 		for _, p := range crag.Profiles {
-			statusLabel := "[active]"
+			var statusLabel string
 			suffix := ""
-			if p.Status == doctorProfileOrphan {
+			switch p.Status {
+			case doctorProfileActive:
+				statusLabel = "[active]"
+			case doctorProfileOrphan:
 				statusLabel = "[orphan]"
 				suffix = fmt.Sprintf("  -- %s", p.Reason)
+			case doctorProfilePreservedCrag:
+				statusLabel = "[preserved-crag]"
+				suffix = fmt.Sprintf("  -- %s", p.Reason)
+			case doctorProfilePreservedTalent:
+				statusLabel = "[preserved-talent]"
+				suffix = fmt.Sprintf("  -- %s", p.Reason)
+			default:
+				statusLabel = "[unknown]"
 			}
-			fmt.Fprintf(out, "  %-52s %-10s %s%s\n",
+			fmt.Fprintf(out, "  %-52s %-18s %s%s\n",
 				p.ProfileName, statusLabel, humanBytes(p.DiskBytes), suffix)
 		}
 		fmt.Fprintln(out)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -385,3 +385,162 @@ func TestDoctorCmd_DiskUsage(t *testing.T) {
 		t.Errorf("expected non-zero disk usage, got:\n%s", stdout)
 	}
 }
+
+// ── Phase 5.B: scope-aware orphan detection tests ─────────────────────────────
+
+// mkProfileDirWithScope creates a minimal belayer-* profile directory with the
+// given memory_scope. Useful for testing scope-aware orphan detection.
+func mkProfileDirWithScope(t *testing.T, hermesHome, profileName, cragSlug, talentName, memoryScope string) {
+	t.Helper()
+	dir := filepath.Join(hermesHome, "profiles", profileName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkProfileDirWithScope: %v", err)
+	}
+	meta := "profile_name: " + profileName + "\n" +
+		"talent_name: " + talentName + "\n" +
+		"crag_slug: " + cragSlug + "\n" +
+		"memory_scope: " + memoryScope + "\n" +
+		"materialized_at: 2026-01-01T00:00:00Z\n"
+	if err := os.WriteFile(filepath.Join(dir, ".belayer-talent.yaml"), []byte(meta), 0o644); err != nil {
+		t.Fatalf("mkProfileDirWithScope: write .belayer-talent.yaml: %v", err)
+	}
+}
+
+// Test 5B-1: Profile with memory.scope=crag and no matching run → reported
+// [preserved-crag], NOT counted in orphan count.
+func TestDoctorCmd_CragScopedPreservedNotOrphan(t *testing.T) {
+	tmp := t.TempDir()
+	hermesHome := filepath.Join(tmp, "hermes")
+	t.Setenv("HERMES_HOME", hermesHome)
+
+	profileName := "belayer-myproject-supervisor"
+	mkProfileDirWithScope(t, hermesHome, profileName, "myproject", "supervisor", "crag")
+	dbPath := mkDoctorDB(t) // empty store — no matching agent_runs row
+
+	stdout, _, err := runDoctorCmd(t, "--db", dbPath)
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+
+	if !strings.Contains(stdout, "[preserved-crag]") {
+		t.Errorf("expected [preserved-crag] label, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[orphan]") {
+		t.Errorf("unexpected [orphan] label for crag-scoped profile, got:\n%s", stdout)
+	}
+	// Should NOT appear in the orphan count issues.
+	if strings.Contains(stdout, "orphan profile(s) found") {
+		t.Errorf("crag-scoped profile should not appear in orphan count issues, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "belayer prune") {
+		t.Errorf("crag-scoped profile should not trigger prune recommendation, got:\n%s", stdout)
+	}
+}
+
+// Test 5B-2: Profile with memory.scope=talent and no matching run → reported
+// [preserved-talent].
+func TestDoctorCmd_TalentScopedPreservedNotOrphan(t *testing.T) {
+	tmp := t.TempDir()
+	hermesHome := filepath.Join(tmp, "hermes")
+	t.Setenv("HERMES_HOME", hermesHome)
+
+	profileName := "belayer-myproject-backend-dev"
+	mkProfileDirWithScope(t, hermesHome, profileName, "myproject", "backend-dev", "talent")
+	dbPath := mkDoctorDB(t) // empty store
+
+	stdout, _, err := runDoctorCmd(t, "--db", dbPath)
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+
+	if !strings.Contains(stdout, "[preserved-talent]") {
+		t.Errorf("expected [preserved-talent] label, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[orphan]") {
+		t.Errorf("unexpected [orphan] label for talent-scoped profile, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "orphan profile(s) found") {
+		t.Errorf("talent-scoped profile should not appear in orphan count issues, got:\n%s", stdout)
+	}
+}
+
+// Test 5B-3: Profile with memory.scope=climb and no matching run → still [orphan]
+// (regression check).
+func TestDoctorCmd_ClimbScopedStillOrphan(t *testing.T) {
+	tmp := t.TempDir()
+	hermesHome := filepath.Join(tmp, "hermes")
+	t.Setenv("HERMES_HOME", hermesHome)
+
+	profileName := "belayer-myproject-qa"
+	mkProfileDirWithScope(t, hermesHome, profileName, "myproject", "qa", "climb")
+	dbPath := mkDoctorDB(t) // empty store
+
+	stdout, _, err := runDoctorCmd(t, "--db", dbPath)
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+
+	if !strings.Contains(stdout, "[orphan]") {
+		t.Errorf("expected [orphan] label for climb-scoped profile, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[preserved-crag]") || strings.Contains(stdout, "[preserved-talent]") {
+		t.Errorf("unexpected preserved label for climb-scoped profile, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "orphan profile(s) found") {
+		t.Errorf("expected orphan count in issues, got:\n%s", stdout)
+	}
+}
+
+// Test 5B-4: Profile with no .belayer-talent.yaml → defaults to orphan
+// (climb default).
+func TestDoctorCmd_NoMetadataFileDefaultsToOrphan(t *testing.T) {
+	tmp := t.TempDir()
+	hermesHome := filepath.Join(tmp, "hermes")
+	t.Setenv("HERMES_HOME", hermesHome)
+
+	// Create profile dir WITHOUT any .belayer-talent.yaml.
+	profileName := "belayer-myproject-reviewer"
+	dir := filepath.Join(hermesHome, "profiles", profileName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir profile: %v", err)
+	}
+	dbPath := mkDoctorDB(t) // empty store
+
+	stdout, _, err := runDoctorCmd(t, "--db", dbPath)
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+
+	if !strings.Contains(stdout, "[orphan]") {
+		t.Errorf("expected [orphan] label when metadata file missing (defaults to climb), got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[preserved-") {
+		t.Errorf("unexpected preserved label when no metadata file present, got:\n%s", stdout)
+	}
+}
+
+// Test 5B-5: --include-scoped flag → preserved-crag reported as orphan.
+func TestDoctorCmd_IncludeScopedFlagTreatsCragAsOrphan(t *testing.T) {
+	tmp := t.TempDir()
+	hermesHome := filepath.Join(tmp, "hermes")
+	t.Setenv("HERMES_HOME", hermesHome)
+
+	profileName := "belayer-myproject-supervisor"
+	mkProfileDirWithScope(t, hermesHome, profileName, "myproject", "supervisor", "crag")
+	dbPath := mkDoctorDB(t) // empty store
+
+	stdout, _, err := runDoctorCmd(t, "--db", dbPath, "--include-scoped")
+	if err != nil {
+		t.Fatalf("doctor --include-scoped: %v", err)
+	}
+
+	if !strings.Contains(stdout, "[orphan]") {
+		t.Errorf("expected [orphan] label with --include-scoped, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[preserved-crag]") {
+		t.Errorf("unexpected [preserved-crag] with --include-scoped, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "orphan profile(s) found") {
+		t.Errorf("expected orphan count in issues with --include-scoped, got:\n%s", stdout)
+	}
+}

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -22,12 +22,20 @@ type pruneOrphan struct {
 	ProfileDir  string
 	CragSlug    string
 	TalentName  string
+	MemoryScope string
 	DiskBytes   int64
+}
+
+// pruneSkipped holds metadata about a preserved (non-orphan) profile that was
+// skipped because its memory scope is crag or talent.
+type pruneSkipped struct {
+	ProfileName string
+	MemoryScope string
 }
 
 func newPruneCmd() *cobra.Command {
 	var cragFilter string
-	var dryRun, keepMemories, yes bool
+	var dryRun, keepMemories, yes, includeScoped bool
 	var dbPath string
 
 	cmd := &cobra.Command{
@@ -38,6 +46,10 @@ func newPruneCmd() *cobra.Command {
 An orphan is a profile directory that starts with "belayer-" but has no
 matching row in the agent_runs store. This can happen when a session ends
 abnormally or a profile is left behind after cleanup failures.
+
+Profiles with memory.scope=crag or memory.scope=talent are intentionally
+preserved across climbs and are skipped by default. Use --include-scoped
+to include them in the prune target list.
 
 By default the command lists orphans and prompts for confirmation before
 removing anything. Use --dry-run to inspect without removing, or --yes for
@@ -53,10 +65,16 @@ non-interactive use in scripts.`,
 				resolvedDB = filepath.Join(home, ".belayer", "belayer.db")
 			}
 
-			// 1. Find orphans.
-			orphans, err := pruneListOrphans(resolvedDB, cragFilter)
+			// 1. Find orphans (and skipped preserved profiles).
+			orphans, skipped, err := pruneListOrphansWithScope(resolvedDB, cragFilter, includeScoped)
 			if err != nil {
 				return fmt.Errorf("prune: find orphans: %w", err)
+			}
+
+			// 2. Print skipped preserved profiles.
+			for _, s := range skipped {
+				fmt.Fprintf(cmd.OutOrStdout(), "[skipped] %s — memory.scope=%s (preserved across climbs; use --include-scoped to remove)\n",
+					s.ProfileName, s.MemoryScope)
 			}
 
 			if len(orphans) == 0 {
@@ -64,16 +82,16 @@ non-interactive use in scripts.`,
 				return nil
 			}
 
-			// 2. Print list.
+			// 3. Print list.
 			printOrphanList(cmd.OutOrStdout(), orphans)
 
-			// 3. If --dry-run, exit without removing.
+			// 4. If --dry-run, exit without removing.
 			if dryRun {
 				fmt.Fprintf(cmd.OutOrStdout(), "\n(dry-run) Would remove %d profile(s).\n", len(orphans))
 				return nil
 			}
 
-			// 4. Prompt unless --yes.
+			// 5. Prompt unless --yes.
 			if !yes {
 				if !isatty.IsTerminal(os.Stdin.Fd()) {
 					return fmt.Errorf("stdin is not a terminal; use --yes to confirm non-interactively")
@@ -91,7 +109,7 @@ non-interactive use in scripts.`,
 				}
 			}
 
-			// 5. Remove each orphan (with optional memory archive).
+			// 6. Remove each orphan (with optional memory archive).
 			removed := 0
 			archived := 0
 			for _, o := range orphans {
@@ -111,7 +129,7 @@ non-interactive use in scripts.`,
 				removed++
 			}
 
-			// 6. Print summary.
+			// 7. Print summary.
 			if keepMemories {
 				fmt.Fprintf(cmd.OutOrStdout(), "Removed %d profile(s), archived %d memory snapshot(s).\n", removed, archived)
 			} else {
@@ -126,6 +144,7 @@ non-interactive use in scripts.`,
 	cmd.Flags().BoolVar(&keepMemories, "keep-memories", false, "Archive memories/ before delete")
 	cmd.Flags().BoolVar(&yes, "yes", false, "Skip interactive confirmation")
 	cmd.Flags().StringVar(&dbPath, "db", "", "SQLite database path (default ~/.belayer/belayer.db)")
+	cmd.Flags().BoolVar(&includeScoped, "include-scoped", false, "Include crag/talent-scoped profiles in prune targets (override preservation safety)")
 	return cmd
 }
 
@@ -133,22 +152,35 @@ non-interactive use in scripts.`,
 // matching row in agent_runs. If cragFilter is non-empty, only profiles whose
 // crag_slug matches are included.
 //
+// Kept for backward compatibility; delegates to pruneListOrphansWithScope with
+// includeScoped=false (safe default: climb-scoped orphans only).
+func pruneListOrphans(dbPath, cragFilter string) ([]pruneOrphan, error) {
+	orphans, _, err := pruneListOrphansWithScope(dbPath, cragFilter, false)
+	return orphans, err
+}
+
+// pruneListOrphansWithScope finds all belayer-* profile directories that have
+// no matching row in agent_runs, separating them into orphans (to remove) and
+// skipped (preserved across climbs). If includeScoped is true, crag/talent-scoped
+// profiles are treated as orphans. If cragFilter is non-empty, only profiles
+// whose crag_slug matches are included.
+//
 // NOTE: orphan detection logic is duplicated from doctor (Task 4.A) to avoid
 // a merge conflict in parallel implementation. TODO: DRY into profile_health.go.
-func pruneListOrphans(dbPath, cragFilter string) ([]pruneOrphan, error) {
+func pruneListOrphansWithScope(dbPath, cragFilter string, includeScoped bool) (orphans []pruneOrphan, skipped []pruneSkipped, _ error) {
 	// Find profiles root.
 	profilesRoot, err := daemon.ProfilesRoot()
 	if err != nil {
-		return nil, fmt.Errorf("resolve profiles root: %w", err)
+		return nil, nil, fmt.Errorf("resolve profiles root: %w", err)
 	}
 
 	// Enumerate all belayer-* subdirectories.
 	entries, err := os.ReadDir(profilesRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, fmt.Errorf("read profiles dir %s: %w", profilesRoot, err)
+		return nil, nil, fmt.Errorf("read profiles dir %s: %w", profilesRoot, err)
 	}
 
 	var candidates []string
@@ -165,34 +197,43 @@ func pruneListOrphans(dbPath, cragFilter string) ([]pruneOrphan, error) {
 	}
 
 	if len(candidates) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Open the store read-only to query known profiles.
 	st, err := store.Open(dbPath)
 	if err != nil {
-		return nil, fmt.Errorf("open store %s: %w", dbPath, err)
+		return nil, nil, fmt.Errorf("open store %s: %w", dbPath, err)
 	}
 	defer st.Close()
 
 	// Build a set of profile names referenced by any agent_runs row.
 	knownProfiles, err := pruneKnownProfiles(st)
 	if err != nil {
-		return nil, fmt.Errorf("query known profiles: %w", err)
+		return nil, nil, fmt.Errorf("query known profiles: %w", err)
 	}
 
-	// Identify orphans.
-	var orphans []pruneOrphan
+	// Identify orphans and preserved profiles.
 	for _, name := range candidates {
 		if knownProfiles[name] {
 			continue
 		}
 
-		// Parse crag slug from .belayer-talent.yaml metadata (best-effort).
-		cragSlug, talentName := pruneReadMetadata(filepath.Join(profilesRoot, name))
+		// Parse crag slug and metadata from .belayer-talent.yaml (best-effort).
+		cragSlug, talentName, memoryScope := pruneReadMetadataWithScope(filepath.Join(profilesRoot, name))
 
 		// Apply crag filter if set.
 		if cragFilter != "" && cragSlug != cragFilter {
+			continue
+		}
+
+		// Determine if this profile should be preserved (crag/talent-scoped) or pruned.
+		isPreserved := !includeScoped && (memoryScope == "crag" || memoryScope == "talent")
+		if isPreserved {
+			skipped = append(skipped, pruneSkipped{
+				ProfileName: name,
+				MemoryScope: memoryScope,
+			})
 			continue
 		}
 
@@ -204,11 +245,12 @@ func pruneListOrphans(dbPath, cragFilter string) ([]pruneOrphan, error) {
 			ProfileDir:  filepath.Join(profilesRoot, name),
 			CragSlug:    cragSlug,
 			TalentName:  talentName,
+			MemoryScope: memoryScope,
 			DiskBytes:   size,
 		})
 	}
 
-	return orphans, nil
+	return orphans, skipped, nil
 }
 
 // pruneKnownProfiles returns a set of profile names that appear in the
@@ -233,6 +275,47 @@ func pruneKnownProfiles(st *store.Store) (map[string]bool, error) {
 		}
 	}
 	return known, rows.Err()
+}
+
+// pruneReadMetadataWithScope reads crag_slug, talent_name, and memory_scope
+// from a profile's .belayer-talent.yaml. Falls back to parsing the profile name
+// for crag/talent and defaults memory_scope to "climb" (ephemeral) if missing.
+func pruneReadMetadataWithScope(profileDir string) (cragSlug, talentName, memoryScope string) {
+	data, err := os.ReadFile(filepath.Join(profileDir, ".belayer-talent.yaml"))
+	if err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "crag_slug:") {
+				cragSlug = strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "crag_slug:")), `"'`)
+			}
+			if strings.HasPrefix(line, "talent_name:") {
+				talentName = strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "talent_name:")), `"'`)
+			}
+			if strings.HasPrefix(line, "memory_scope:") {
+				memoryScope = strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "memory_scope:")), `"'`)
+			}
+		}
+		if cragSlug != "" {
+			if memoryScope == "" {
+				memoryScope = "climb"
+			}
+			return
+		}
+	}
+
+	// Fallback: parse from profile name "belayer-<crag>-<talent>".
+	profileName := filepath.Base(profileDir)
+	rest := strings.TrimPrefix(profileName, "belayer-")
+	parts := strings.SplitN(rest, "-", 2)
+	if len(parts) == 2 {
+		cragSlug, talentName = parts[0], parts[1]
+	} else {
+		cragSlug = rest
+	}
+	if memoryScope == "" {
+		memoryScope = "climb"
+	}
+	return
 }
 
 // pruneReadMetadata reads crag_slug and talent_name from a profile's

--- a/internal/cli/prune_test.go
+++ b/internal/cli/prune_test.go
@@ -385,3 +385,145 @@ func TestHumanBytes(t *testing.T) {
 		}
 	}
 }
+
+// ── Phase 5.B: scope-aware orphan detection tests ─────────────────────────────
+
+// makeProfileWithScope creates a fake fork profile directory with the given
+// memory_scope in its .belayer-talent.yaml.
+func makeProfileWithScope(t *testing.T, profilesDir, profileName, cragSlug, talentName, memoryScope string) string {
+	t.Helper()
+	profileDir := filepath.Join(profilesDir, profileName)
+	memoriesDir := filepath.Join(profileDir, "memories")
+	if err := os.MkdirAll(memoriesDir, 0o755); err != nil {
+		t.Fatalf("mkdir profile %s: %v", profileName, err)
+	}
+	meta := fmt.Sprintf("profile_name: %s\ntalent_name: %s\ncrag_slug: %s\nmemory_scope: %s\nmaterialized_at: 2026-01-01T00:00:00Z\n",
+		profileName, talentName, cragSlug, memoryScope)
+	if err := os.WriteFile(filepath.Join(profileDir, ".belayer-talent.yaml"), []byte(meta), 0o644); err != nil {
+		t.Fatalf("write .belayer-talent.yaml for %s: %v", profileName, err)
+	}
+	return profileDir
+}
+
+// Test 5B-1: Crag-scoped profile NOT pruned by default.
+func TestPruneCmd_CragScopedNotPrunedByDefault(t *testing.T) {
+	profilesDir, dbFile := setupPruneFixture(t)
+
+	profileName := "belayer-local-supervisor"
+	makeProfileWithScope(t, profilesDir, profileName, "local", "supervisor", "crag")
+
+	stdout, _, err := runPruneCmd(t, "--yes", "--db", dbFile)
+	if err != nil {
+		t.Fatalf("prune with crag-scoped profile: %v", err)
+	}
+
+	// Profile should NOT be removed.
+	if _, statErr := os.Stat(filepath.Join(profilesDir, profileName)); statErr != nil {
+		t.Errorf("crag-scoped profile should not be removed by default: %v", statErr)
+	}
+	// Should report no orphans.
+	if !strings.Contains(stdout, "No orphan profiles found") {
+		t.Errorf("expected 'No orphan profiles found' (crag-scoped is preserved), got: %s", stdout)
+	}
+}
+
+// Test 5B-2: Talent-scoped profile NOT pruned by default.
+func TestPruneCmd_TalentScopedNotPrunedByDefault(t *testing.T) {
+	profilesDir, dbFile := setupPruneFixture(t)
+
+	profileName := "belayer-local-backend-dev"
+	makeProfileWithScope(t, profilesDir, profileName, "local", "backend-dev", "talent")
+
+	stdout, _, err := runPruneCmd(t, "--yes", "--db", dbFile)
+	if err != nil {
+		t.Fatalf("prune with talent-scoped profile: %v", err)
+	}
+
+	// Profile should NOT be removed.
+	if _, statErr := os.Stat(filepath.Join(profilesDir, profileName)); statErr != nil {
+		t.Errorf("talent-scoped profile should not be removed by default: %v", statErr)
+	}
+	if !strings.Contains(stdout, "No orphan profiles found") {
+		t.Errorf("expected 'No orphan profiles found' (talent-scoped is preserved), got: %s", stdout)
+	}
+}
+
+// Test 5B-3: Climb-scoped profile still pruned (regression check).
+func TestPruneCmd_ClimbScopedStillPruned(t *testing.T) {
+	profilesDir, dbFile := setupPruneFixture(t)
+
+	profileName := "belayer-local-qa"
+	makeProfileWithScope(t, profilesDir, profileName, "local", "qa", "climb")
+
+	stdout, _, err := runPruneCmd(t, "--yes", "--db", dbFile)
+	if err != nil {
+		t.Fatalf("prune with climb-scoped profile: %v", err)
+	}
+
+	// Profile should be removed.
+	if _, statErr := os.Stat(filepath.Join(profilesDir, profileName)); !os.IsNotExist(statErr) {
+		t.Errorf("climb-scoped orphan profile should have been removed")
+	}
+	if !strings.Contains(stdout, "Removed 1 profile") {
+		t.Errorf("expected removal summary, got: %s", stdout)
+	}
+}
+
+// Test 5B-4: --include-scoped flag → crag-scoped profiles ARE pruned.
+func TestPruneCmd_IncludeScopedRemovesCragScoped(t *testing.T) {
+	profilesDir, dbFile := setupPruneFixture(t)
+
+	profileName := "belayer-local-supervisor"
+	makeProfileWithScope(t, profilesDir, profileName, "local", "supervisor", "crag")
+
+	stdout, _, err := runPruneCmd(t, "--yes", "--include-scoped", "--db", dbFile)
+	if err != nil {
+		t.Fatalf("prune --include-scoped with crag-scoped profile: %v", err)
+	}
+
+	// Profile should be removed when --include-scoped is set.
+	if _, statErr := os.Stat(filepath.Join(profilesDir, profileName)); !os.IsNotExist(statErr) {
+		t.Errorf("crag-scoped profile should be removed with --include-scoped")
+	}
+	if !strings.Contains(stdout, "Removed 1 profile") {
+		t.Errorf("expected removal summary with --include-scoped, got: %s", stdout)
+	}
+}
+
+// Test 5B-5: Output includes [skipped] lines for preserved profiles.
+func TestPruneCmd_SkippedLinesForPreservedProfiles(t *testing.T) {
+	profilesDir, dbFile := setupPruneFixture(t)
+
+	// One crag-scoped profile (should be skipped) + one climb-scoped (should be pruned).
+	cragProfile := "belayer-local-supervisor"
+	climbProfile := "belayer-local-qa"
+	makeProfileWithScope(t, profilesDir, cragProfile, "local", "supervisor", "crag")
+	makeProfileWithScope(t, profilesDir, climbProfile, "local", "qa", "climb")
+
+	stdout, _, err := runPruneCmd(t, "--yes", "--db", dbFile)
+	if err != nil {
+		t.Fatalf("prune with mixed scope profiles: %v", err)
+	}
+
+	// Crag-scoped profile should appear in [skipped] output.
+	if !strings.Contains(stdout, "[skipped]") {
+		t.Errorf("expected [skipped] line for crag-scoped profile, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, cragProfile) {
+		t.Errorf("expected skipped profile name %q in output, got: %s", cragProfile, stdout)
+	}
+	if !strings.Contains(stdout, "memory.scope=crag") {
+		t.Errorf("expected memory.scope=crag annotation in [skipped] line, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "--include-scoped") {
+		t.Errorf("expected --include-scoped hint in [skipped] line, got: %s", stdout)
+	}
+	// Climb-scoped profile should be removed.
+	if _, statErr := os.Stat(filepath.Join(profilesDir, climbProfile)); !os.IsNotExist(statErr) {
+		t.Errorf("climb-scoped orphan profile should have been removed")
+	}
+	// Crag-scoped profile should still exist.
+	if _, statErr := os.Stat(filepath.Join(profilesDir, cragProfile)); statErr != nil {
+		t.Errorf("crag-scoped profile should still exist: %v", statErr)
+	}
+}

--- a/internal/daemon/agents.go
+++ b/internal/daemon/agents.go
@@ -1786,14 +1786,17 @@ func (d *Daemon) materializeBridgeProfile(req agentSpawnRequest) agentSpawnReque
 		cragSlug = localCragSlug
 	}
 
-	// Use the agent run's existing UUID as the instance seed. The store row
-	// must already exist (it is created before materializeBridgeProfile is
-	// called). If GetAgentRun fails for any reason, fall back to an empty
-	// instanceID (singleton semantics).
+	// Phase 5.A: pass an empty instanceID so the profile name is stable across
+	// climbs — belayer-<crag>-<talent> — enabling crag-scoped memory persistence.
+	// DeriveInstanceID is no longer called on the spawn path; it is retained for
+	// future callers that need explicit per-instance disambiguation.
+	//
+	// Generated talents use their name as the unique discriminator (handled
+	// inside ResolveProfileName); the instanceID value is irrelevant for them.
+	//
+	// Concurrent sessions on the same profile are safe: Hermes handles contention
+	// via WAL + BEGIN IMMEDIATE + jitter retry (hermes_state.py:167-201).
 	instanceID := ""
-	if existingRun, runErr := d.store.GetAgentRun(req.SessionID, req.Name); runErr == nil {
-		instanceID = DeriveInstanceID(existingRun.ID)
-	}
 
 	forkName, forkErr := ResolveProfileName(cragSlug, req.identityKey(), instanceID)
 	if forkErr != nil {

--- a/internal/daemon/agents_phase3_integration_test.go
+++ b/internal/daemon/agents_phase3_integration_test.go
@@ -601,34 +601,20 @@ func TestPhase3Integration_CragScopedAcrossTwoClimbs(t *testing.T) {
 		t.Fatalf("climb-2: expected fork profile, got %q", profile2)
 	}
 
-	// TODO(Phase 4): This assertion documents the CURRENT LIMITATION.
-	// Cross-climb persistence requires a stable identifier independent of run ID.
-	// Today: profile1 ≠ profile2 (different sessions → different run UUIDs →
-	// different DeriveInstanceID → different fork names → sentinel NOT visible).
-	//
-	// Once Phase 4 implements stable cross-climb IDs (keyed on crag+talent),
-	// profile1 should equal profile2, and the sentinel should be accessible in
-	// climb 2's profile.
-	if profile1 == profile2 {
-		// Unexpected today — log but don't fail, in case Phase 4 lands first.
-		t.Logf("INFO: climb-1 and climb-2 produced the same fork profile %q. "+
-			"This means cross-climb reuse already works. If Phase 4 is not yet landed, "+
-			"investigate whether the store reused the same run UUID.", profile1)
-	} else {
-		// Expected today: different sessions → different profiles (Phase 4 limitation).
-		t.Logf("KNOWN LIMITATION (Phase 4): climb-2 got a different profile (%q) than climb-1 (%q). "+
-			"Cross-climb memory persistence is not yet implemented. The sentinel written in climb-1 "+
-			"is not accessible in climb-2. Phase 4 should implement stable crag+talent-keyed profiles.",
-			profile2, profile1)
+	// Phase 5.A: stable crag+talent profile name — climb-2 must resolve to the
+	// same fork as climb-1. This enables crag-scoped memory to persist across
+	// climbs without any extra bookkeeping.
+	if profile1 != profile2 {
+		t.Errorf("cross-climb profile mismatch: climb-1=%q climb-2=%q; same identity in same crag must resolve to the same fork (Phase 5.A)", profile1, profile2)
+	}
 
-		// Verify the sentinel is NOT in climb-2's profile (confirms the limitation).
-		sentinel2Path := filepath.Join(profilesRoot, profile2, "memories", "MEMORY.md")
-		if _, err := os.Stat(sentinel2Path); err == nil {
-			// Sentinel appeared in climb-2's profile — this would be surprising today
-			// (implies profiles got cross-contaminated), but would be correct in Phase 4.
-			t.Logf("INFO: sentinel found in climb-2 profile — cross-climb memory reuse may be partially working.")
-		}
-		// else: sentinel not in climb-2 profile — expected limitation, no error.
+	// Sentinel written in climb-1 must be accessible in climb-2's profile dir.
+	sentinel2Path := filepath.Join(profilesRoot, profile2, "memories", "MEMORY.md")
+	got2, err := os.ReadFile(sentinel2Path)
+	if err != nil {
+		t.Errorf("sentinel not accessible in climb-2 profile: %v", err)
+	} else if string(got2) != sentinelContent {
+		t.Errorf("sentinel in climb-2 = %q, want %q", string(got2), sentinelContent)
 	}
 
 	// Climb-1 profile must still exist (it's crag-scoped, not swept by climb-2).

--- a/internal/daemon/agents_phase5_integration_test.go
+++ b/internal/daemon/agents_phase5_integration_test.go
@@ -1,0 +1,324 @@
+package daemon
+
+// Phase 5.D integration tests — end-to-end coverage of parallel mains sharing
+// one profile directory under the Phase 5.A stable naming scheme (no per-run
+// instance hash).
+//
+// Scenario 1 — TestPhase5Integration_ParallelMainsShareProfile:
+//   Spawn backend-dev-1, backend-dev-2 → same profile → write sentinel →
+//   spawn backend-dev-3 → sentinel visible → session teardown with crag scope →
+//   profile dir survives.
+//
+// Scenario 2 — TestPhase5Integration_ParallelMainsConcurrentStateDB:
+//   Two goroutines open the same profile/state.db (WAL mode) and each do N
+//   inserts. Validates WAL concurrency without deadlock.
+//
+// Helpers reused from:
+//   - setupBaseBelayerProfile  (agents_profile_spawn_test.go)
+//   - setupForkProfile          (agents_profile_teardown_test.go)
+//   - addAgentRunToSession      (agents_profile_session_teardown_test.go)
+//   - markSessionTerminal       (agents_profile_session_teardown_test.go)
+//   - mustWrite                 (agents_identity_test.go)
+//   - setupIntegrationBase      (agents_profile_integration_test.go)
+//   - createSession             (agents_profile_integration_test.go)
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/donovan-yohan/belayer/internal/bridge"
+	_ "modernc.org/sqlite"
+)
+
+// ── Scenario 1: Parallel mains share one profile + sentinel persistence ───────
+
+// TestPhase5Integration_ParallelMainsShareProfile verifies that:
+//  1. Two parallel mains (backend-dev-1, backend-dev-2) with Identity=backend-dev
+//     both resolve to the same profile name "belayer-local-backend-dev" (no hash).
+//  2. Both agent_runs rows record that same profile name.
+//  3. The profile dir exists exactly once on disk with valid symlinks.
+//  4. A sentinel written to <profile>/memories/MEMORY.md (simulating one agent's
+//     write) is visible to a third backend-dev-3 that is spawned afterward.
+//  5. After session teardown, with a crag-scoped talent.yaml present, the profile
+//     dir survives (crag-scoped profiles are preserved on session end).
+func TestPhase5Integration_ParallelMainsShareProfile(t *testing.T) {
+	profilesRoot, _ := setupIntegrationBase(t)
+
+	workspace := t.TempDir()
+
+	// Write talent.yaml with memory.scope=crag so the profile is preserved on
+	// session teardown (see step 5).
+	mustWrite(
+		t,
+		filepath.Join(workspace, ".belayer", "agents", "backend-dev", "talent.yaml"),
+		"schema_version: \"belayer-talent/v1\"\nmemory:\n  scope: crag\n",
+	)
+	mustWrite(
+		t,
+		filepath.Join(workspace, ".belayer", "agents", "backend-dev", "system-prompt.md"),
+		"you are backend-dev",
+	)
+	mustWrite(
+		t,
+		filepath.Join(workspace, ".belayer", "agents", "backend-dev", "agent.yaml"),
+		"kind: main\n",
+	)
+
+	d := testDaemon(t)
+
+	// supervisor is required by checkSessionStalled logic.
+	sessID := createSession(t, d, "phase5-parallel-mains-test", workspace)
+	addAgentRunToSession(t, d, sessID, "supervisor", "default")
+
+	// Capture profiles from bridge spawn calls.
+	var mu sync.Mutex
+	profiles := make(map[string]string) // agent name → fork profile
+	d.spawnBridgeAgent = func(req agentSpawnRequest) (*bridge.Process, error) {
+		mu.Lock()
+		profiles[req.Name] = req.Profile
+		mu.Unlock()
+		return nil, nil
+	}
+
+	// Step 1 & 2: Spawn backend-dev-1 and backend-dev-2 with Identity=backend-dev.
+	for _, name := range []string{"backend-dev-1", "backend-dev-2"} {
+		rr := doRequest(t, d, "POST", "/sessions/"+sessID+"/agents", agentSpawnRequest{
+			Name:     name,
+			Identity: "backend-dev",
+			Role:     "backend-dev",
+			Kind:     "main",
+			Profile:  belayerBaseProfileName,
+			Workdir:  workspace,
+		})
+		if rr.Code != 201 {
+			t.Fatalf("spawn %q: %d %s", name, rr.Code, rr.Body.String())
+		}
+	}
+
+	mu.Lock()
+	p1 := profiles["backend-dev-1"]
+	p2 := profiles["backend-dev-2"]
+	mu.Unlock()
+
+	// Both must resolve to "belayer-local-backend-dev" (Phase 5.A stable naming).
+	const wantProfile = "belayer-local-backend-dev"
+	if p1 != wantProfile {
+		t.Errorf("backend-dev-1 profile = %q, want %q", p1, wantProfile)
+	}
+	if p2 != wantProfile {
+		t.Errorf("backend-dev-2 profile = %q, want %q", p2, wantProfile)
+	}
+	if p1 != p2 {
+		t.Errorf("parallel mains must share one fork profile; got backend-dev-1=%q backend-dev-2=%q", p1, p2)
+	}
+
+	// Step 3: Both agent_runs rows must record the shared profile.
+	for _, name := range []string{"backend-dev-1", "backend-dev-2"} {
+		stored, err := d.store.GetAgentRun(sessID, name)
+		if err != nil {
+			t.Fatalf("GetAgentRun %q: %v", name, err)
+		}
+		if stored.Profile != wantProfile {
+			t.Errorf("agent_runs.profile for %q = %q, want %q", name, stored.Profile, wantProfile)
+		}
+	}
+
+	// Step 4: Profile dir must exist exactly once on disk.
+	forkDir := filepath.Join(profilesRoot, wantProfile)
+	if _, err := os.Stat(forkDir); err != nil {
+		t.Fatalf("fork profile dir %s not created: %v", forkDir, err)
+	}
+
+	// Verify symlinks: auth.json, plugins/belayer, skills.
+	authLink := filepath.Join(forkDir, "auth.json")
+	if _, err := os.Readlink(authLink); err != nil {
+		t.Errorf("fork %s: auth.json symlink missing or broken: %v", wantProfile, err)
+	}
+	pluginLink := filepath.Join(forkDir, "plugins", "belayer")
+	if _, err := os.Readlink(pluginLink); err != nil {
+		t.Errorf("fork %s: plugins/belayer symlink missing or broken: %v", wantProfile, err)
+	}
+	skillsLink := filepath.Join(forkDir, "skills")
+	if _, err := os.Readlink(skillsLink); err != nil {
+		t.Errorf("fork %s: skills symlink missing or broken: %v", wantProfile, err)
+	}
+
+	// No second copy of the profile dir should exist.
+	entries, err := os.ReadDir(profilesRoot)
+	if err != nil {
+		t.Fatalf("read profilesRoot: %v", err)
+	}
+	var forkCount int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "belayer-local-backend-dev") {
+			forkCount++
+		}
+	}
+	if forkCount != 1 {
+		t.Errorf("expected exactly 1 fork dir for backend-dev, found %d", forkCount)
+	}
+
+	// Step 5: Write sentinel to <profile>/memories/MEMORY.md (simulating one agent's write).
+	memoriesDir := filepath.Join(forkDir, "memories")
+	if err := os.MkdirAll(memoriesDir, 0o755); err != nil {
+		t.Fatalf("mkdir memories: %v", err)
+	}
+	const sentinelContent = "sentinel: backend-dev shared memory pool"
+	sentinelPath := filepath.Join(memoriesDir, "MEMORY.md")
+	if err := os.WriteFile(sentinelPath, []byte(sentinelContent), 0o644); err != nil {
+		t.Fatalf("write sentinel MEMORY.md: %v", err)
+	}
+
+	// Step 6: Spawn backend-dev-3 — must resolve to the same profile.
+	// The sentinel written by step 5 must be readable afterward.
+	rr3 := doRequest(t, d, "POST", "/sessions/"+sessID+"/agents", agentSpawnRequest{
+		Name:     "backend-dev-3",
+		Identity: "backend-dev",
+		Role:     "backend-dev",
+		Kind:     "main",
+		Profile:  belayerBaseProfileName,
+		Workdir:  workspace,
+	})
+	if rr3.Code != 201 {
+		t.Fatalf("spawn backend-dev-3: %d %s", rr3.Code, rr3.Body.String())
+	}
+
+	mu.Lock()
+	p3 := profiles["backend-dev-3"]
+	mu.Unlock()
+
+	if p3 != wantProfile {
+		t.Errorf("backend-dev-3 profile = %q, want %q (third parallel spawn must reuse same profile)", p3, wantProfile)
+	}
+
+	// Sentinel must still be readable (third spawn must not clobber memories/).
+	got, err := os.ReadFile(sentinelPath)
+	if err != nil {
+		t.Fatalf("sentinel MEMORY.md not readable after third spawn: %v", err)
+	}
+	if string(got) != sentinelContent {
+		t.Errorf("sentinel content changed after third spawn: got %q, want %q", string(got), sentinelContent)
+	}
+
+	// Step 7: Tear down session (terminal status). With memory.scope=crag the profile
+	// dir must survive the 3.C session-end sweep.
+	markSessionTerminal(t, d, sessID, "complete")
+
+	if _, err := os.Stat(forkDir); err != nil {
+		t.Errorf("crag-scoped profile dir %s should survive session teardown, but was removed: %v", forkDir, err)
+	}
+
+	// Sentinel must also survive session teardown.
+	got2, err := os.ReadFile(sentinelPath)
+	if err != nil {
+		t.Fatalf("sentinel MEMORY.md gone after session teardown (profile should be preserved for crag scope): %v", err)
+	}
+	if string(got2) != sentinelContent {
+		t.Errorf("sentinel content changed after session teardown: got %q, want %q", string(got2), sentinelContent)
+	}
+}
+
+// ── Scenario 2: Concurrent SQLite writes to shared state.db ─────────────────
+
+// TestPhase5Integration_ParallelMainsConcurrentStateDB validates that two
+// goroutines can open the same SQLite database (WAL mode) simultaneously and
+// perform concurrent inserts without deadlock or data corruption.
+//
+// This simulates the "two parallel mains sharing one profile" scenario at the
+// Hermes state.db level: both agents open <profile>/state.db and write rows.
+// The test uses raw database/sql + modernc.org/sqlite (the same driver used by
+// the belayer store) to exercise WAL + concurrent access.
+//
+// NOTE: Hermes itself adds BEGIN IMMEDIATE + jitter retry on the Python side
+// (hermes_state.py:167-201). This Go test validates the underlying SQLite WAL
+// behaviour that makes those retries safe. We cannot import Hermes's Python
+// SessionDB directly, so we exercise the SQLite layer directly.
+func TestPhase5Integration_ParallelMainsConcurrentStateDB(t *testing.T) {
+	profilesRoot, _ := setupIntegrationBase(t)
+
+	// Create the shared profile dir that both "agents" will use.
+	forkDir := filepath.Join(profilesRoot, "belayer-local-backend-dev")
+	if err := os.MkdirAll(forkDir, 0o755); err != nil {
+		t.Fatalf("mkdir fork profile: %v", err)
+	}
+
+	dbPath := filepath.Join(forkDir, "state.db")
+	// Include busy_timeout to simulate the retry semantics that Hermes applies on
+	// the Python side via BEGIN IMMEDIATE + jitter retry (hermes_state.py:167-201).
+	// Without busy_timeout, concurrent SQLite writers from the same process receive
+	// "database is locked" immediately (no retry) — that is a test-design issue,
+	// not a production bug. In production, Hermes Python handles the retry loop;
+	// here we delegate to SQLite's built-in busy handler (5 s timeout).
+	dbDSN := fmt.Sprintf("file:%s?_pragma=journal_mode(wal)&_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)", dbPath)
+
+	// Bootstrap the schema using the first connection.
+	setupDB, err := sql.Open("sqlite", dbDSN)
+	if err != nil {
+		t.Fatalf("open setup db: %v", err)
+	}
+	_, err = setupDB.Exec(`CREATE TABLE IF NOT EXISTS entries (id INTEGER PRIMARY KEY AUTOINCREMENT, agent TEXT NOT NULL, payload TEXT NOT NULL)`)
+	if err != nil {
+		setupDB.Close()
+		t.Fatalf("create schema: %v", err)
+	}
+	setupDB.Close()
+
+	const insertsPerAgent = 50
+
+	// Open two separate connections (simulating two agent processes).
+	db1, err := sql.Open("sqlite", dbDSN)
+	if err != nil {
+		t.Fatalf("open db1: %v", err)
+	}
+	defer db1.Close()
+
+	db2, err := sql.Open("sqlite", dbDSN)
+	if err != nil {
+		t.Fatalf("open db2: %v", err)
+	}
+	defer db2.Close()
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+
+	insertN := func(db *sql.DB, agentName string, n int, errOut *error) {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			payload := fmt.Sprintf("message-%d", i)
+			_, execErr := db.Exec(`INSERT INTO entries (agent, payload) VALUES (?, ?)`, agentName, payload)
+			if execErr != nil {
+				*errOut = fmt.Errorf("agent %s insert %d: %w", agentName, i, execErr)
+				return
+			}
+		}
+	}
+
+	wg.Add(2)
+	go insertN(db1, "backend-dev-1", insertsPerAgent, &errs[0])
+	go insertN(db2, "backend-dev-2", insertsPerAgent, &errs[1])
+	wg.Wait()
+
+	for i, e := range errs {
+		if e != nil {
+			t.Errorf("goroutine %d failed: %v", i, e)
+		}
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	// Verify final row count == 2N (no lost inserts, no phantom rows).
+	var count int
+	if err := db1.QueryRow(`SELECT COUNT(*) FROM entries`).Scan(&count); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	wantCount := 2 * insertsPerAgent
+	if count != wantCount {
+		t.Errorf("row count = %d, want %d (some inserts were lost or duplicated)", count, wantCount)
+	}
+}

--- a/internal/daemon/agents_profile_integration_test.go
+++ b/internal/daemon/agents_profile_integration_test.go
@@ -82,14 +82,14 @@ func createSession(t *testing.T, d *Daemon, name, workspaceDir string) string {
 	return decodeJSON[sessionAPIResponse](t, rr).ID
 }
 
-// ── Scenario 1: Parallel mains get distinct profile dirs ─────────────────────
+// ── Scenario 1: Parallel mains share one profile dir (Phase 5.A) ─────────────
 
-// TestPhase2Integration_ParallelMainsGetDistinctForkDirs verifies that spawning
-// two parallel main agents with the same identity (backend-dev) but different
-// names produces two distinct fork profile directories, each with the correct
-// crag-and-talent structure, each with working symlinks, and each with the
-// agent_runs.profile row reflecting the actual fork name.
-func TestPhase2Integration_ParallelMainsGetDistinctForkDirs(t *testing.T) {
+// TestPhase2Integration_ParallelMainsShareForkDir verifies that spawning two
+// parallel main agents with the same identity (backend-dev) but different names
+// resolves to the SAME fork profile directory (Phase 5.A: stable crag+talent
+// naming). The fork dir must have correct symlinks and both agent_runs rows must
+// record the same profile name.
+func TestPhase2Integration_ParallelMainsShareForkDir(t *testing.T) {
 	profilesRoot, _ := setupIntegrationBase(t)
 
 	workspace := t.TempDir()
@@ -133,50 +133,44 @@ func TestPhase2Integration_ParallelMainsGetDistinctForkDirs(t *testing.T) {
 	if !strings.Contains(p1, "backend-dev") || !strings.Contains(p2, "backend-dev") {
 		t.Errorf("identity 'backend-dev' missing from fork names: p1=%q p2=%q", p1, p2)
 	}
-	// Distinct (different UUIDs → different hashes).
-	if p1 == p2 {
-		t.Errorf("parallel mains must have distinct fork profiles; both got %q", p1)
+	// Phase 5.A: same identity → same profile (stable crag+talent name, no per-run hash).
+	if p1 != p2 {
+		t.Errorf("parallel mains with same identity must share one fork profile; got p1=%q p2=%q", p1, p2)
 	}
 	// No crag link → "local" slug in both.
 	if !strings.Contains(p1, "-local-") || !strings.Contains(p2, "-local-") {
 		t.Errorf("expected 'local' slug in fork names: p1=%q p2=%q", p1, p2)
 	}
 
-	// Both fork dirs must exist with correct symlinks.
-	for _, p := range []string{p1, p2} {
-		forkDir := filepath.Join(profilesRoot, p)
-		if _, err := os.Stat(forkDir); err != nil {
-			t.Errorf("fork dir %s not created: %v", forkDir, err)
-			continue
-		}
-		// auth.json symlink must exist.
-		authLink := filepath.Join(forkDir, "auth.json")
-		if _, err := os.Readlink(authLink); err != nil {
-			t.Errorf("fork %s: auth.json symlink missing or broken: %v", p, err)
-		}
-		// plugins/belayer symlink must exist.
-		pluginLink := filepath.Join(forkDir, "plugins", "belayer")
-		if _, err := os.Readlink(pluginLink); err != nil {
-			t.Errorf("fork %s: plugins/belayer symlink missing or broken: %v", p, err)
-		}
-		// skills symlink must exist.
-		skillsLink := filepath.Join(forkDir, "skills")
-		if _, err := os.Readlink(skillsLink); err != nil {
-			t.Errorf("fork %s: skills symlink missing or broken: %v", p, err)
-		}
+	// Fork dir must exist with correct symlinks.
+	forkDir := filepath.Join(profilesRoot, p1)
+	if _, err := os.Stat(forkDir); err != nil {
+		t.Fatalf("fork dir %s not created: %v", forkDir, err)
+	}
+	// auth.json symlink must exist.
+	authLink := filepath.Join(forkDir, "auth.json")
+	if _, err := os.Readlink(authLink); err != nil {
+		t.Errorf("fork %s: auth.json symlink missing or broken: %v", p1, err)
+	}
+	// plugins/belayer symlink must exist.
+	pluginLink := filepath.Join(forkDir, "plugins", "belayer")
+	if _, err := os.Readlink(pluginLink); err != nil {
+		t.Errorf("fork %s: plugins/belayer symlink missing or broken: %v", p1, err)
+	}
+	// skills symlink must exist.
+	skillsLink := filepath.Join(forkDir, "skills")
+	if _, err := os.Readlink(skillsLink); err != nil {
+		t.Errorf("fork %s: skills symlink missing or broken: %v", p1, err)
 	}
 
-	// agent_runs.profile must reflect actual fork name for each agent.
-	for _, tc := range []struct{ name, want string }{
-		{"backend-dev-1", p1},
-		{"backend-dev-2", p2},
-	} {
-		stored, err := d.store.GetAgentRun(sessID, tc.name)
+	// agent_runs.profile must reflect the (shared) fork name for each agent.
+	for _, name := range []string{"backend-dev-1", "backend-dev-2"} {
+		stored, err := d.store.GetAgentRun(sessID, name)
 		if err != nil {
-			t.Fatalf("GetAgentRun %q: %v", tc.name, err)
+			t.Fatalf("GetAgentRun %q: %v", name, err)
 		}
-		if stored.Profile != tc.want {
-			t.Errorf("agent_runs.profile for %q = %q, want %q", tc.name, stored.Profile, tc.want)
+		if stored.Profile != p1 {
+			t.Errorf("agent_runs.profile for %q = %q, want %q", name, stored.Profile, p1)
 		}
 	}
 }
@@ -472,27 +466,19 @@ func TestPhase2Integration_AuthJSONSymlinkSurvivesBaseRewrite(t *testing.T) {
 	}
 }
 
-// ── Scenario 6: Re-spawn with new run ID derives new instance hash ────────────
+// ── Scenario 6: Re-spawn reuses the same fork across climbs (Phase 5.A) ───────
 
-// TestPhase2Integration_ReSpawnDerivesFreshInstanceHash verifies that spawning
-// the same identity a second time (new run) produces a new fork profile with a
-// different instance hash, because DeriveInstanceID is keyed off the agent
-// run's UUID which changes on each new run.
-//
-// IMPORTANT: This is intentional behaviour for Phase 2. If Phase 3 ever wants
-// to REUSE the same fork on resume, it must detect the existing run by
-// hermes_session_id and either:
-//   (a) look up the stored profile name from agent_runs.profile, or
-//   (b) not call materializeBridgeProfile when hermes_session_id is set.
-//
-// This test documents the current contract (new run → new hash → new fork) so
-// any future change is a deliberate decision rather than a surprise.
-func TestPhase2Integration_ReSpawnDerivesFreshInstanceHash(t *testing.T) {
+// TestPhase2Integration_ReSpawnReusesSameForkAcrossClimbs verifies that
+// spawning the same identity a second time (same session, new run row) produces
+// the SAME fork profile name. Phase 5.A dropped the per-run instance hash, so
+// the profile is now derived purely from crag + talent — identical across all
+// climbs for the same identity.
+func TestPhase2Integration_ReSpawnReusesSameForkAcrossClimbs(t *testing.T) {
 	profilesRoot, _ := setupIntegrationBase(t)
 
 	workspace := t.TempDir()
 	d := testDaemon(t)
-	sessID := createSession(t, d, "respawn-hash-test", workspace)
+	sessID := createSession(t, d, "respawn-stable-test", workspace)
 
 	// First spawn.
 	profile1 := spawnAgentHTTP(t, d, sessID, agentSpawnRequest{
@@ -528,41 +514,24 @@ func TestPhase2Integration_ReSpawnDerivesFreshInstanceHash(t *testing.T) {
 		t.Errorf("talent name missing: profile1=%q profile2=%q", profile1, profile2)
 	}
 
-	// The two profiles will be the same because the store reuses the same
-	// agent_run row (resume path: prior run found → UpdateAgentRunStatus).
-	// DeriveInstanceID is seeded from the stored run ID which does NOT change
-	// on re-spawn (the row is updated, not re-created). This means the fork
-	// profile is stable across re-spawns — the same agent run always maps to
-	// the same fork.
-	//
-	// NOTE: If Phase 3 introduces a "fresh run" path where a new UUID is
-	// generated on each spawn (rather than re-using the existing row), the hash
-	// would differ. Document this finding here so the expectation is explicit.
-	//
-	// For now: same run ID → same hash → same fork profile.
+	// Phase 5.A: stable crag+talent profile name — both spawns must resolve to
+	// the same fork regardless of session or run UUID.
 	if profile1 != profile2 {
-		// This is also acceptable if the store creates a new row each time.
-		// Log it as a finding rather than a hard failure so the test stays
-		// informative under both store semantics.
-		t.Logf("NOTE: re-spawn produced a different fork profile (profile1=%q profile2=%q)"+
-			" — this means the store created a new run row with a new UUID."+
-			" If intentional (fresh run on re-spawn), this is correct.", profile1, profile2)
+		t.Errorf("re-spawn must reuse the same fork profile; got profile1=%q profile2=%q", profile1, profile2)
 	}
 
-	// Regardless of whether they match, both fork dirs must exist on disk.
-	for _, p := range []string{profile1, profile2} {
-		forkDir := filepath.Join(profilesRoot, p)
-		if _, err := os.Stat(forkDir); err != nil {
-			t.Errorf("fork dir %s not created: %v", forkDir, err)
-		}
+	// Fork dir must exist on disk.
+	forkDir := filepath.Join(profilesRoot, profile1)
+	if _, err := os.Stat(forkDir); err != nil {
+		t.Errorf("fork dir %s not created: %v", forkDir, err)
 	}
 
-	// agent_runs.profile must reflect the latest fork name.
+	// agent_runs.profile must reflect the stable fork name.
 	stored, err := d.store.GetAgentRun(sessID, "supervisor")
 	if err != nil {
 		t.Fatalf("GetAgentRun supervisor: %v", err)
 	}
-	if stored.Profile != profile2 {
-		t.Errorf("after second spawn agent_runs.profile = %q, want %q", stored.Profile, profile2)
+	if stored.Profile != profile1 {
+		t.Errorf("after second spawn agent_runs.profile = %q, want %q", stored.Profile, profile1)
 	}
 }

--- a/internal/daemon/agents_profile_resume_test.go
+++ b/internal/daemon/agents_profile_resume_test.go
@@ -299,9 +299,10 @@ func TestResumable_WakeOnTornDownProfileReMaterializes(t *testing.T) {
 		t.Errorf("fork profile %s should have been re-materialized after prune wake, but stat failed: %v", firstProfile, err)
 	}
 
-	// Profile name must be the same (DeriveInstanceID is stable for the same run UUID).
+	// Profile name must be the same (Phase 5.A: stable crag+talent name — same
+	// identity always resolves to the same fork regardless of run UUID).
 	if capturedProfile != firstProfile {
-		t.Errorf("re-materialized profile name = %q, want %q (DeriveInstanceID should be stable)", capturedProfile, firstProfile)
+		t.Errorf("re-materialized profile name = %q, want %q (profile name must be stable across re-spawns)", capturedProfile, firstProfile)
 	}
 
 	// Memory is gone (no MEMORY.md) — operator accepted by running prune.

--- a/internal/daemon/agents_profile_spawn_test.go
+++ b/internal/daemon/agents_profile_spawn_test.go
@@ -330,6 +330,135 @@ func TestSpawnProfile_BaseProfileMissingFallsBackToDefault(t *testing.T) {
 	}
 }
 
+// ── Phase 5.A: stable cross-climb profile naming ─────────────────────────────
+
+// TestSpawnProfile_StableProfileNameAcrossClimbs verifies that spawning the
+// same identity in two different sessions (climbs) resolves to the same fork
+// profile name. Phase 5.A drops the per-run instance hash so the profile is
+// keyed purely on crag+talent.
+func TestSpawnProfile_StableProfileNameAcrossClimbs(t *testing.T) {
+	setupBaseBelayerProfile(t)
+
+	workspace := t.TempDir()
+	d := testDaemon(t)
+
+	// Climb 1: create a session and spawn supervisor.
+	sess1RR := doRequest(t, d, "POST", "/sessions", createSessionRequest{
+		Name:         "climb-1-stable-name",
+		WorkspaceDir: workspace,
+	})
+	if sess1RR.Code != http.StatusCreated {
+		t.Fatalf("create session 1: %d %s", sess1RR.Code, sess1RR.Body.String())
+	}
+	sess1 := decodeJSON[sessionAPIResponse](t, sess1RR)
+
+	var profile1 string
+	d.spawnBridgeAgent = func(req agentSpawnRequest) (*bridge.Process, error) {
+		profile1 = req.Profile
+		return nil, nil
+	}
+
+	rr1 := doRequest(t, d, "POST", "/sessions/"+sess1.ID+"/agents", agentSpawnRequest{
+		Name:    "supervisor",
+		Role:    "supervisor",
+		Profile: belayerBaseProfileName,
+		Workdir: workspace,
+	})
+	if rr1.Code != http.StatusCreated {
+		t.Fatalf("climb-1 spawn: %d %s", rr1.Code, rr1.Body.String())
+	}
+	if !strings.HasPrefix(profile1, "belayer-") {
+		t.Fatalf("climb-1: expected fork profile, got %q", profile1)
+	}
+
+	// Climb 2: different session, same project, same identity.
+	sess2RR := doRequest(t, d, "POST", "/sessions", createSessionRequest{
+		Name:         "climb-2-stable-name",
+		WorkspaceDir: workspace,
+	})
+	if sess2RR.Code != http.StatusCreated {
+		t.Fatalf("create session 2: %d %s", sess2RR.Code, sess2RR.Body.String())
+	}
+	sess2 := decodeJSON[sessionAPIResponse](t, sess2RR)
+
+	var profile2 string
+	d.spawnBridgeAgent = func(req agentSpawnRequest) (*bridge.Process, error) {
+		profile2 = req.Profile
+		return nil, nil
+	}
+
+	rr2 := doRequest(t, d, "POST", "/sessions/"+sess2.ID+"/agents", agentSpawnRequest{
+		Name:    "supervisor",
+		Role:    "supervisor",
+		Profile: belayerBaseProfileName,
+		Workdir: workspace,
+	})
+	if rr2.Code != http.StatusCreated {
+		t.Fatalf("climb-2 spawn: %d %s", rr2.Code, rr2.Body.String())
+	}
+	if !strings.HasPrefix(profile2, "belayer-") {
+		t.Fatalf("climb-2: expected fork profile, got %q", profile2)
+	}
+
+	// Phase 5.A: same crag + same identity → same profile across climbs.
+	if profile1 != profile2 {
+		t.Errorf("cross-climb profile mismatch: climb-1=%q climb-2=%q; same identity in same crag must resolve to the same fork", profile1, profile2)
+	}
+}
+
+// TestSpawnProfile_ParallelMainsShareProfile verifies that two parallel main
+// agents with the same identity (backend-dev) but different names resolve to
+// the same profile: belayer-local-backend-dev. Phase 5.A dropped per-run
+// hashes, so identity alone determines the fork.
+func TestSpawnProfile_ParallelMainsShareProfile(t *testing.T) {
+	setupBaseBelayerProfile(t)
+
+	workspace := t.TempDir()
+	d := testDaemon(t)
+
+	sessRR := doRequest(t, d, "POST", "/sessions", createSessionRequest{
+		Name:         "parallel-mains-share-profile",
+		WorkspaceDir: workspace,
+	})
+	if sessRR.Code != http.StatusCreated {
+		t.Fatalf("create session: %d %s", sessRR.Code, sessRR.Body.String())
+	}
+	sess := decodeJSON[sessionAPIResponse](t, sessRR)
+
+	profiles := make(map[string]string)
+	d.spawnBridgeAgent = func(req agentSpawnRequest) (*bridge.Process, error) {
+		profiles[req.Name] = req.Profile
+		return nil, nil
+	}
+
+	for _, name := range []string{"backend-dev-1", "backend-dev-2"} {
+		rr := doRequest(t, d, "POST", "/sessions/"+sess.ID+"/agents", agentSpawnRequest{
+			Name:     name,
+			Identity: "backend-dev",
+			Role:     "backend-dev",
+			Profile:  belayerBaseProfileName,
+			Workdir:  workspace,
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("spawn %q: %d %s", name, rr.Code, rr.Body.String())
+		}
+	}
+
+	p1 := profiles["backend-dev-1"]
+	p2 := profiles["backend-dev-2"]
+
+	// Both must resolve to the same stable profile name.
+	if p1 != p2 {
+		t.Errorf("parallel mains with same identity must share one profile; got backend-dev-1=%q backend-dev-2=%q", p1, p2)
+	}
+
+	// Profile name must be belayer-local-backend-dev (no hash suffix).
+	const wantProfile = "belayer-local-backend-dev"
+	if p1 != wantProfile {
+		t.Errorf("profile = %q, want %q", p1, wantProfile)
+	}
+}
+
 // TestResolveCragSlug tests the crag slug resolver helper directly.
 func TestResolveCragSlug(t *testing.T) {
 	t.Parallel()

--- a/internal/daemon/profiles.go
+++ b/internal/daemon/profiles.go
@@ -37,9 +37,14 @@ func ValidateProfileName(name string) error {
 }
 
 // DeriveInstanceID returns a stable 8-character lowercase hex string derived
-// from seed via SHA-256 truncated to 4 bytes. This is used to generate a
-// short unique suffix for parallel main agents (e.g. "a3f9c2d1"). An empty
-// seed signals a singleton talent and returns an empty string.
+// from seed via SHA-256 truncated to 4 bytes (e.g. "a3f9c2d1"). An empty seed
+// returns an empty string.
+//
+// NOTE: As of Phase 5.A the spawn path no longer calls DeriveInstanceID —
+// profile names are now keyed on crag+talent only (stable across climbs).
+// DeriveInstanceID is retained for future callers that need explicit
+// per-instance disambiguation (e.g. a hypothetical parallel-main override
+// where the operator wants distinct profiles per run).
 func DeriveInstanceID(seed string) string {
 	if seed == "" {
 		return ""

--- a/internal/daemon/profiles.go
+++ b/internal/daemon/profiles.go
@@ -338,35 +338,45 @@ func TeardownProfile(profileName string) error {
 	return nil
 }
 
-// readTalentMetadata reads the .belayer-talent.yaml file from a materialized
+// ReadTalentMetadata reads the .belayer-talent.yaml file from a materialized
 // profile directory and returns the memory_scope field. It is the authoritative
 // source for teardown decisions in Phase 3.B.
 //
 // Returns ("", err) if the file cannot be read or parsed. The caller must treat
 // an unreadable file as "climb" (ephemeral) — see teardownProfileIfClimbScoped.
-func readTalentMetadata(profileName string) (memoryScope string, err error) {
-	meta, err := readFullTalentMetadata(profileName)
+func ReadTalentMetadata(profileName string) (memoryScope string, err error) {
+	meta, err := ReadFullTalentMetadata(profileName)
 	if err != nil {
 		return "", err
 	}
 	if meta.MemoryScope == "" {
-		return "", fmt.Errorf("readTalentMetadata: memory_scope field not found in profile %q", profileName)
+		return "", fmt.Errorf("ReadTalentMetadata: memory_scope field not found in profile %q", profileName)
 	}
 	return meta.MemoryScope, nil
 }
 
-// readFullTalentMetadata reads the .belayer-talent.yaml file from a materialized
+// readTalentMetadata is the package-private alias retained for internal callers.
+func readTalentMetadata(profileName string) (memoryScope string, err error) {
+	return ReadTalentMetadata(profileName)
+}
+
+// readFullTalentMetadata is the package-private alias retained for internal callers.
+func readFullTalentMetadata(profileName string) (talentMetadata, error) {
+	return ReadFullTalentMetadata(profileName)
+}
+
+// ReadFullTalentMetadata reads the .belayer-talent.yaml file from a materialized
 // profile directory and returns all available metadata fields. Returns a zero-value
 // talentMetadata and an error if the file cannot be read or parsed.
-func readFullTalentMetadata(profileName string) (talentMetadata, error) {
+func ReadFullTalentMetadata(profileName string) (talentMetadata, error) {
 	root, err := ProfilesRoot()
 	if err != nil {
-		return talentMetadata{}, fmt.Errorf("readFullTalentMetadata: resolve profiles root: %w", err)
+		return talentMetadata{}, fmt.Errorf("ReadFullTalentMetadata: resolve profiles root: %w", err)
 	}
 	metaPath := filepath.Join(root, profileName, ".belayer-talent.yaml")
 	data, err := os.ReadFile(metaPath)
 	if err != nil {
-		return talentMetadata{}, fmt.Errorf("readFullTalentMetadata: read %s: %w", metaPath, err)
+		return talentMetadata{}, fmt.Errorf("ReadFullTalentMetadata: read %s: %w", metaPath, err)
 	}
 	// Simple line scan — avoids pulling in a YAML library for individual fields.
 	var meta talentMetadata


### PR DESCRIPTION
## Summary

- Drops per-run instance hash from spawn-path profile naming. Profile = \`belayer-<crag>-<identity>\`. Stable across climbs.
- Crag-scoped memory now actually persists across climbs. Climb 1's MEMORY.md visible in Climb 2.
- \`doctor\` + \`prune\` honor \`memory.scope\` — preserved (crag/talent) profiles no longer flagged as orphans. \`--include-scoped\` overrides.
- Hermes handles concurrent sessions on shared profile via WAL + BEGIN IMMEDIATE + jitter retry (\`hermes_state.py:167-201\`).

## Stack

Stacked on **PR #141** (Phase 4). Merge order: #138 → #139 → #140 → #141 → this PR.

## Why this changed

Phase 2.D used \`DeriveInstanceID(agent_runs.id)\` for fork naming, making profile names per-climb. \`memory.scope: crag\` was supposed to persist across climbs but couldn't — fresh climb = fresh fork = blank memory. Surfaced via \`TestPhase3Integration_CrossClimbCragPersistence_LimitationDocumented\` (now renamed to a positive assertion).

## Commits

```
68a9b2c test(profiles): integration test for parallel mains sharing profile
7355ef3 feat(cli): scope-aware orphan detection for doctor/prune
a91c8cd feat(profiles): drop instance hash for stable cross-climb profile naming
```

## Sub-tasks

| ID | Description | Commit |
|---|---|---|
| 5.A | Drop instance hash; profile = belayer-<crag>-<identity> | a91c8cd |
| 5.B | Doctor/prune scope-aware; --include-scoped flag | 7355ef3 |
| 5.C | Real cross-climb persistence test | (subsumed by 5.A: existing limitation test rewritten as positive assertion) |
| 5.D | Parallel mains shared-profile integration test | 68a9b2c |

## Behavior change

| Before | After |
|---|---|
| 2 climbs, same supervisor identity → 2 profile dirs | 1 profile dir (shared across climbs) |
| Parallel \`backend-dev-1\` + \`backend-dev-2\` → 2 profile dirs | 1 profile dir (shared via Hermes multi-session) |
| Crag-scoped profile after climb end → \`doctor\` flags as \`[orphan]\` | \`doctor\` reports \`[preserved-crag]\` |
| \`prune\` would remove preserved profiles | Skips by default; \`--include-scoped\` overrides |

## API stability

- \`ResolveProfileName(cragSlug, talentName, instanceID string)\` — signature unchanged. instanceID still respected when caller passes one (future explicit-disambiguation).
- \`DeriveInstanceID(seed string)\` — unchanged. No longer called by spawn path; reserved for future callers. Documented in code comment.
- \`MaterializeProfile\` / \`MaterializeOptions\` — unchanged.

## Tests

| Sub-task | New tests |
|---|---|
| 5.A spawn naming | 2 (StableProfileNameAcrossClimbs, ParallelMainsShareProfile) |
| 5.A test renames | 2 (ParallelMainsShareForkDir, ReSpawnReusesSameForkAcrossClimbs) |
| 5.B doctor scope | 5 |
| 5.B prune scope | 5 |
| 5.D parallel mains integration | 2 (incl. concurrent state.db stress test) |
| **Total Phase 5 new** | **14 (+ 2 renames/rewrites)** |

Concurrency stress test (\`TestPhase5Integration_ParallelMainsConcurrentStateDB\`): 2 goroutines × 50 inserts on shared state.db with \`busy_timeout(5000)\` matching Hermes's retry semantics. Final row count == 100. Confirms WAL contention is handled.

Full suite: 974 passing in 20 packages (was 960 at end of Phase 4).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — 974 passed
- [x] Integration tests cover end-to-end flow: spawn → spawn-again → assert shared dir → write sentinel → spawn-third → assert sentinel visible
- [x] Cross-climb crag-scoped memory persistence test now PASSES (was previously a limitation marker)

## Refs

- Closes #142
- Refs #131 (epic)
- Stacked on PR #141 (Phase 4) → #140 (Phase 3) → #139 (Phase 2) → #138 (Phase 1)
- Design: \`docs/design-docs/2026-05-03-belayer-hermes-profiles-spec.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)